### PR TITLE
Restore promised params for dynamic pages

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { use, useEffect, useState, useRef } from "react";
 import Link from "next/link";
 import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/RouletteWheel";
 import SpinResultModal from "@/components/SpinResultModal";
@@ -8,8 +8,8 @@ import type { Poll } from "@/types";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
-export default function ArchivedPollPage({ params }: { params: { id: string } }) {
-  const { id } = params;
+export default function ArchivedPollPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
   const [poll, setPoll] = useState<Poll | null>(null);
   const [loading, setLoading] = useState(true);
   const [rouletteGames, setRouletteGames] = useState<WheelGame[]>([]);

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { use, useEffect, useState } from "react";
 import Link from "next/link";
 import { supabase } from "@/utils/supabaseClient";
 import type { Session } from "@supabase/supabase-js";
@@ -20,8 +20,8 @@ interface UserInfo {
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
-export default function UserPage({ params }: { params: { id: string } }) {
-  const { id } = params;
+export default function UserPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
   const [user, setUser] = useState<UserInfo | null>(null);
   const [history, setHistory] = useState<PollHistory[]>([]);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- revert to promised params in archive and user pages
- use React's `use` to unwrap the params promise
- verify frontend build after re-installing dependencies

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887f4626e408320917cc3e0e6bc35e7