### PR TITLE
Update roulette pages to 12-column layout

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -110,8 +110,58 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
   if (!poll) return <div className="p-4">Poll not found.</div>;
 
   return (
-    <main className="p-4 max-w-5xl mx-auto flex h-full space-x-4">
-      <div className="flex flex-col items-center justify-center w-72 flex-shrink-0">
+    <>
+      <div className="col-span-3 p-4 space-y-4 overflow-y-auto">
+        <Link href="/archive" className="text-purple-600 underline">
+          Back to archive
+        </Link>
+        <h1 className="text-2xl font-semibold">
+          Roulette from {new Date(poll.created_at).toLocaleString()}
+        </h1>
+        {result && (
+          <div className="space-y-2">
+            {result.winner_id && (
+              <p className="font-semibold">
+                Winning game: {poll.games.find((g) => g.id === result.winner_id)?.name}
+              </p>
+            )}
+            {result.eliminated_order.length > 0 && (
+              <div>
+                <p>Elimination order:</p>
+                <ol className="list-decimal pl-4">
+                  {result.eliminated_order.map((id) => (
+                    <li key={id}>{poll.games.find((g) => g.id === id)?.name}</li>
+                  ))}
+                </ol>
+              </div>
+            )}
+            {result.spin_seed && (
+              <button
+                className="px-2 py-1 bg-purple-600 text-white rounded"
+                onClick={handleReplay}
+              >
+                Replay
+              </button>
+            )}
+          </div>
+        )}
+        <ul className="space-y-2">
+          {poll.games.map((game) => (
+            <li key={game.id} className="border p-2 rounded space-y-1">
+              <div className="flex items-center space-x-2">
+                <span>{game.name}</span>
+                <span className="font-mono">{game.count}</span>
+              </div>
+              <ul className="pl-4 list-disc">
+                {game.nicknames.map((name, i) => (
+                  <li key={name + i}>{name}</li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="col-span-7 p-4 flex flex-col items-center justify-center">
         {rouletteGames.length > 0 && !winner && (
           <>
             <RouletteWheel
@@ -132,56 +182,6 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
           <h2 className="text-2xl font-bold">Winning game: {winner.name}</h2>
         )}
       </div>
-      <div className="flex-1 space-y-4 overflow-y-auto">
-        <Link href="/archive" className="text-purple-600 underline">
-          Back to archive
-        </Link>
-        <h1 className="text-2xl font-semibold">
-          Roulette from {new Date(poll.created_at).toLocaleString()}
-        </h1>
-      {result && (
-        <div className="space-y-2">
-          {result.winner_id && (
-            <p className="font-semibold">
-              Winning game: {poll.games.find((g) => g.id === result.winner_id)?.name}
-            </p>
-          )}
-          {result.eliminated_order.length > 0 && (
-            <div>
-              <p>Elimination order:</p>
-              <ol className="list-decimal pl-4">
-                {result.eliminated_order.map((id) => (
-                  <li key={id}>{poll.games.find((g) => g.id === id)?.name}</li>
-                ))}
-              </ol>
-            </div>
-          )}
-          {result.spin_seed && (
-            <button
-              className="px-2 py-1 bg-purple-600 text-white rounded"
-              onClick={handleReplay}
-            >
-              Replay
-            </button>
-          )}
-        </div>
-      )}
-      <ul className="space-y-2">
-        {poll.games.map((game) => (
-          <li key={game.id} className="border p-2 rounded space-y-1">
-            <div className="flex items-center space-x-2">
-              <span>{game.name}</span>
-              <span className="font-mono">{game.count}</span>
-            </div>
-            <ul className="pl-4 list-disc">
-              {game.nicknames.map((name, i) => (
-                <li key={name + i}>{name}</li>
-              ))}
-            </ul>
-          </li>
-        ))}
-      </ul>
-      </div>
       {eliminatedGame && !isReplay && (
         <SpinResultModal
           eliminated={eliminatedGame}
@@ -189,6 +189,6 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
           onClose={closeResult}
         />
       )}
-    </main>
+    </>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -73,7 +73,10 @@ export default function RootLayout({
           </nav>
         </header>
         <main className="mt-4 flex-grow">
-          {children}
+          <div className="grid grid-cols-12 gap-4 max-w-5xl mx-auto">
+            {children}
+            <div className="col-span-2" />
+          </div>
         </main>
       </body>
     </html>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -418,43 +418,13 @@ export default function Home() {
 
   return (
     <>
-    <main className="p-4 max-w-5xl mx-auto flex h-full space-x-4">
-      <div className="flex flex-col items-center justify-center w-72 flex-shrink-0">
-        {rouletteGames.length > 0 && !winner && (
-          <>
-            <RouletteWheel
-              ref={wheelRef}
-              games={rouletteGames}
-              onDone={handleSpinEnd}
-              weightCoeff={weightCoeff}
-              zeroWeight={zeroWeight}
-              spinSeed={spinSeed ?? undefined}
-            />
-            <button
-              className="px-4 py-2 bg-purple-600 text-white rounded"
-              onClick={handleSpin}
-            >
-              Spin
-            </button>
-            <button
-              className="px-4 py-2 bg-gray-300 rounded"
-              onClick={resetWheel}
-            >
-              Reset
-            </button>
-          </>
-        )}
-        {winner && (
-          <h2 className="text-2xl font-bold">Winning game: {winner.name}</h2>
-        )}
-      </div>
-      <div className="flex-1 space-y-4 overflow-y-auto">
+      <div className="col-span-3 p-4 space-y-4 overflow-y-auto">
         <h1 className="text-2xl font-semibold">Current Poll</h1>
-      {isModerator && (
-        <div className="space-x-2">
-          <button
-            className="px-2 py-1 bg-purple-600 text-white rounded"
-            onClick={() => setShowSettings(true)}
+        {isModerator && (
+          <div className="space-x-2">
+            <button
+              className="px-2 py-1 bg-purple-600 text-white rounded"
+              onClick={() => setShowSettings(true)}
           >
             Settings
           </button>
@@ -466,11 +436,11 @@ export default function Home() {
               Start official spin
             </button>
           ) : (
-            <span className="px-2 py-1 bg-green-600 text-white rounded">
-              Official spin
-            </span>
-          )}
-        </div>
+          <span className="px-2 py-1 bg-green-600 text-white rounded">
+            Official spin
+          </span>
+        )}
+      </div>
       )}
       <p>You can cast up to {voteLimit} votes.</p>
       {!acceptVotes && (
@@ -524,12 +494,41 @@ export default function Home() {
         You have used {usedVotes} of {voteLimit} votes.
       </p>
       </div>
-    </main>
-    {showSettings && (
-      <SettingsModal
-        coeff={weightCoeff}
-        zeroWeight={zeroWeight}
-        acceptVotes={acceptVotes}
+      <div className="col-span-7 p-4 flex flex-col items-center justify-center">
+        {rouletteGames.length > 0 && !winner && (
+          <>
+            <RouletteWheel
+              ref={wheelRef}
+              games={rouletteGames}
+              onDone={handleSpinEnd}
+              weightCoeff={weightCoeff}
+              zeroWeight={zeroWeight}
+              spinSeed={spinSeed ?? undefined}
+            />
+            <button
+              className="px-4 py-2 bg-purple-600 text-white rounded"
+              onClick={handleSpin}
+            >
+              Spin
+            </button>
+            <button
+              className="px-4 py-2 bg-gray-300 rounded"
+              onClick={resetWheel}
+            >
+              Reset
+            </button>
+          </>
+        )}
+        {winner && (
+          <h2 className="text-2xl font-bold">Winning game: {winner.name}</h2>
+        )}
+      </div>
+
+      {showSettings && (
+        <SettingsModal
+          coeff={weightCoeff}
+          zeroWeight={zeroWeight}
+          acceptVotes={acceptVotes}
         allowEdit={allowEdit}
         onClose={() => setShowSettings(false)}
         onSave={async (c, z, acc, edit) => {
@@ -544,14 +543,14 @@ export default function Home() {
           setShowSettings(false);
         }}
       />
-    )}
-    {eliminatedGame && (
-      <SpinResultModal
-        eliminated={eliminatedGame}
-        winner={postSpinWinner}
-        onClose={closeResult}
-      />
-    )}
+      )}
+      {eliminatedGame && (
+        <SpinResultModal
+          eliminated={eliminatedGame}
+          winner={postSpinWinner}
+          onClose={closeResult}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add grid layout with empty right column
- show games list on the left and wheel in the center on main page
- use the same layout for archived roulette pages

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6889f0d1eb888320b1d64b202ed0ee0f