### PR TITLE
Add zero vote weight setting

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -16,10 +16,20 @@ interface RouletteWheelProps {
   onDone: (game: WheelGame) => void;
   size?: number;
   weightCoeff?: number;
+  zeroWeight?: number;
 }
 
 const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
-  ({ games, onDone, size = 300, weightCoeff = 2 }, ref) => {
+  (
+    {
+      games,
+      onDone,
+      size = 300,
+      weightCoeff = 2,
+      zeroWeight = 40,
+    },
+    ref
+  ) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [rotation, setRotation] = useState(0);
     const spinningRef = useRef(false);
@@ -27,7 +37,10 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
     const maxVotes = games.reduce((m, g) => Math.max(m, g.count), 0);
     const weighted = games.map((g) => ({
       ...g,
-      weight: 1 + weightCoeff * (maxVotes - g.count),
+      weight:
+        g.count === 0
+          ? zeroWeight
+          : 1 + weightCoeff * (maxVotes - g.count),
     }));
     const totalWeight = weighted.reduce((sum, g) => sum + g.weight, 0);
 
@@ -70,7 +83,7 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
 
     useEffect(() => {
       drawWheel();
-    }, [games, weightCoeff]);
+    }, [games, weightCoeff, zeroWeight]);
 
     useEffect(() => {
       const canvas = canvasRef.current;

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -4,19 +4,22 @@ import { useState, useEffect } from "react";
 
 interface SettingsModalProps {
   coeff: number;
+  zeroWeight: number;
   onClose: () => void;
-  onSave: (value: number) => void;
+  onSave: (coeff: number, zeroWeight: number) => void;
 }
 
-export default function SettingsModal({ coeff, onClose, onSave }: SettingsModalProps) {
+export default function SettingsModal({ coeff, zeroWeight, onClose, onSave }: SettingsModalProps) {
   const [value, setValue] = useState(coeff);
+  const [zero, setZero] = useState(zeroWeight);
 
   useEffect(() => {
     setValue(coeff);
-  }, [coeff]);
+    setZero(zeroWeight);
+  }, [coeff, zeroWeight]);
 
   const handleSave = () => {
-    onSave(value);
+    onSave(value, zero);
   };
 
   return (
@@ -29,6 +32,15 @@ export default function SettingsModal({ coeff, onClose, onSave }: SettingsModalP
             type="number"
             value={value}
             onChange={(e) => setValue(parseFloat(e.target.value))}
+            className="border p-1 w-24 text-black"
+          />
+        </div>
+        <div className="flex items-center space-x-2">
+          <label className="text-sm">Zero vote weight:</label>
+          <input
+            type="number"
+            value={zero}
+            onChange={(e) => setZero(parseFloat(e.target.value))}
             className="border p-1 w-24 text-black"
           />
         </div>

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -46,6 +46,10 @@ insert into settings(key, value)
   values ('wheel_coeff', 2)
   on conflict (key) do nothing;
 
+insert into settings(key, value)
+  values ('zero_vote_weight', 40)
+  on conflict (key) do nothing;
+
 -- Populate auth_id for existing users based on matching email
 update users
 set auth_id = u.id


### PR DESCRIPTION
## Summary
- insert default zero vote weight value in SQL schema
- expose zero vote weight on the backend API
- handle zero vote weight in roulette and settings modal
- fetch and save zero vote weight in frontend page

## Testing
- `npm run build` in `backend`
- `npm run build` in `frontend` *(fails: supabaseUrl is required)*
- `npm run lint` in `frontend` *(prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6881e80ff0908320a4fdf2c91b380089