### PR TITLE
Capture year and genres from RAWG

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -25,6 +25,10 @@ alter table games
 alter table games
   add column if not exists background_image text;
 
+alter table games
+  add column if not exists released_year integer,
+  add column if not exists genres text[];
+
 create table if not exists polls (
   id serial primary key,
   created_at timestamp default now(),


### PR DESCRIPTION
## Summary
- extend `games` table with `released_year` and `genres`
- capture and store these fields when adding or managing a game
- expose the new fields via the `/api/games` endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688787edb9d4832089a98909fe9f6dc6