### PR TITLE
Fix Twitch profile info persistence

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -43,7 +43,6 @@ export default function RootLayout({
               <Link href="/playlists">Playlists</Link>
             </div>
             <div className="flex items-center space-x-4">
-              <AuthStatus />
               <a
                 href="https://twitch.tv/terrenkur"
                 target="_blank"
@@ -65,6 +64,7 @@ export default function RootLayout({
               >
                 Discord
               </a>
+              <AuthStatus />
             </div>
           </nav>
         </header>

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { use, useEffect, useState } from "react";
+
+const TOKEN_KEY = 'twitch_provider_token';
 import Link from "next/link";
 import { supabase } from "@/utils/supabaseClient";
 import type { Session } from "@supabase/supabase-js";
@@ -57,6 +59,18 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
     return () => subscription.unsubscribe();
   }, []);
 
+  // Store provider token for reloads
+  useEffect(() => {
+    const token = (session as any)?.provider_token as string | undefined;
+    if (token) {
+      try {
+        localStorage.setItem(TOKEN_KEY, token);
+      } catch {
+        // ignore
+      }
+    }
+  }, [session]);
+
   useEffect(() => {
     if (!user || !user.logged_in) {
       setProfileUrl(null);
@@ -69,7 +83,11 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       setRoles([]);
       return;
     }
-    const token = (session as any)?.provider_token as string | undefined;
+    const token =
+      ((session as any)?.provider_token as string | undefined) ||
+      (typeof localStorage !== 'undefined'
+        ? localStorage.getItem(TOKEN_KEY) || undefined
+        : undefined);
     const clientId = process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID;
     const channelId = process.env.NEXT_PUBLIC_TWITCH_CHANNEL_ID;
     if (!token || !clientId) {


### PR DESCRIPTION
## Summary
- keep Twitch OAuth token in localStorage so avatar and roles load after refresh
- use stored token on user pages
- place profile info after social links in the header

## Testing
- `npm run build` (fails: supabaseUrl is required)
- `npm run build` in backend

------
https://chatgpt.com/codex/tasks/task_e_6887f6c7c420832083f4b6e9bc4aa02c