### PR TITLE
Add active roulette status and clean homepage

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -801,7 +801,7 @@ app.post('/api/manage_game', async (req, res) => {
     return res.status(400).json({ error: 'name is required' });
   }
 
-  if (status && !['completed', 'backlog'].includes(status)) {
+  if (status && !['completed', 'backlog', 'active'].includes(status)) {
     return res.status(400).json({ error: 'Invalid status' });
   }
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState, useRef } from "react";
 import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/RouletteWheel";
 import SettingsModal from "@/components/SettingsModal";
 import SpinResultModal from "@/components/SpinResultModal";
-import AddGameModal from "@/components/AddGameModal";
 import type { Session } from "@supabase/supabase-js";
 import type { Game } from "@/types";
 
@@ -43,7 +42,6 @@ export default function Home() {
   const [allowEdit, setAllowEdit] = useState(true);
   const [isModerator, setIsModerator] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
-  const [showAddGame, setShowAddGame] = useState(false);
   const [eliminatedGame, setEliminatedGame] = useState<WheelGame | null>(null);
   const [postSpinGames, setPostSpinGames] = useState<WheelGame[]>([]);
   const [postSpinWinner, setPostSpinWinner] = useState<WheelGame | null>(null);
@@ -332,12 +330,6 @@ export default function Home() {
         <div className="space-x-2">
           <button
             className="px-2 py-1 bg-purple-600 text-white rounded"
-            onClick={() => setShowAddGame(true)}
-          >
-            Add Game
-          </button>
-          <button
-            className="px-2 py-1 bg-purple-600 text-white rounded"
             onClick={() => setShowSettings(true)}
           >
             Settings
@@ -436,14 +428,6 @@ export default function Home() {
           setAllowEdit(edit);
           setShowSettings(false);
         }}
-      />
-    )}
-    {showAddGame && (
-      <AddGameModal
-        pollId={poll.id}
-        session={session}
-        onClose={() => setShowAddGame(false)}
-        onAdded={fetchPoll}
       />
     )}
     {eliminatedGame && (

--- a/frontend/components/AddCatalogGameModal.tsx
+++ b/frontend/components/AddCatalogGameModal.tsx
@@ -87,6 +87,7 @@ export default function AddCatalogGameModal({ session, onClose, onAdded }: Props
           >
             <option value="completed">Completed</option>
             <option value="backlog">Backlog</option>
+            <option value="active">Active Roulette</option>
           </select>
         </div>
         <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- remove Add Game button from the poll page
- let moderators add Active Roulette games in catalog
- accept `active` status in manage_game API

## Testing
- `npm install` *(frontend)*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6885f5542648832090b453798ef0e22b