### PR TITLE
Enable vote control settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The `/api/poll` endpoint aggregates votes for each game and now also includes th
 The `/api/poll/:id` endpoint returns results for a specific poll and `/api/polls` lists all polls.
 Games are linked to polls through the new `poll_games` table defined in `supabase/schema.sql`.
 
+Moderators can toggle accepting votes and vote editing via the `/api/accept_votes` and `/api/allow_edit` endpoints (also available in the Settings modal). When voting is closed or editing disabled, the frontend disables the vote controls.
+
 To see the current poll visualized as a spinning wheel, open the homepage. Games are eliminated from the wheel one by one as it spins until a final winner remains. This does not remove anything from the database; it's only a visual way to pick a random game.
 
 With a YouTube API key configured you can also visit `/playlists` to see videos from your channel grouped by tags extracted from their descriptions.

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -5,21 +5,39 @@ import { useState, useEffect } from "react";
 interface SettingsModalProps {
   coeff: number;
   zeroWeight: number;
+  acceptVotes: boolean;
+  allowEdit: boolean;
   onClose: () => void;
-  onSave: (coeff: number, zeroWeight: number) => void;
+  onSave: (
+    coeff: number,
+    zeroWeight: number,
+    acceptVotes: boolean,
+    allowEdit: boolean
+  ) => void;
 }
 
-export default function SettingsModal({ coeff, zeroWeight, onClose, onSave }: SettingsModalProps) {
+export default function SettingsModal({
+  coeff,
+  zeroWeight,
+  acceptVotes,
+  allowEdit,
+  onClose,
+  onSave,
+}: SettingsModalProps) {
   const [value, setValue] = useState(coeff);
   const [zero, setZero] = useState(zeroWeight);
+  const [accept, setAccept] = useState(acceptVotes);
+  const [edit, setEdit] = useState(allowEdit);
 
   useEffect(() => {
     setValue(coeff);
     setZero(zeroWeight);
-  }, [coeff, zeroWeight]);
+    setAccept(acceptVotes);
+    setEdit(allowEdit);
+  }, [coeff, zeroWeight, acceptVotes, allowEdit]);
 
   const handleSave = () => {
-    onSave(value, zero);
+    onSave(value, zero, accept, edit);
   };
 
   return (
@@ -42,6 +60,22 @@ export default function SettingsModal({ coeff, zeroWeight, onClose, onSave }: Se
             value={zero}
             onChange={(e) => setZero(parseFloat(e.target.value))}
             className="border p-1 w-24 text-black"
+          />
+        </div>
+        <div className="flex items-center space-x-2">
+          <label className="text-sm">Accept votes:</label>
+          <input
+            type="checkbox"
+            checked={accept}
+            onChange={(e) => setAccept(e.target.checked)}
+          />
+        </div>
+        <div className="flex items-center space-x-2">
+          <label className="text-sm">Allow edit:</label>
+          <input
+            type="checkbox"
+            checked={edit}
+            onChange={(e) => setEdit(e.target.checked)}
           />
         </div>
         <div className="flex justify-end space-x-2">

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -56,6 +56,14 @@ insert into settings(key, value)
   values ('zero_vote_weight', 40)
   on conflict (key) do nothing;
 
+insert into settings(key, value)
+  values ('accept_votes', 1)
+  on conflict (key) do nothing;
+
+insert into settings(key, value)
+  values ('allow_edit', 1)
+  on conflict (key) do nothing;
+
 -- Populate auth_id for existing users based on matching email
 update users
 set auth_id = u.id


### PR DESCRIPTION
## Summary
- add `accept_votes` and `allow_edit` rows to schema
- expose `/api/accept_votes` and `/api/allow_edit` endpoints
- respect these settings when voting or editing votes
- make bot skip votes when voting is closed
- surface settings in the frontend and disable controls accordingly
- document new capabilities

## Testing
- `node -c backend/server.js`
- `node -c bot/bot.js`
- `CI=true npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6884dc7ad5908320a76e703033191d09