### PR TITLE
Fix wheel size

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -42,7 +42,7 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
     {
       games,
       onDone,
-      size = 300,
+      size = 500,
       weightCoeff = 2,
       zeroWeight = 40,
       spinSeed,


### PR DESCRIPTION
## Summary
- enlarge the default size of the RouletteWheel component

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a983fbeb883209a56cf7d5f17a141