### PR TITLE
Add poll result storage and replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Moderators can toggle accepting votes and vote editing via the `/api/accept_vote
 
 To see the current poll visualized as a spinning wheel, open the homepage. Games are eliminated from the wheel one by one as it spins until a final winner remains. This does not remove anything from the database; it's only a visual way to pick a random game.
 
+Archived roulettes now store the elimination order and the winning game. When viewing an entry in the archive you will see the full elimination sequence and a button to replay the wheel using the recorded seed so the spins reproduce exactly.
+
 With a YouTube API key configured you can also visit `/playlists` to see videos from your channel grouped by tags extracted from their descriptions.
 
 ## Updating the Supabase schema

--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -18,19 +18,29 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
   const [postSpinGames, setPostSpinGames] = useState<WheelGame[]>([]);
   const [postSpinWinner, setPostSpinWinner] = useState<WheelGame | null>(null);
   const wheelRef = useRef<RouletteWheelHandle>(null);
+  const [result, setResult] = useState<{
+    poll_id: number;
+    winner_id: number | null;
+    eliminated_order: number[];
+    spin_seed: string | null;
+  } | null>(null);
+  const [replaySeed, setReplaySeed] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
       if (!backendUrl) return;
       const resp = await fetch(`${backendUrl}/api/poll/${id}`);
-      if (!resp.ok) {
-        setLoading(false);
-        return;
+      if (resp.ok) {
+        const data = await resp.json();
+        setPoll(data);
+        setRouletteGames(data.games);
+        setWinner(null);
       }
-      const data = await resp.json();
-      setPoll(data);
-      setRouletteGames(data.games);
-      setWinner(null);
+      const res = await fetch(`${backendUrl}/api/poll/${id}/result`);
+      if (res.ok) {
+        const rdata = await res.json();
+        setResult(rdata);
+      }
       setLoading(false);
     };
     fetchData();
@@ -64,6 +74,16 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
     setEliminatedGame(null);
   };
 
+  const handleReplay = () => {
+    if (!result || !poll) return;
+    setRouletteGames(poll.games);
+    setWinner(null);
+    setReplaySeed(result.spin_seed);
+    setPostSpinGames([]);
+    setPostSpinWinner(null);
+    wheelRef.current?.spin();
+  };
+
   if (!backendUrl) return <div className="p-4">Backend URL not configured.</div>;
   if (loading) return <div className="p-4">Loading...</div>;
   if (!poll) return <div className="p-4">Poll not found.</div>;
@@ -76,6 +96,33 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
       <h1 className="text-2xl font-semibold">
         Roulette from {new Date(poll.created_at).toLocaleString()}
       </h1>
+      {result && (
+        <div className="space-y-2">
+          {result.winner_id && (
+            <p className="font-semibold">
+              Winning game: {poll.games.find((g) => g.id === result.winner_id)?.name}
+            </p>
+          )}
+          {result.eliminated_order.length > 0 && (
+            <div>
+              <p>Elimination order:</p>
+              <ol className="list-decimal pl-4">
+                {result.eliminated_order.map((id) => (
+                  <li key={id}>{poll.games.find((g) => g.id === id)?.name}</li>
+                ))}
+              </ol>
+            </div>
+          )}
+          {result.spin_seed && (
+            <button
+              className="px-2 py-1 bg-purple-600 text-white rounded"
+              onClick={handleReplay}
+            >
+              Replay
+            </button>
+          )}
+        </div>
+      )}
       <ul className="space-y-2">
         {poll.games.map((game) => (
           <li key={game.id} className="border p-2 rounded space-y-1">
@@ -98,6 +145,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
               ref={wheelRef}
               games={rouletteGames}
               onDone={handleSpinEnd}
+              spinSeed={replaySeed ?? undefined}
             />
             <button
               className="px-4 py-2 bg-purple-600 text-white rounded"

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -54,6 +54,14 @@ create table if not exists votes (
   slot integer not null
 );
 
+create table if not exists poll_results (
+  poll_id integer primary key references polls(id),
+  winner_id integer references games(id),
+  eliminated_order integer[] not null,
+  spin_seed text,
+  created_at timestamp default now()
+);
+
 create index if not exists votes_user_id_idx on votes(user_id);
 
 create index if not exists votes_poll_id_idx on votes(poll_id);


### PR DESCRIPTION
## Summary
- add `poll_results` table to schema
- implement POST/GET `/api/poll/:id/result`
- track elimination order and submit result from the roulette
- show archived results and replay using seed
- allow deterministic spins via `spinSeed` prop
- document archive replay feature

## Testing
- `psql "$SUPABASE_URL" -f supabase/schema.sql` *(fails: connection not available)*
- `npm run build` in `backend` (no build step)
- `npm run build` in `frontend` *(fails: missing env var `supabaseUrl`)*

------
https://chatgpt.com/codex/tasks/task_e_6886af63d92c8320a272839b2c7e2e13