### PR TITLE
Redirect to new poll after official spin

### DIFF
--- a/frontend/app/new-poll/page.tsx
+++ b/frontend/app/new-poll/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import AddGameModal from "@/components/AddGameModal";
 import { supabase } from "@/utils/supabaseClient";
 import type { Session } from "@supabase/supabase-js";
@@ -24,11 +24,16 @@ export default function NewPollPage() {
   const [submitting, setSubmitting] = useState(false);
   const [archive, setArchive] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const fetchPoll = async () => {
     if (!backendUrl) return;
     setLoading(true);
-    const resp = await fetch(`${backendUrl}/api/poll`);
+    const copyId = searchParams.get("copy");
+    const url = copyId
+      ? `${backendUrl}/api/poll/${copyId}`
+      : `${backendUrl}/api/poll`;
+    const resp = await fetch(url);
     if (resp.ok) {
       const data = await resp.json();
       setGames(data.games.map((g: any) => ({ id: g.id, name: g.name })));

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3,6 +3,7 @@
 import { supabase } from "@/utils/supabaseClient";
 import { useEffect, useState, useRef } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/RouletteWheel";
 import SettingsModal from "@/components/SettingsModal";
 import SpinResultModal from "@/components/SpinResultModal";
@@ -46,6 +47,7 @@ export default function Home() {
   const [elimOrder, setElimOrder] = useState<number[]>([]);
   const [spinSeed, setSpinSeed] = useState<string | null>(null);
   const [officialMode, setOfficialMode] = useState(false);
+  const router = useRouter();
 
   const sendResult = async (winnerId: number) => {
     if (!backendUrl || !isModerator || !poll) return null;
@@ -254,6 +256,10 @@ export default function Home() {
               "Content-Type": "application/json",
               ...(token ? { Authorization: `Bearer ${token}` } : {}),
             },
+          }).then((arch) => {
+            if (arch.ok) {
+              router.push(`/new-poll?copy=${poll.id}`);
+            }
           });
         });
       }


### PR DESCRIPTION
## Summary
- redirect moderator to `/new-poll` after archiving the poll
- allow `/new-poll` page to pre-populate games by passing `copy` query parameter

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npm run build` in `frontend` *(fails: missing env `supabaseUrl`)*

------
https://chatgpt.com/codex/tasks/task_e_6886ba996f188320ab95e7e955983abd