### PR TITLE
Add ADMIN_TOKEN to env example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,3 +5,4 @@ TWITCH_CLIENT_ID=
 TWITCH_SECRET=
 # OAuth callback URL, e.g. http://localhost:3000/auth/callback
 OAUTH_CALLBACK_URL=http://localhost:3000/auth/callback
+ADMIN_TOKEN=


### PR DESCRIPTION
## Summary
- update `.env.example` in backend to include `ADMIN_TOKEN`

## Testing
- `cat backend/.env.example`


------
https://chatgpt.com/codex/tasks/task_e_6880fb4a09ac83208bb2f0f1769305cf