### PR TITLE
Fix base border style

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -69,7 +69,7 @@
   }
 
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
 
   body {


### PR DESCRIPTION
## Summary
- remove `@apply border-border` usage in globals.css
- keep `border` token in Tailwind config
- confirm `npm run build` succeeds without the warning

## Testing
- `npm install` in `frontend`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888e7e99b6483209b3650efb8ed8e4e