### PR TITLE
Fix roulette refresh when coeff changes

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -70,7 +70,7 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
 
     useEffect(() => {
       drawWheel();
-    }, [games]);
+    }, [games, weightCoeff]);
 
     useEffect(() => {
       const canvas = canvasRef.current;


### PR DESCRIPTION
## Summary
- refresh wheel whenever the weight coefficient changes

## Testing
- `npm run lint` *(fails: Could not finish ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68815da245048320a78095229ad5ad8c