### PR TITLE
Fix missing Twitch rewards scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ in:
 moderation:read
 channel:read:vips
 channel:read:subscriptions
+channel:read:redemptions
 ```
 These allow the frontend to check whether the user is a moderator, VIP or
 subscriber of the configured channel.

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -111,7 +111,7 @@ export default function AuthStatus() {
       options: {
         redirectTo: `${window.location.origin}/auth/callback`,
         scopes:
-          "user:read:email moderation:read channel:read:vips channel:read:subscriptions",
+          "user:read:email moderation:read channel:read:vips channel:read:subscriptions channel:read:redemptions",
       },
     });
   };


### PR DESCRIPTION
## Summary
- request channel point rewards scope on login
- update README with required scope

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688a5852405c8320a7890d620dfc3cdb