### PR TITLE
Improve roulette with images

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -26,7 +26,7 @@ async function buildPollResponse(poll) {
   const gameIds = pollGames.map((pg) => pg.game_id);
   const { data: games, error: gamesError } = await supabase
     .from('games')
-    .select('id, name')
+    .select('id, name, background_image')
     .in('id', gameIds.length > 0 ? gameIds : [0]);
   if (gamesError) return { error: gamesError };
 
@@ -61,6 +61,7 @@ async function buildPollResponse(poll) {
   const results = games.map((g) => ({
     id: g.id,
     name: g.name,
+    background_image: g.background_image,
     count: counts[g.id] || 0,
     nicknames: nicknames[g.id] || [],
   }));

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -1,6 +1,7 @@
 export interface Game {
   id: number;
   name: string;
+  background_image?: string | null;
   nicknames?: string[];
 }
 


### PR DESCRIPTION
## Summary
- send `background_image` for poll games
- show game images on the roulette wheel when available
- extend `Game` type with optional `background_image`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887bcec4a3483209f65f2a0c91da99f