### PR TITLE
Unify Game interface

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,21 +2,24 @@
 
 import { supabase } from "@/utils/supabaseClient";
 import { useEffect, useState, useRef } from "react";
-import RouletteWheel, { RouletteWheelHandle, Game as WheelGame } from "@/components/RouletteWheel";
+import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/RouletteWheel";
 import type { Session } from "@supabase/supabase-js";
+import type { Game } from "@/types";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 if (!backendUrl) {
   console.error("NEXT_PUBLIC_BACKEND_URL is not set");
 }
 
-interface Game extends WheelGame {
+
+interface PollGame extends Game {
+  count: number;
   nicknames: string[];
 }
 
 interface Poll {
   id: number;
-  games: Game[];
+  games: PollGame[];
 }
 
 export default function Home() {
@@ -29,7 +32,7 @@ export default function Home() {
   const [voteLimit, setVoteLimit] = useState(1);
   const [usedVotes, setUsedVotes] = useState(0);
   const [actionHint, setActionHint] = useState("");
-  const [rouletteGames, setRouletteGames] = useState<Game[]>([]);
+  const [rouletteGames, setRouletteGames] = useState<WheelGame[]>([]);
   const [winner, setWinner] = useState<WheelGame | null>(null);
   const wheelRef = useRef<RouletteWheelHandle>(null);
 
@@ -45,7 +48,7 @@ export default function Home() {
       return;
     }
     const pollRes = await resp.json();
-    const pollData = { id: pollRes.poll_id, games: pollRes.games };
+    const pollData: Poll = { id: pollRes.poll_id, games: pollRes.games };
 
     const { data: votes } = await supabase
       .from("votes")

--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import type { Game } from "@/types";
 
-export interface Game {
-  id: number;
-  name: string;
+export interface WheelGame extends Game {
   count: number;
 }
 
@@ -13,8 +12,8 @@ export interface RouletteWheelHandle {
 }
 
 interface RouletteWheelProps {
-  games: Game[];
-  onDone: (game: Game) => void;
+  games: WheelGame[];
+  onDone: (game: WheelGame) => void;
   size?: number;
 }
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -1,0 +1,5 @@
+export interface Game {
+  id: number;
+  name: string;
+  nicknames?: string[];
+}


### PR DESCRIPTION
## Summary
- add shared `Game` interface in `frontend/types.ts`
- use `WheelGame` in roulette wheel
- update page to consume new Game types

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6880fde8fc7c8320a4fc938381b26828