### PR TITLE
Update deployment README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ npm run dev
 ## Deployment
 
  - **Render**: Create a new Web Service, set Node 18, and point it to the `backend/` folder. The backend has a no-op `build` script so you can keep the default build command `npm run build`.
-- **Vercel**: Import the repository and set the project root to `frontend/`.
+- **Vercel**: Import the repository, set the project root to `frontend/`, and add
+  `NEXT_PUBLIC_BACKEND_URL` in the environment variables (e.g.
+  `https://terrenkur.onrender.com`).
 - **Supabase**: Apply `supabase/schema.sql` to initialize the database.
 
 This setup provides a simple API route `/api/data` that reads from the `items` table in Supabase.


### PR DESCRIPTION
## Summary
- mention configuring `NEXT_PUBLIC_BACKEND_URL` when deploying the frontend to Vercel
- show `https://terrenkur.onrender.com` as an example backend URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687eb21627448320b086d985e0ff078e