### PR TITLE
Fix tailwind config name

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,4 @@
-import { fontFamily } from "tailwindcss/defaultTheme";
+const { fontFamily } = require("tailwindcss/defaultTheme");
 
 /** @type {import('tailwindcss').Config} */
 const config = {
@@ -78,4 +78,4 @@ const config = {
   plugins: [require("tailwindcss-animate")],
 };
 
-export default config;
+module.exports = config;


### PR DESCRIPTION
## Summary
- rename `tailwind.config.mjs` to `tailwind.config.js`
- switch tailwind config to CommonJS export

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68890dc7e39483209031f3965f808bbe