### PR TITLE
Add Twitch role checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,19 @@ RAWG_API_KEY=your-rawg-key
 ```
 TWITCH_CLIENT_ID=your-client-id
 TWITCH_SECRET=your-client-secret
+TWITCH_CHANNEL_ID=your-channel-id
 ```
 Configure the same URLs in the Supabase dashboard for both local development
-and production.
+and production. The app requests the following Twitch OAuth scopes when logging
+in:
+
+```
+moderation:read
+channel:read:vips
+channel:read:subscriptions
+```
+These allow the frontend to check whether the user is a moderator, VIP or
+subscriber of the configured channel.
 
 3. Run the backend and frontend:
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,7 @@ SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZi
 PORT=3001
 TWITCH_CLIENT_ID=
 TWITCH_SECRET=
+TWITCH_CHANNEL_ID=
 # OAuth callback URL, e.g. http://localhost:3000/auth/callback
 OAUTH_CALLBACK_URL=http://localhost:3000/auth/callback
 ADMIN_TOKEN=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,6 +2,7 @@ NEXT_PUBLIC_SUPABASE_URL=https://bsiiyuwbzhwrflsdpoud.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJzaWl5dXdiemh3cmZsc2Rwb3VkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI3NDIzMzUsImV4cCI6MjA2ODMxODMzNX0.2dGo45jMsUK4Zg8aoSc4kuXd2yBIpFfXgzvhw6zEQfU
 TWITCH_CLIENT_ID=
 TWITCH_SECRET=
+TWITCH_CHANNEL_ID=
 # OAuth callback URL. Configure this in the Twitch dashboard as
 # http://localhost:3000/auth/callback for local development
 OAUTH_CALLBACK_URL=http://localhost:3000/auth/callback

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -6,6 +6,8 @@ import type { Session } from "@supabase/supabase-js";
 
 export default function AuthStatus() {
   const [session, setSession] = useState<Session | null>(null);
+  const [profileUrl, setProfileUrl] = useState<string | null>(null);
+  const [roles, setRoles] = useState<string[]>([]);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -19,10 +21,73 @@ export default function AuthStatus() {
     return () => subscription.unsubscribe();
   }, []);
 
+  useEffect(() => {
+    const token = (session as any)?.provider_token as string | undefined;
+    const clientId = process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID;
+    const channelId = process.env.TWITCH_CHANNEL_ID;
+    if (!token || !clientId) {
+      setProfileUrl(null);
+      setRoles([]);
+      return;
+    }
+
+    const headers = {
+      'Client-ID': clientId,
+      Authorization: `Bearer ${token}`,
+    };
+
+    const fetchInfo = async () => {
+      try {
+        const userRes = await fetch('https://api.twitch.tv/helix/users', {
+          headers,
+        });
+        if (!userRes.ok) throw new Error('user');
+        const userData = await userRes.json();
+        const me = userData.data?.[0];
+        if (!me) throw new Error('user');
+        setProfileUrl(me.profile_image_url);
+        const uid = me.id as string;
+
+        const r: string[] = [];
+        if (channelId && uid === channelId) r.push('Streamer');
+
+        const query = `?broadcaster_id=${channelId}&user_id=${uid}`;
+        const checkRole = async (url: string, name: string) => {
+          try {
+            const resp = await fetch(url + query, { headers });
+            if (!resp.ok) return; // likely missing scope
+            const d = await resp.json();
+            if (d.data && d.data.length > 0) r.push(name);
+          } catch {
+            // ignore
+          }
+        };
+
+        if (channelId) {
+          await checkRole('https://api.twitch.tv/helix/moderation/moderators', 'Mod');
+          await checkRole('https://api.twitch.tv/helix/channels/vips', 'VIP');
+          await checkRole('https://api.twitch.tv/helix/subscriptions', 'Sub');
+        }
+
+        setRoles(r);
+      } catch (e) {
+        console.error('Twitch API error', e);
+        setRoles([]);
+        setProfileUrl(null);
+      }
+    };
+
+    fetchInfo();
+  }, [session]);
+
   const handleLogin = () => {
     supabase.auth.signInWithOAuth({
       provider: "twitch",
-      options: { redirectTo: `${window.location.origin}/auth/callback` },
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+        scopes:
+          "user:read:email moderation:read channel:read:vips channel:read:subscriptions",
+      },
     });
   };
 
@@ -40,7 +105,19 @@ export default function AuthStatus() {
 
   return session ? (
     <div className="flex items-center space-x-2">
-      <span className="truncate max-w-xs">{username}</span>
+      {profileUrl && (
+        <img
+          src={profileUrl}
+          alt="profile"
+          className="w-6 h-6 rounded-full"
+        />
+      )}
+      <span className="truncate max-w-xs">
+        {username}
+        {roles.length > 0 && (
+          <> ({roles.join(', ')})</>
+        )}
+      </span>
       <button
         className="px-2 py-1 bg-gray-800 text-white rounded"
         onClick={handleLogout}


### PR DESCRIPTION
## Summary
- add `TWITCH_CHANNEL_ID` example variable to env files
- display Twitch profile image and roles after login
- request mod/VIP/sub scopes when logging into Twitch
- document new variable and OAuth scopes in README

## Testing
- `npm install` *(frontend)*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6887e070492c8320a953a582de85f4d1