### PR TITLE
Remove obsolete vote index

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,10 @@ psql "$SUPABASE_URL" -f supabase/schema.sql
 
 Where `$SUPABASE_URL` is your database connection string.
 
+If your database already contains the `votes_user_poll_unique` index from an
+earlier version of the schema, drop it before reapplying:
+
+```bash
+psql "$SUPABASE_URL" -c "DROP INDEX IF EXISTS votes_user_poll_unique"
+```
+

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -32,7 +32,6 @@ create index if not exists votes_user_id_idx on votes(user_id);
 
 create index if not exists votes_poll_id_idx on votes(poll_id);
 create index if not exists votes_game_id_idx on votes(game_id);
-create unique index if not exists votes_user_poll_unique on votes(user_id, poll_id);
 
 create unique index if not exists votes_user_poll_slot_unique
   on votes(user_id, poll_id, slot);


### PR DESCRIPTION
## Summary
- drop `votes_user_poll_unique` from schema
- document how to drop the old index when reapplying the schema

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880af5b06e88320ba85fc3ab45b1433