### PR TITLE
Update wheel label orientation

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -133,14 +133,17 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
         const x = r + (r - 35) * Math.cos(mid);
         const y = r + (r - 35) * Math.sin(mid);
         const fontSize = Math.min(slice * r, 14);
-        ctx.font = `${fontSize}px sans-serif`;
-        ctx.fillStyle = "#000";
+        ctx.font = `bold ${fontSize}px sans-serif`;
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.save();
         ctx.translate(x, y);
-        ctx.rotate(mid + Math.PI / 2);
+        ctx.rotate(mid);
+        ctx.strokeStyle = "#000";
+        ctx.lineWidth = 2;
         const label = g.name.length > 10 ? g.name.slice(0, 10) + "…" : g.name;
+        ctx.strokeText(label, 0, 0);
+        ctx.fillStyle = "#fff";
         ctx.fillText(label, 0, 0);
         ctx.restore();
 


### PR DESCRIPTION
## Summary
- orient wheel labels along slice radius
- outline labels for contrast

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` *(fails: missing `supabaseUrl` env var)*

------
https://chatgpt.com/codex/tasks/task_e_6887c13d43808320912f11b72b19b09d