### PR TITLE
Switch vote API to usernames

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -57,22 +57,22 @@ app.get('/api/poll', async (_req, res) => {
 
 // Record a vote for a specific game in a poll
 app.post('/api/vote', async (req, res) => {
-  const { poll_id, game_id, nickname } = req.body;
-  if (!poll_id || !game_id || !nickname) {
-    return res.status(400).json({ error: 'poll_id, game_id and nickname are required' });
+  const { poll_id, game_id, username } = req.body;
+  if (!poll_id || !game_id || !username) {
+    return res.status(400).json({ error: 'poll_id, game_id and username are required' });
   }
 
   let { data: user, error: userError } = await supabase
     .from('users')
     .select('*')
-    .eq('nickname', nickname)
+    .eq('username', username)
     .maybeSingle();
   if (userError) return res.status(500).json({ error: userError.message });
 
   if (!user) {
     const { data: newUser, error: insertError } = await supabase
       .from('users')
-      .insert({ nickname })
+      .insert({ username })
       .select()
       .single();
     if (insertError) return res.status(500).json({ error: insertError.message });
@@ -82,7 +82,7 @@ app.post('/api/vote', async (req, res) => {
   const { error: voteError } = await supabase.from('votes').insert({
     poll_id,
     game_id,
-    voter_nickname: user.id,
+    user_id: user.id,
   });
 
   if (voteError) return res.status(500).json({ error: voteError.message });

--- a/frontend/app/poll/page.tsx
+++ b/frontend/app/poll/page.tsx
@@ -6,7 +6,7 @@ interface Game {
   id: number;
   name: string;
   count: number;
-  nicknames: string[];
+  usernames: string[];
 }
 
 interface Poll {
@@ -35,26 +35,26 @@ export default function PollPage() {
     const { data: games } = await supabase.from('games').select('id, name');
     const { data: votes } = await supabase
       .from('votes')
-      .select('game_id, voter_nickname')
+      .select('game_id, user_id')
       .eq('poll_id', pollData.id);
     const { data: users } = await supabase
       .from('users')
-      .select('id, nickname');
+      .select('id, username');
 
     const userMap =
       users?.reduce((acc: Record<number, string>, u) => {
-        acc[u.id] = u.nickname;
+        acc[u.id] = u.username;
         return acc;
       }, {}) || {};
 
     const counts: Record<number, number> = {};
-    const nicknames: Record<number, string[]> = {};
+    const usernames: Record<number, string[]> = {};
 
     votes?.forEach((v) => {
       counts[v.game_id] = (counts[v.game_id] || 0) + 1;
-      if (!nicknames[v.game_id]) nicknames[v.game_id] = [];
-      const nick = userMap[v.voter_nickname];
-      if (nick) nicknames[v.game_id].push(nick);
+      if (!usernames[v.game_id]) usernames[v.game_id] = [];
+      const name = userMap[v.user_id];
+      if (name) usernames[v.game_id].push(name);
     });
 
     const results =
@@ -62,7 +62,7 @@ export default function PollPage() {
         id: g.id,
         name: g.name,
         count: counts[g.id] || 0,
-        nicknames: nicknames[g.id] || [],
+        usernames: usernames[g.id] || [],
       })) || [];
 
     setPoll({ id: pollData.id, games: results });
@@ -88,8 +88,8 @@ export default function PollPage() {
             <span>{game.name}</span>
             <span className="font-mono">{game.count}</span>
             <ul className="pl-4 list-disc">
-              {game.nicknames.map((nick) => (
-                <li key={nick}>{nick}</li>
+              {game.usernames.map((name) => (
+                <li key={name}>{name}</li>
               ))}
             </ul>
           </li>


### PR DESCRIPTION
## Summary
- update POST `/api/vote` to read `username` and store votes by `user_id`
- refactor poll page to display usernames instead of nicknames

## Testing
- `npm -C backend run build`
- `NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=... npm -C frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_687d675f3d9c83209cbc07d9a979a057