### PR TITLE
Fix game lookup to avoid multiple rows

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -641,6 +641,7 @@ app.post('/api/games', async (req, res) => {
     .from('games')
     .select('id')
     .eq('name', name)
+    .limit(1)
     .maybeSingle();
   if (gameErr) return res.status(500).json({ error: gameErr.message });
 


### PR DESCRIPTION
## Summary
- enforce single-row game lookup with `.limit(1)`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688521308e588320808d46372e62b59e