### PR TITLE
Add Twitch event logging to bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ have remaining votes.
    ```bash
    cp bot/.env.example bot/.env
    ```
+   The bot can also log channel point rewards, new followers and subs.
+   To enable these features set the following variables in `bot/.env`:
+
+   ```
+   TWITCH_CLIENT_ID=your-client-id
+   TWITCH_SECRET=your-client-secret
+   TWITCH_CHANNEL_ID=your-channel-id
+   # Optional comma separated list of reward IDs to log
+   LOG_REWARD_IDS=id1,id2
+   ```
+
 3. Start the bot:
    ```bash
    npm start

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -3,3 +3,8 @@ SUPABASE_KEY=your-supabase-service-key
 BOT_USERNAME=your-bot-username
 BOT_OAUTH_TOKEN=oauth:your-oauth-token
 TWITCH_CHANNEL=terrenkur
+TWITCH_CLIENT_ID=
+TWITCH_SECRET=
+TWITCH_CHANNEL_ID=
+# Comma separated reward IDs to log, leave empty to log all
+LOG_REWARD_IDS=


### PR DESCRIPTION
## Summary
- capture Twitch events in the bot and store them in `event_logs`
- track channel point reward IDs and log messages
- poll Helix API for new follows
- log subscription and gift sub events
- document new environment variables

## Testing
- `npm test` in `bot/`
- `npm test` in `backend/`
- `npm test` in `frontend/`

------
https://chatgpt.com/codex/tasks/task_e_688a1df22d088320a813f330fea27884