### PR TITLE
Add spin result modal to roulette

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,6 +4,7 @@ import { supabase } from "@/utils/supabaseClient";
 import { useEffect, useState, useRef } from "react";
 import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/RouletteWheel";
 import SettingsModal from "@/components/SettingsModal";
+import SpinResultModal from "@/components/SpinResultModal";
 import type { Session } from "@supabase/supabase-js";
 import type { Game } from "@/types";
 
@@ -41,6 +42,9 @@ export default function Home() {
   const [allowEdit, setAllowEdit] = useState(true);
   const [isModerator, setIsModerator] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [eliminatedGame, setEliminatedGame] = useState<WheelGame | null>(null);
+  const [postSpinGames, setPostSpinGames] = useState<WheelGame[]>([]);
+  const [postSpinWinner, setPostSpinWinner] = useState<WheelGame | null>(null);
   const wheelRef = useRef<RouletteWheelHandle>(null);
 
   if (!backendUrl) {
@@ -194,12 +198,23 @@ export default function Home() {
 
   const handleSpinEnd = (game: WheelGame) => {
     const remaining = rouletteGames.filter((g) => g.id !== game.id);
+    let win: WheelGame | null = null;
     if (remaining.length === 1) {
-      setWinner(remaining[0]);
+      win = remaining[0];
     } else if (remaining.length === 0) {
-      setWinner(game);
+      win = game;
     }
-    setRouletteGames(remaining);
+    setPostSpinGames(remaining);
+    setPostSpinWinner(win);
+    setEliminatedGame(game);
+  };
+
+  const closeResult = () => {
+    setRouletteGames(postSpinGames);
+    if (postSpinWinner) {
+      setWinner(postSpinWinner);
+    }
+    setEliminatedGame(null);
   };
 
   const handleVote = async () => {
@@ -404,6 +419,13 @@ export default function Home() {
           setAllowEdit(edit);
           setShowSettings(false);
         }}
+      />
+    )}
+    {eliminatedGame && (
+      <SpinResultModal
+        eliminated={eliminatedGame}
+        winner={postSpinWinner}
+        onClose={closeResult}
       />
     )}
     </>

--- a/frontend/components/SpinResultModal.tsx
+++ b/frontend/components/SpinResultModal.tsx
@@ -1,0 +1,26 @@
+"use client";
+import type { WheelGame } from "./RouletteWheel";
+
+interface SpinResultModalProps {
+  eliminated: WheelGame;
+  winner?: WheelGame | null;
+  onClose: () => void;
+}
+
+export default function SpinResultModal({ eliminated, winner, onClose }: SpinResultModalProps) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded space-y-4 shadow-lg">
+        <h2 className="text-xl font-semibold">Dropped game: {eliminated.name}</h2>
+        {winner && (
+          <p className="text-lg">Winning game: {winner.name}</p>
+        )}
+        <div className="flex justify-end">
+          <button className="px-4 py-2 bg-purple-600 text-white rounded" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show message after each spin with eliminated game
- update roulette once user closes the message
- show winning game in the final spin message

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6884e8780f008320b73b8a52909b581b