### PR TITLE
Add archived roulette option

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -32,6 +32,7 @@ async function getActivePoll() {
   const { data: poll, error } = await supabase
     .from('polls')
     .select('*')
+    .eq('archived', false)
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle();

--- a/frontend/app/archive/page.tsx
+++ b/frontend/app/archive/page.tsx
@@ -2,25 +2,53 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { supabase } from "@/utils/supabaseClient";
+import type { Session } from "@supabase/supabase-js";
 
 interface PollInfo {
   id: number;
   created_at: string;
+  archived: boolean;
 }
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 export default function ArchivePage() {
   const [polls, setPolls] = useState<PollInfo[]>([]);
+  const [session, setSession] = useState<Session | null>(null);
+  const [isModerator, setIsModerator] = useState(false);
 
   useEffect(() => {
     if (!backendUrl) return;
     fetch(`${backendUrl}/api/polls`).then(async (res) => {
       if (!res.ok) return;
       const data = await res.json();
-      setPolls(data.polls || []);
+      setPolls((data.polls || []) as PollInfo[]);
     });
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session);
+    });
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_e, sess) => {
+      setSession(sess);
+    });
+    return () => subscription.unsubscribe();
   }, []);
+
+  useEffect(() => {
+    const checkMod = async () => {
+      setIsModerator(false);
+      if (!session) return;
+      const { data } = await supabase
+        .from("users")
+        .select("is_moderator")
+        .eq("auth_id", session.user.id)
+        .maybeSingle();
+      setIsModerator(!!data?.is_moderator);
+    };
+    checkMod();
+  }, [session]);
 
   if (!backendUrl) {
     return <div className="p-4">Backend URL not configured.</div>;
@@ -32,14 +60,24 @@ export default function ArchivePage() {
       <Link href="/" className="underline text-purple-600">
         Go to active roulette
       </Link>
+      {isModerator && (
+        <Link
+          href="/new-poll"
+          className="px-2 py-1 bg-purple-600 text-white rounded inline-block"
+        >
+          New Roulette
+        </Link>
+      )}
       <ul className="space-y-2">
-        {polls.slice(1).map((p) => (
-          <li key={p.id}>
-            <Link href={`/archive/${p.id}`} className="text-purple-600 underline">
-              Roulette from {new Date(p.created_at).toLocaleString()}
-            </Link>
-          </li>
-        ))}
+        {polls
+          .filter((p) => p.archived)
+          .map((p) => (
+            <li key={p.id}>
+              <Link href={`/archive/${p.id}`} className="text-purple-600 underline">
+                Roulette from {new Date(p.created_at).toLocaleString()}
+              </Link>
+            </li>
+          ))}
       </ul>
     </main>
   );

--- a/frontend/app/new-poll/page.tsx
+++ b/frontend/app/new-poll/page.tsx
@@ -22,6 +22,7 @@ export default function NewPollPage() {
   const [loading, setLoading] = useState(true);
   const [showAdd, setShowAdd] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [archive, setArchive] = useState(false);
   const router = useRouter();
 
   const fetchPoll = async () => {
@@ -95,10 +96,13 @@ export default function NewPollPage() {
         "Content-Type": "application/json",
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: JSON.stringify({ game_ids: games.map((g) => g.id) }),
+      body: JSON.stringify({
+        game_ids: games.map((g) => g.id),
+        archived: archive,
+      }),
     });
     if (resp.ok) {
-      router.push("/");
+      router.push(archive ? "/archive" : "/");
     } else {
       setSubmitting(false);
     }
@@ -114,8 +118,16 @@ export default function NewPollPage() {
   return (
     <>
       <main className="p-4 max-w-xl mx-auto space-y-4">
-        <h1 className="text-2xl font-semibold">New Roulette</h1>
-        {games.length === 0 ? (
+      <h1 className="text-2xl font-semibold">New Roulette</h1>
+      <div className="flex items-center space-x-2">
+        <label className="text-sm">Add to archive only:</label>
+        <input
+          type="checkbox"
+          checked={archive}
+          onChange={(e) => setArchive(e.target.checked)}
+        />
+      </div>
+      {games.length === 0 ? (
           <p>No games selected.</p>
         ) : (
           <ul className="space-y-2">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -60,7 +60,12 @@ export default function Home() {
       return;
     }
     const pollRes = await resp.json();
-    const pollData: Poll = { id: pollRes.poll_id, games: pollRes.games };
+    const pollData: Poll = {
+      id: pollRes.poll_id,
+      created_at: pollRes.created_at,
+      archived: pollRes.archived,
+      games: pollRes.games,
+    };
 
     const coeffResp = await fetch(`${backendUrl}/api/voice_coeff`);
     if (coeffResp.ok) {
@@ -335,12 +340,6 @@ export default function Home() {
           >
             Settings
           </button>
-          <Link
-            href="/new-poll"
-            className="px-2 py-1 bg-purple-600 text-white rounded"
-          >
-            New Roulette
-          </Link>
         </div>
       )}
       <p>You can cast up to {voteLimit} votes.</p>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -12,5 +12,6 @@ export interface PollGame extends Game {
 export interface Poll {
   id: number;
   created_at: string;
+  archived: boolean;
   games: PollGame[];
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -27,8 +27,12 @@ alter table games
 
 create table if not exists polls (
   id serial primary key,
-  created_at timestamp default now()
+  created_at timestamp default now(),
+  archived boolean default false
 );
+
+alter table polls
+  add column if not exists archived boolean default false;
 
 create table if not exists poll_games (
   poll_id integer references polls(id),


### PR DESCRIPTION
## Summary
- allow polls to be marked as archived in DB
- filter active poll and expose archive flag via API
- update bot to ignore archived polls
- support `archive` option when creating new polls
- move New Roulette button to archive page
- tidy types and UI for archived polls

## Testing
- `npm run lint` *(fails: requires initial configuration)*
- `npx tsc -p frontend --noEmit` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6886989c50b483208edabbcc03d1b5d0