### PR TITLE
Add auth_id column and update existing users

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5,7 +5,8 @@ create table if not exists items (
 
 create table if not exists users (
   id serial primary key,
-  username text
+  username text,
+  auth_id uuid references auth.users(id) unique
 );
 
 create table if not exists games (
@@ -29,3 +30,10 @@ create index if not exists votes_user_id_idx on votes(user_id);
 
 create index if not exists votes_poll_id_idx on votes(poll_id);
 create index if not exists votes_game_id_idx on votes(game_id);
+
+-- Populate auth_id for existing users based on matching email
+update users
+set auth_id = u.id
+from auth.users u
+where users.auth_id is null
+  and u.email = users.username;


### PR DESCRIPTION
## Summary
- add `auth_id` to `users` table in `schema.sql`
- backfill existing users based on matching email

## Testing
- `npx supabase db push --debug` *(fails: Cannot find project ref)*
- `npm run lint` in `frontend` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d6e3268a8832089b21679d857b938