### PR TITLE
Add multi-vote support

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -6,7 +6,8 @@ create table if not exists items (
 create table if not exists users (
   id serial primary key,
   username text,
-  auth_id uuid references auth.users(id) unique
+  auth_id uuid references auth.users(id) unique,
+  vote_limit integer default 1
 );
 
 create table if not exists games (
@@ -23,7 +24,8 @@ create table if not exists votes (
   id serial primary key,
   poll_id integer references polls(id),
   game_id integer references games(id),
-  user_id integer references users(id)
+  user_id integer references users(id),
+  slot integer not null
 );
 
 create index if not exists votes_user_id_idx on votes(user_id);
@@ -31,8 +33,8 @@ create index if not exists votes_user_id_idx on votes(user_id);
 create index if not exists votes_poll_id_idx on votes(poll_id);
 create index if not exists votes_game_id_idx on votes(game_id);
 
-create unique index if not exists votes_user_poll_unique
-  on votes(user_id, poll_id);
+create unique index if not exists votes_user_poll_slot_unique
+  on votes(user_id, poll_id, slot);
 
 -- Populate auth_id for existing users based on matching email
 update users


### PR DESCRIPTION
## Summary
- allow several vote slots per poll
- track vote limits per user in database
- update vote handling and add admin route
- adapt frontend to multiple selections

## Testing
- `npm run build` in backend
- `npm run build` in frontend

------
https://chatgpt.com/codex/tasks/task_e_687fa7d898ec8320b1de34bc431c11be