### PR TITLE
Fix vote allocation when exceeding limit

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -229,7 +229,8 @@ export default function Home() {
                       if (free !== -1) {
                         arr[free] = game.id;
                       } else {
-                        arr[0] = game.id;
+                        setActionHint("Vote limit reached");
+                        return arr;
                       }
                     } else {
                       if (idx !== -1) {


### PR DESCRIPTION
## Summary
- avoid overwriting existing votes if no unused slots remain
- display a hint when trying to add more votes than allowed

## Testing
- `npm install` *(fails: next lint prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_6880b89019e08320939d6dfdb6925d58