### PR TITLE
Fix archive roulette replay timing

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -81,8 +81,13 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
     setReplaySeed(result.spin_seed);
     setPostSpinGames([]);
     setPostSpinWinner(null);
-    wheelRef.current?.spin();
   };
+
+  useEffect(() => {
+    if (replaySeed) {
+      wheelRef.current?.spin();
+    }
+  }, [replaySeed]);
 
   if (!backendUrl) return <div className="p-4">Backend URL not configured.</div>;
   if (loading) return <div className="p-4">Loading...</div>;


### PR DESCRIPTION
## Summary
- replay the archive roulette wheel only after the seed is applied

## Testing
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68872edfee48832097091c00c60b8b9c