### PR TITLE
Fix postcss plugin name

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    "@tailwindcss/postcss": {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- use `tailwindcss` in `postcss.config.js`

## Testing
- `npm run build` *(fails: Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_68895223c2d483209e59b836760cd033