### PR TITLE
Allow vote updates

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -104,7 +104,14 @@ app.post('/api/vote', async (req, res) => {
     .eq('user_id', user.id)
     .maybeSingle();
   if (existing) {
-    return res.status(400).json({ error: 'User has already voted' });
+    const { error: updateError } = await supabase
+      .from('votes')
+      .update({ game_id })
+      .eq('id', existing.id);
+    if (updateError) {
+      return res.status(500).json({ error: updateError.message });
+    }
+    return res.status(200).json({ success: true, updated: true });
   }
 
   const { error: voteError } = await supabase.from('votes').insert({

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -214,13 +214,15 @@ export default function Home() {
       </ul>
       <button
         className="px-4 py-2 bg-purple-600 text-white rounded disabled:opacity-50"
-        disabled={selected === null || submitting || !session || hasVoted}
+        disabled={selected === null || submitting || !session}
         onClick={handleVote}
       >
         {submitting ? "Voting..." : "Vote"}
       </button>
       {hasVoted && (
-        <p className="text-sm text-gray-500">You've already voted</p>
+        <p className="text-sm text-gray-500">
+          You've already voted. Voting again will replace your previous choice.
+        </p>
       )}
     </main>
   );


### PR DESCRIPTION
## Summary
- update votes when users revote on a poll
- enable the vote button even when the user has already voted
- explain that revoting will replace the previous choice

## Testing
- `npm install` *(fails: 41 packages are looking for funding)*
- `npm run lint` *(interactive prompt prevents completion)*

------
https://chatgpt.com/codex/tasks/task_e_687fa2228f588320a2d30e79f35907f6