### PR TITLE
Fix Next.js build error with Suspense

### DIFF
--- a/frontend/app/new-poll/page.tsx
+++ b/frontend/app/new-poll/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import AddGameModal from "@/components/AddGameModal";
 import { supabase } from "@/utils/supabaseClient";
@@ -15,7 +15,7 @@ interface SearchResult {
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
-export default function NewPollPage() {
+function NewPollPageContent() {
   const [games, setGames] = useState<Game[]>([]);
   const [session, setSession] = useState<Session | null>(null);
   const [isModerator, setIsModerator] = useState(false);
@@ -170,5 +170,13 @@ export default function NewPollPage() {
         />
       )}
     </>
+  );
+}
+
+export default function NewPollPage() {
+  return (
+    <Suspense>
+      <NewPollPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the New Roulette page in a Suspense boundary to satisfy Next.js CSR bailout check

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6886bc4032a08320b3b9ae80e725702d