### PR TITLE
Show logs column globally

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
 import AuthStatus from "@/components/AuthStatus";
 import TwitchVideos from "@/components/TwitchVideos";
+import EventLog from "@/components/EventLog";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -76,7 +77,8 @@ export default function RootLayout({
         <main className="mt-4 flex-grow">
           <div className="grid grid-cols-12 gap-x-2 gap-y-4 max-w-5xl mx-auto">
             {children}
-            <div className="col-span-2">
+            <div className="col-span-2 space-y-4">
+              <EventLog />
               <TwitchVideos />
             </div>
           </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/RouletteWheel";
-import EventLog from "@/components/EventLog";
 import SettingsModal from "@/components/SettingsModal";
 import SpinResultModal from "@/components/SpinResultModal";
 import type { Session } from "@supabase/supabase-js";
@@ -524,9 +523,7 @@ export default function Home() {
           <h2 className="text-2xl font-bold">Winning game: {winner.name}</h2>
         )}
       </div>
-      <div className="col-span-2 px-2 py-4 overflow-y-auto">
-        <EventLog />
-      </div>
+
 
       {showSettings && (
         <SettingsModal


### PR DESCRIPTION
## Summary
- show recent event logs on all pages
- remove per-page event log from home page

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a161410c48320af0c83bde6a9e7d0