### PR TITLE
Update docs for poll feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,35 @@ npm run dev
 - **Supabase**: Apply `supabase/schema.sql` to initialize the database.
 
 This setup provides a simple API route `/api/data` that reads from the `items` table in Supabase.
+
+### Database schema
+
+The included `supabase/schema.sql` file creates the following tables:
+
+- `items` – basic example data
+- `users` – voters identified by a nickname
+- `games` – list of games to vote on
+- `polls` – each poll instance
+- `votes` – records of user votes for games in a poll
+
+You can create the schema using the Supabase SQL editor or with the Supabase CLI:
+
+```bash
+supabase db push supabase/schema.sql
+```
+
+If you prefer `psql`, pass your database connection string and run:
+
+```bash
+psql "$SUPABASE_DB_URL" -f supabase/schema.sql
+```
+
+### API endpoints
+
+- `GET /api/data` – returns rows from the `items` table
+- `GET /api/poll` – fetches the latest poll with vote counts per game
+- `POST /api/vote` – record a vote `{ poll_id, game_id, nickname }`
+
+### Frontend
+
+In addition to the default home page, a new page is available at `/poll` which displays the latest poll and allows voting. During local development visit `http://localhost:3000/poll`. After deploying the frontend on Vercel the page will be accessible at `https://<your-vercel-domain>/poll`.


### PR DESCRIPTION
## Summary
- document poll tables and endpoints
- show example commands for creating the schema in Supabase
- mention new poll page and where to access it

## Testing
- `npm test` in backend *(fails: Missing script)*
- `npm test` in frontend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687cc0a435088320a47d3e0c32a1d6e4