### PR TITLE
Fix RAWG images via proxy

### DIFF
--- a/backend/__tests__/proxy.test.js
+++ b/backend/__tests__/proxy.test.js
@@ -20,6 +20,19 @@ describe('GET /api/proxy', () => {
     expect(res.header['access-control-allow-origin']).toBe('*');
   });
 
+  it('allows media.rawg.io host', async () => {
+    const mockResponse = new Response('img', {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+    jest.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+    const res = await request(app).get(
+      '/api/proxy?url=https://media.rawg.io/media/games/test.jpg'
+    );
+    expect(res.status).toBe(200);
+  });
+
   it('rejects disallowed hosts', async () => {
     const res = await request(app).get(
       '/api/proxy?url=https://example.com/data'

--- a/backend/server.js
+++ b/backend/server.js
@@ -12,6 +12,7 @@ app.use(express.json());
 const ALLOWED_PROXY_HOSTS = [
   'static-cdn.jtvnw.net',
   'clips-media-assets2.twitch.tv',
+  'media.rawg.io',
 ];
 
 app.get('/api/proxy', async (req, res) => {


### PR DESCRIPTION
## Summary
- allow `media.rawg.io` through backend image proxy
- cover new host in proxy unit tests

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68893c9b9cb48320973b71781ca578d8