### PR TITLE
Add API and React component tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install backend deps
+        run: npm install --prefix backend
+      - name: Run backend tests
+        run: npm test --prefix backend
+      - name: Install frontend deps
+        run: npm install --prefix frontend
+      - name: Run frontend tests
+        run: npm test --prefix frontend

--- a/backend/__tests__/manage_game.test.js
+++ b/backend/__tests__/manage_game.test.js
@@ -1,0 +1,36 @@
+const request = require('supertest');
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_KEY = 'test';
+
+const mockSupabase = {
+  auth: {
+    getUser: jest.fn(() => ({ data: { user: { id: '1' } }, error: null })),
+  },
+  from: jest.fn((table) => ({
+    select: jest.fn(() => ({
+      eq: jest.fn(() => ({ maybeSingle: jest.fn(() => Promise.resolve({ data: { is_moderator: true } })) }))
+    })),
+    upsert: jest.fn(() => ({
+      onConflict: jest.fn(() => ({ maybeSingle: jest.fn(() => Promise.resolve({ data: {} })) }))
+    })),
+    insert: jest.fn(() => ({ select: jest.fn(() => ({ single: jest.fn(() => Promise.resolve({ data: { id: 1 } })) })) })),
+    update: jest.fn(() => ({ eq: jest.fn(() => ({}) ) })),
+  })),
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => mockSupabase),
+}));
+
+const app = require('../server');
+
+describe('POST /api/manage_game', () => {
+  it('requires game_id or name/rawg_id', async () => {
+    const res = await request(app)
+      .post('/api/manage_game')
+      .set('Authorization', 'Bearer token')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/__tests__/poll.test.js
+++ b/backend/__tests__/poll.test.js
@@ -1,0 +1,69 @@
+const request = require('supertest');
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_KEY = 'test';
+
+const poll = { id: 1, created_at: '2024-01-01', archived: false };
+const pollGames = [{ game_id: 1 }, { game_id: 2 }];
+const games = [
+  { id: 1, name: 'Game1', background_image: null },
+  { id: 2, name: 'Game2', background_image: null },
+];
+const votes = [
+  { game_id: 1, user_id: 1 },
+  { game_id: 1, user_id: 2 },
+  { game_id: 2, user_id: 2 },
+];
+const users = [
+  { id: 1, username: 'Alice' },
+  { id: 2, username: 'Bob' },
+];
+
+const build = (data) => {
+  const builder = {};
+  const chain = ['select', 'eq', 'order', 'limit', 'in', 'insert', 'update', 'upsert', 'delete'];
+  chain.forEach((m) => {
+    builder[m] = jest.fn(() => builder);
+  });
+  builder.maybeSingle = jest.fn(async () => ({ data, error: null }));
+  builder.single = jest.fn(async () => ({ data, error: null }));
+  builder.then = (resolve) => Promise.resolve({ data, error: null }).then(resolve);
+  return builder;
+};
+
+const mockSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn((table) => {
+    switch (table) {
+      case 'polls':
+        return build(poll);
+      case 'poll_games':
+        return build(pollGames);
+      case 'games':
+        return build(games);
+      case 'votes':
+        return build(votes);
+      case 'users':
+        return build(users);
+      default:
+        return build(null);
+    }
+  }),
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => mockSupabase),
+}));
+
+const app = require('../server');
+
+describe('GET /api/poll', () => {
+  it('returns aggregated poll data', async () => {
+    const res = await request(app).get('/api/poll');
+    expect(res.status).toBe(200);
+    expect(res.body.games.length).toBe(2);
+    const game = res.body.games.find((g) => g.id === 1);
+    expect(game.count).toBe(2);
+    expect(game.nicknames).toEqual(expect.arrayContaining(['Alice', 'Bob']));
+  });
+});

--- a/backend/__tests__/vote.test.js
+++ b/backend/__tests__/vote.test.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_KEY = 'test';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    auth: { getUser: jest.fn() },
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({ eq: jest.fn(() => Promise.resolve({ data: [] })) })),
+    })),
+  })),
+}));
+
+const app = require('../server');
+
+describe('POST /api/vote', () => {
+  it('requires authorization', async () => {
+    const res = await request(app).post('/api/vote').send({ poll_id: 1 });
+    expect(res.status).toBe(401);
+  });
+});

--- a/frontend/components/__tests__/AddCatalogGameModal.test.tsx
+++ b/frontend/components/__tests__/AddCatalogGameModal.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AddCatalogGameModal from '../AddCatalogGameModal';
+
+const backend = 'http://example.com';
+process.env.NEXT_PUBLIC_BACKEND_URL = backend;
+
+let origFetch: any;
+beforeEach(() => {
+  origFetch = (global as any).fetch;
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ results: [{ rawg_id: 1, name: 'Game', background_image: null }] }),
+  });
+});
+
+afterEach(() => {
+  (global as any).fetch = origFetch;
+});
+
+test('searches and displays results', async () => {
+  render(
+    <AddCatalogGameModal session={null} onClose={() => {}} onAdded={() => {}} />
+  );
+  fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'foo' } });
+  fireEvent.click(screen.getByText('Search'));
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledWith(`${backend}/api/rawg_search?query=foo`));
+  expect(await screen.findByText('Game')).toBeInTheDocument();
+});
+
+test('adds game and calls callbacks', async () => {
+  const onAdded = jest.fn();
+  const onClose = jest.fn();
+  render(
+    <AddCatalogGameModal
+      session={{ access_token: 'tok' } as any}
+      onClose={onClose}
+      onAdded={onAdded}
+    />
+  );
+  fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'foo' } });
+  fireEvent.click(screen.getByText('Search'));
+  await screen.findByText('Game');
+  fireEvent.click(screen.getByText('Add'));
+  await waitFor(() =>
+    expect(global.fetch).toHaveBeenLastCalledWith(`${backend}/api/manage_game`, expect.any(Object))
+  );
+  expect(onAdded).toHaveBeenCalled();
+  expect(onClose).toHaveBeenCalled();
+});

--- a/frontend/components/__tests__/RouletteWheel.test.tsx
+++ b/frontend/components/__tests__/RouletteWheel.test.tsx
@@ -1,0 +1,20 @@
+import { render, act } from '@testing-library/react';
+import RouletteWheel, { RouletteWheelHandle } from '../RouletteWheel';
+
+jest.useFakeTimers();
+
+const games = [
+  { id: 1, name: 'G1', count: 1, background_image: null },
+  { id: 2, name: 'G2', count: 0, background_image: null },
+];
+
+test('calls onDone after spin', () => {
+  const onDone = jest.fn();
+  const ref = { current: null as RouletteWheelHandle | null };
+  render(<RouletteWheel ref={ref} games={games} onDone={onDone} spinSeed="seed" />);
+  act(() => {
+    ref.current!.spin();
+    jest.runAllTimers();
+  });
+  expect(onDone).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- test API routes for polls, voting, and game management
- test AddCatalogGameModal and RouletteWheel components
- run backend and frontend tests in CI

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68893a5fd0b48320907bebca2163488c