### PR TITLE
Fix winner reset logic

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -58,6 +58,8 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
     setRouletteGames(postSpinGames);
     if (postSpinWinner) {
       setWinner(postSpinWinner);
+    } else {
+      setWinner(null);
     }
     setEliminatedGame(null);
   };

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -218,6 +218,8 @@ export default function Home() {
     setRouletteGames(postSpinGames);
     if (postSpinWinner) {
       setWinner(postSpinWinner);
+    } else {
+      setWinner(null);
     }
     setEliminatedGame(null);
   };


### PR DESCRIPTION
## Summary
- keep `winner` in sync after each spin
- apply the same fix in archived poll view

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6884efdaea948320bae40a886d307ba7