### PR TITLE
Fix grid spans for main sections

### DIFF
--- a/frontend/app/archive/page.tsx
+++ b/frontend/app/archive/page.tsx
@@ -55,7 +55,7 @@ export default function ArchivePage() {
   }
 
   return (
-    <main className="p-4 max-w-xl mx-auto space-y-4">
+    <main className="col-span-10 p-4 max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-semibold">Roulette Archive</h1>
       <Link href="/" className="underline text-purple-600">
         Go to active roulette

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -118,7 +118,7 @@ export default function GamesPage() {
 
   return (
     <>
-    <main className="p-4 max-w-xl mx-auto space-y-6">
+    <main className="col-span-10 p-4 max-w-xl mx-auto space-y-6">
       <h1 className="text-2xl font-semibold">Games</h1>
       {isModerator && (
         <button

--- a/frontend/app/new-poll/page.tsx
+++ b/frontend/app/new-poll/page.tsx
@@ -122,7 +122,7 @@ function NewPollPageContent() {
 
   return (
     <>
-      <main className="p-4 max-w-xl mx-auto space-y-4">
+      <main className="col-span-10 p-4 max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-semibold">New Roulette</h1>
       <div className="flex items-center space-x-2">
         <label className="text-sm">Add to archive only:</label>

--- a/frontend/app/playlists/page.tsx
+++ b/frontend/app/playlists/page.tsx
@@ -35,7 +35,7 @@ export default function PlaylistsPage() {
   const tags = Object.keys(data).sort();
 
   return (
-    <main className="p-4 max-w-2xl mx-auto space-y-6">
+    <main className="col-span-10 p-4 max-w-2xl mx-auto space-y-6">
       <h1 className="text-2xl font-semibold">Playlists</h1>
       {tags.map((tag) => (
         <section key={tag} className="space-y-2">

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -103,7 +103,7 @@ export default function SettingsPage() {
   if (!isModerator) return <div className="p-4">Access denied.</div>;
 
   return (
-    <main className="p-4 max-w-xl mx-auto space-y-4">
+    <main className="col-span-10 p-4 max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-semibold">Settings</h1>
       {rewards.length === 0 ? (
         <p>No rewards found.</p>

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -150,7 +150,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   if (!user) return <div className="p-4">User not found.</div>;
 
   return (
-    <main className="p-4 max-w-xl mx-auto space-y-4">
+    <main className="col-span-10 p-4 max-w-xl mx-auto space-y-4">
       <Link href="/users" className="text-purple-600 underline">
         Back to users
       </Link>

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -29,7 +29,7 @@ export default function UsersPage() {
   }
 
   return (
-    <main className="p-4 max-w-xl mx-auto space-y-4">
+    <main className="col-span-10 p-4 max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-semibold">Users</h1>
       <ul className="space-y-2">
         {users.map((u) => (


### PR DESCRIPTION
## Summary
- adjust grid columns for `<main>` elements to span 10 columns
- keep sidebar + main grid layout aligned with 12-column grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a81c3b2548320a2f0a1c1aebf24b2