### PR TITLE
Keep RouletteWheel labels vertical

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -81,7 +81,8 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
         ctx.textBaseline = "middle";
         ctx.save();
         ctx.translate(x, y);
-        ctx.rotate(mid + Math.PI / 2);
+        // Keep labels vertical for better readability
+        ctx.rotate(Math.PI / 2);
         ctx.fillText(g.name, 0, 0);
         ctx.restore();
 


### PR DESCRIPTION
## Summary
- keep label text upright rather than angled with the slice

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6883e5d38a988320be56c41ba06f7588