### PR TITLE
Fix Next.js viewport metadata

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -17,7 +17,11 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Terrenkur",
   description: "Random game roulette",
-  viewport: "width=device-width, initial-scale=1",
+};
+
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- remove deprecated `viewport` field from layout metadata
- export viewport settings separately
- run Next.js build to verify no unsupported metadata warnings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888e93d1afc8320b6b032bfec48a5cb