### PR TITLE
Reduce roulette column spacing

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -111,7 +111,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
 
   return (
     <>
-      <div className="col-span-3 p-4 space-y-4 overflow-y-auto">
+      <div className="col-span-3 px-2 py-4 space-y-4 overflow-y-auto">
         <Link href="/archive" className="text-purple-600 underline">
           Back to archive
         </Link>
@@ -161,7 +161,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
           ))}
         </ul>
       </div>
-      <div className="col-span-7 p-4 flex flex-col items-center justify-center">
+      <div className="col-span-7 px-2 py-4 flex flex-col items-center justify-center">
         {rouletteGames.length > 0 && !winner && (
           <>
             <RouletteWheel

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -73,7 +73,7 @@ export default function RootLayout({
           </nav>
         </header>
         <main className="mt-4 flex-grow">
-          <div className="grid grid-cols-12 gap-4 max-w-5xl mx-auto">
+          <div className="grid grid-cols-12 gap-x-2 gap-y-4 max-w-5xl mx-auto">
             {children}
             <div className="col-span-2" />
           </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -418,7 +418,7 @@ export default function Home() {
 
   return (
     <>
-      <div className="col-span-3 p-4 space-y-4 overflow-y-auto">
+      <div className="col-span-3 px-2 py-4 space-y-4 overflow-y-auto">
         <h1 className="text-2xl font-semibold">Current Poll</h1>
         {isModerator && (
           <div className="space-x-2">
@@ -494,7 +494,7 @@ export default function Home() {
         You have used {usedVotes} of {voteLimit} votes.
       </p>
       </div>
-      <div className="col-span-7 p-4 flex flex-col items-center justify-center">
+      <div className="col-span-7 px-2 py-4 flex flex-col items-center justify-center">
         {rouletteGames.length > 0 && !winner && (
           <>
             <RouletteWheel


### PR DESCRIPTION
## Summary
- tighten horizontal gaps in the main layout
- decrease padding on main roulette columns
- update archive page column padding

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889f56a299483208a4b3d7ec47d1f88