### PR TITLE
Add unique vote constraint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -97,13 +97,28 @@ app.post('/api/vote', async (req, res) => {
     await supabase.from('users').update({ username }).eq('id', user.id);
   }
 
+  const { data: existing } = await supabase
+    .from('votes')
+    .select('id')
+    .eq('poll_id', poll_id)
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (existing) {
+    return res.status(400).json({ error: 'User has already voted' });
+  }
+
   const { error: voteError } = await supabase.from('votes').insert({
     poll_id,
     game_id,
     user_id: user.id,
   });
 
-  if (voteError) return res.status(500).json({ error: voteError.message });
+  if (voteError) {
+    if (voteError.code === '23505') {
+      return res.status(400).json({ error: 'User has already voted' });
+    }
+    return res.status(500).json({ error: voteError.message });
+  }
   res.status(201).json({ success: true });
 });
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -31,6 +31,9 @@ create index if not exists votes_user_id_idx on votes(user_id);
 create index if not exists votes_poll_id_idx on votes(poll_id);
 create index if not exists votes_game_id_idx on votes(game_id);
 
+create unique index if not exists votes_user_poll_unique
+  on votes(user_id, poll_id);
+
 -- Populate auth_id for existing users based on matching email
 update users
 set auth_id = u.id


### PR DESCRIPTION
## Summary
- enforce unique voting on `(user_id, poll_id)` pair
- check existing votes before insert and catch unique constraint errors

## Testing
- `node -c backend/server.js`
- `npm --prefix backend install`
- `node backend/server.js` *(fails: supabaseUrl is required when not launched from backend folder)*
- `node backend/server.js` from backend folder

------
https://chatgpt.com/codex/tasks/task_e_687f97fb64d48320b35f37c63db27f58