### PR TITLE
Reset users vote_limit on new roulette

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -253,6 +253,11 @@ app.post('/api/polls', async (req, res) => {
     if (pgErr) return res.status(500).json({ error: pgErr.message });
   }
 
+  const { error: resetErr } = await supabase
+    .from('users')
+    .update({ vote_limit: 1 });
+  if (resetErr) return res.status(500).json({ error: resetErr.message });
+
   res.json({ poll_id: newPoll.id });
 });
 


### PR DESCRIPTION
## Summary
- ensure user vote limits reset to 1 when creating a new poll

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68889fc3658c832088242a6e7ef64e40