### PR TITLE
Log failures when game images can't load

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -90,6 +90,9 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
             drawWheel();
           };
           img.onerror = () => {
+            console.warn(
+              `Failed to load image for game ${g.id}: ${g.background_image}`
+            );
             imagesRef.current.delete(g.id);
             drawWheel();
           };


### PR DESCRIPTION
## Summary
- add console warning to log failed roulette image loads

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run build` *(fails: missing Supabase config)*

------
https://chatgpt.com/codex/tasks/task_e_6887ceaa23d88320bd2ec8a6b6b23a46