### PR TITLE
Add confirmation before starting official roulette spin

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -403,6 +403,8 @@ export default function Home() {
   };
 
   const startOfficialSpin = async () => {
+    const confirmStart = window.confirm("Start official spin?");
+    if (!confirmStart) return;
     await saveAccept(false);
     await saveAllowEdit(false);
     setAcceptVotes(false);


### PR DESCRIPTION
## Summary
- prompt user before starting official spin

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6888ab3fdd9c8320a45752bfc2f9f40a