### PR TITLE
Fix archived poll params type

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { use, useEffect, useState, useRef } from "react";
 import Link from "next/link";
 import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/RouletteWheel";
 import type { Poll } from "@/types";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
-export default function ArchivedPollPage({ params }: { params: { id: string } }) {
-  const { id } = params;
+export default function ArchivedPollPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
   const [poll, setPoll] = useState<Poll | null>(null);
   const [loading, setLoading] = useState(true);
   const [rouletteGames, setRouletteGames] = useState<WheelGame[]>([]);


### PR DESCRIPTION
## Summary
- use `use()` to unwrap async params on the ArchivedPollPage component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68820e248ffc8320aad6c2a75f4f8b4a