### PR TITLE
Fix roulette winner detection

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -34,7 +34,9 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
 
   const handleSpinEnd = (game: WheelGame) => {
     const remaining = rouletteGames.filter((g) => g.id !== game.id);
-    if (remaining.length === 0) {
+    if (remaining.length === 1) {
+      setWinner(remaining[0]);
+    } else if (remaining.length === 0) {
       setWinner(game);
     }
     setRouletteGames(remaining);

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -187,7 +187,9 @@ export default function Home() {
 
   const handleSpinEnd = (game: WheelGame) => {
     const remaining = rouletteGames.filter((g) => g.id !== game.id);
-    if (remaining.length === 0) {
+    if (remaining.length === 1) {
+      setWinner(remaining[0]);
+    } else if (remaining.length === 0) {
       setWinner(game);
     }
     setRouletteGames(remaining);


### PR DESCRIPTION
## Summary
- fix roulette winner logic when only one game remains

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883eedb05bc832090faa823d35f97ae