### PR TITLE
Handle broken images on roulette wheel

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -87,6 +87,10 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
             imagesRef.current.set(g.id, img);
             drawWheel();
           };
+          img.onerror = () => {
+            imagesRef.current.delete(g.id);
+            drawWheel();
+          };
           imagesRef.current.set(g.id, img);
         }
       });
@@ -110,7 +114,12 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
         ctx.closePath();
         if (g.background_image) {
           const img = imagesRef.current.get(g.id);
-          if (img && img.complete) {
+          if (
+            img &&
+            img.complete &&
+            img.naturalWidth > 0 &&
+            img.naturalHeight > 0
+          ) {
             ctx.save();
             ctx.clip();
             const scale = Math.max(size / img.width, size / img.height);


### PR DESCRIPTION
## Summary
- remove images from the cache when they fail to load
- verify image dimensions before drawing
- draw fallback colors when images are invalid

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: missing `supabaseUrl` env var)*

------
https://chatgpt.com/codex/tasks/task_e_6887c9b9a0bc8320a2b0859a709a9e6e