### PR TITLE
Fix wheel image crossOrigin handling

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -81,7 +81,9 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
       weighted.forEach((g) => {
         if (g.background_image && !imagesRef.current.has(g.id)) {
           const img = new Image();
-          img.crossOrigin = "anonymous";
+          if (g.background_image.startsWith("http")) {
+            img.crossOrigin = "anonymous";
+          }
           img.src = g.background_image;
           img.onload = () => {
             imagesRef.current.set(g.id, img);


### PR DESCRIPTION
## Summary
- set `img.crossOrigin` only when the image URL looks cross-origin

## Testing
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_6887cd677db8832089d9fb212cbbca64