### PR TITLE
Add moderator mode for wheel coefficient

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -15,10 +15,11 @@ interface RouletteWheelProps {
   games: WheelGame[];
   onDone: (game: WheelGame) => void;
   size?: number;
+  weightCoeff?: number;
 }
 
 const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
-  ({ games, onDone, size = 300 }, ref) => {
+  ({ games, onDone, size = 300, weightCoeff = 2 }, ref) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [rotation, setRotation] = useState(0);
     const spinningRef = useRef(false);
@@ -26,7 +27,7 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
     const maxVotes = games.reduce((m, g) => Math.max(m, g.count), 0);
     const weighted = games.map((g) => ({
       ...g,
-      weight: 1 + 2 * (maxVotes - g.count),
+      weight: 1 + weightCoeff * (maxVotes - g.count),
     }));
     const totalWeight = weighted.reduce((sum, g) => sum + g.weight, 0);
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7,7 +7,8 @@ create table if not exists users (
   id serial primary key,
   username text,
   auth_id uuid references auth.users(id) unique,
-  vote_limit integer default 1
+  vote_limit integer default 1,
+  is_moderator boolean default false
 );
 
 create table if not exists games (
@@ -35,6 +36,15 @@ create index if not exists votes_game_id_idx on votes(game_id);
 
 create unique index if not exists votes_user_poll_slot_unique
   on votes(user_id, poll_id, slot);
+
+create table if not exists settings (
+  key text primary key,
+  value numeric
+);
+
+insert into settings(key, value)
+  values ('wheel_coeff', 2)
+  on conflict (key) do nothing;
 
 -- Populate auth_id for existing users based on matching email
 update users


### PR DESCRIPTION
## Summary
- add `is_moderator` column and new `settings` table
- expose REST endpoints to get/set roulette coefficient
- allow moderators in the UI to edit the coefficient
- pass coefficient to the wheel component

## Testing
- `npm run build` in `backend`
- `npm run build` in `frontend`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_688157d9140c832086efd82a438b066f