### PR TITLE
Add voting closed notice

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -313,6 +313,9 @@ export default function Home() {
         </button>
       )}
       <p>You can cast up to {voteLimit} votes.</p>
+      {!acceptVotes && (
+        <p className="text-red-500">Voting is currently closed.</p>
+      )}
       <ul className="space-y-2">
         {poll.games.map((game) => {
           const count = slots.filter((s) => s === game.id).length;


### PR DESCRIPTION
## Summary
- show a "Voting is currently closed" notice when the poll stops accepting votes
- keep vote actions disabled while the notice shows

## Testing
- `npm install`
- `npm run lint` *(fails: project not configured)*
- `npm run build` *(fails: missing env var supabaseUrl)*

------
https://chatgpt.com/codex/tasks/task_e_6884e2ba3be883209b8a8adfeffcf494