### PR TITLE
Fix roulette arrow orientation

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -140,7 +140,7 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
       <div className="relative" style={{ width: size, height: size }}>
         <canvas ref={canvasRef} width={size} height={size} />
         <div
-          className="absolute left-1/2 top-0 -translate-x-1/2 w-0 h-0 border-l-8 border-r-8 border-b-8 border-transparent border-b-red-500"
+          className="absolute left-1/2 top-0 -translate-x-1/2 w-0 h-0 border-l-8 border-r-8 border-t-8 border-transparent border-t-red-500"
           style={{ transform: "translateY(-2px)" }}
         />
       </div>


### PR DESCRIPTION
## Summary
- point roulette arrow down by using `border-t` styles

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: Next.js build error `supabaseUrl is required`)*

------
https://chatgpt.com/codex/tasks/task_e_6883e400ae0c8320a7b4b68507e5bd60