### PR TITLE
Fix PostCSS config to use object syntax

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,3 +1,5 @@
 module.exports = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
 };


### PR DESCRIPTION
## Summary
- switch PostCSS plugins array to object syntax in `frontend/postcss.config.js`

## Testing
- `npm ci`
- `npm run build` *(fails: Cannot apply unknown utility class `bg-background`)*

------
https://chatgpt.com/codex/tasks/task_e_68891b14a380832082d0619ee4ed88c9