### PR TITLE
Use Geist fonts by default

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
## Summary
- apply Geist font variables globally

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: `supabaseUrl is required` error)*

------
https://chatgpt.com/codex/tasks/task_e_6883bf518d50832094246d6462d195a0