### PR TITLE
Handle OAuth callback in Next frontend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,5 @@ SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZi
 PORT=3001
 TWITCH_CLIENT_ID=
 TWITCH_SECRET=
+# OAuth callback URL, e.g. http://localhost:3000/auth/callback
+OAUTH_CALLBACK_URL=http://localhost:3000/auth/callback

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,6 @@ NEXT_PUBLIC_SUPABASE_URL=https://bsiiyuwbzhwrflsdpoud.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJzaWl5dXdiemh3cmZsc2Rwb3VkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI3NDIzMzUsImV4cCI6MjA2ODMxODMzNX0.2dGo45jMsUK4Zg8aoSc4kuXd2yBIpFfXgzvhw6zEQfU
 TWITCH_CLIENT_ID=
 TWITCH_SECRET=
+# OAuth callback URL. Configure this in the Twitch dashboard as
+# http://localhost:3000/auth/callback for local development
+OAUTH_CALLBACK_URL=http://localhost:3000/auth/callback

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { supabase } from "@/utils/supabaseClient";
+
+export default function AuthCallback() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const exchange = async () => {
+      const url = new URL(window.location.href);
+      const code = url.searchParams.get("code");
+      if (code) {
+        await (supabase.auth as any).exchangeCodeForSession(code);
+      }
+      router.replace("/");
+    };
+    exchange();
+  }, [router]);
+
+  return <p className="p-4">Logging in...</p>;
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -88,7 +88,10 @@ export default function Home() {
   }, []);
 
   const handleLogin = () => {
-    supabase.auth.signInWithOAuth({ provider: "twitch" });
+    supabase.auth.signInWithOAuth({
+      provider: "twitch",
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
+    });
   };
 
   const handleLogout = async () => {


### PR DESCRIPTION
## Summary
- add `/auth/callback` page that exchanges the OAuth code and redirects home
- redirect Twitch OAuth login to `/auth/callback`
- document callback URL in frontend and backend env examples

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run build`
- `npm run build` in backend

------
https://chatgpt.com/codex/tasks/task_e_687dffe43d8c8320a60c76267ce2f274