### PR TITLE
Add backend URL variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ cp frontend/.env.example frontend/.env.local
 
 The provided examples already contain working Supabase credentials. If you plan
 to enable Twitch login, add your Twitch OAuth keys and redirect URLs as shown
-below.
+below. The frontend also needs `NEXT_PUBLIC_BACKEND_URL` pointing to your
+backend. For local development it should be `http://localhost:3001`.
 
 ```
 TWITCH_CLIENT_ID=your-client-id

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,3 +5,4 @@ TWITCH_SECRET=
 # OAuth callback URL. Configure this in the Twitch dashboard as
 # http://localhost:3000/auth/callback for local development
 OAUTH_CALLBACK_URL=http://localhost:3000/auth/callback
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3001

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,6 +4,8 @@ import { supabase } from "@/utils/supabaseClient";
 import { useEffect, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
 
+const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL!;
+
 interface Game {
   id: number;
   name: string;
@@ -112,7 +114,7 @@ export default function Home() {
       session?.user.user_metadata.nickname ||
       session?.user.email;
 
-    await fetch("/api/vote", {
+    await fetch(`${backendUrl}/api/vote`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- include `NEXT_PUBLIC_BACKEND_URL` in sample frontend environment file
- use this variable when calling the vote API
- mention the variable in the README

## Testing
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_687e48ec28d48320a88e2a402ff1fff3