### PR TITLE
Move auth info into layout

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
+import AuthStatus from "@/components/AuthStatus";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -40,7 +41,8 @@ export default function RootLayout({
               <Link href="/users">Users</Link>
               <Link href="/playlists">Playlists</Link>
             </div>
-            <div className="flex space-x-4">
+            <div className="flex items-center space-x-4">
+              <AuthStatus />
               <a
                 href="https://twitch.tv/terrenkur"
                 target="_blank"

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -150,18 +150,6 @@ export default function Home() {
     }
   }, [slots, initialSlots]);
 
-  const handleLogin = () => {
-    supabase.auth.signInWithOAuth({
-      provider: "twitch",
-      options: { redirectTo: `${window.location.origin}/auth/callback` },
-    });
-  };
-
-  const handleLogout = async () => {
-    await supabase.auth.signOut();
-    setSession(null);
-    setSlots([]);
-  };
 
   const adjustVote = (gameId: number, delta: number) => {
     setActionHint("");
@@ -265,35 +253,10 @@ export default function Home() {
   if (loading) return <div className="p-4">Loading...</div>;
   if (!poll) return <div className="p-4">No poll available.</div>;
 
-  const username =
-    session?.user.user_metadata.preferred_username ||
-    session?.user.user_metadata.name ||
-    session?.user.user_metadata.full_name ||
-    session?.user.user_metadata.nickname ||
-    session?.user.email;
-
   return (
     <>
     <main className="p-4 max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-semibold">Current Poll</h1>
-      {session ? (
-        <div className="flex items-center space-x-2">
-          <p>Logged in as {username}</p>
-          <button
-            className="px-2 py-1 bg-gray-800 text-white rounded"
-            onClick={handleLogout}
-          >
-            Log out
-          </button>
-        </div>
-      ) : (
-        <button
-          className="px-4 py-2 bg-purple-600 text-white rounded"
-          onClick={handleLogin}
-        >
-          Login with Twitch
-        </button>
-      )}
       {isModerator && (
         <button
           className="px-2 py-1 bg-purple-600 text-white rounded"

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { supabase } from "@/utils/supabaseClient";
+import { useEffect, useState } from "react";
+import type { Session } from "@supabase/supabase-js";
+
+export default function AuthStatus() {
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session);
+    });
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (_event, sess) => {
+        setSession(sess);
+      }
+    );
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const handleLogin = () => {
+    supabase.auth.signInWithOAuth({
+      provider: "twitch",
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
+    });
+  };
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    setSession(null);
+  };
+
+  const username =
+    session?.user.user_metadata.preferred_username ||
+    session?.user.user_metadata.name ||
+    session?.user.user_metadata.full_name ||
+    session?.user.user_metadata.nickname ||
+    session?.user.email;
+
+  return session ? (
+    <div className="flex items-center space-x-2">
+      <span className="truncate max-w-xs">{username}</span>
+      <button
+        className="px-2 py-1 bg-gray-800 text-white rounded"
+        onClick={handleLogout}
+      >
+        Log out
+      </button>
+    </div>
+  ) : (
+    <button
+      className="px-4 py-2 bg-purple-600 text-white rounded"
+      onClick={handleLogin}
+    >
+      Login with Twitch
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AuthStatus` component that handles Twitch login/logout
- display `AuthStatus` in the global layout header so auth info shows on every page
- remove per-page login/logout UI

## Testing
- `npm run lint` *(fails: configuration prompt)*
- `npm run build` in frontend *(fails: supabaseUrl is required)*
- `npm test` in backend *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6884d47e4a68832098d3746a3c5bc6b7