### PR TITLE
Load reward IDs from Supabase for Twitch bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,13 @@ have remaining votes.
    TWITCH_SECRET=your-client-secret
    TWITCH_CHANNEL_ID=your-channel-id
    # Optional comma separated list of reward IDs to log
+   # These will be merged with IDs stored in the `log_rewards` table
    LOG_REWARD_IDS=id1,id2
    ```
+
+   The bot also fetches reward IDs from the `log_rewards` table in Supabase at
+   startup and refreshes them every minute. This allows adding or removing
+   rewards without redeploying the bot.
 
 3. Start the bot:
    ```bash

--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -1,5 +1,6 @@
 const loadBot = (mockSupabase) => {
   jest.resetModules();
+  jest.useFakeTimers();
   jest.doMock('@supabase/supabase-js', () => ({
     createClient: jest.fn(() => mockSupabase),
   }));
@@ -11,7 +12,29 @@ const loadBot = (mockSupabase) => {
   process.env.BOT_USERNAME = 'bot';
   process.env.BOT_OAUTH_TOKEN = 'token';
   process.env.TWITCH_CHANNEL = 'channel';
-  return require('../bot');
+  const bot = require('../bot');
+  jest.useRealTimers();
+  return bot;
+};
+
+const loadBotWithOn = (mockSupabase, onMock) => {
+  jest.resetModules();
+  jest.useFakeTimers();
+  jest.doMock('@supabase/supabase-js', () => ({
+    createClient: jest.fn(() => mockSupabase),
+  }));
+  jest.doMock('tmi.js', () => ({
+    Client: jest.fn(() => ({ connect: jest.fn(), on: onMock })),
+  }));
+  process.env.SUPABASE_URL = 'http://localhost';
+  process.env.SUPABASE_KEY = 'key';
+  process.env.BOT_USERNAME = 'bot';
+  process.env.BOT_OAUTH_TOKEN = 'token';
+  process.env.TWITCH_CHANNEL = 'channel';
+  delete process.env.LOG_REWARD_IDS;
+  const bot = require('../bot');
+  jest.useRealTimers();
+  return bot;
 };
 
 const createSupabase = (
@@ -74,5 +97,33 @@ describe('addVote', () => {
     const res = await addVote({ id: 1, vote_limit: 1 }, 5, 10);
     expect(res).toEqual({ success: false, reason: 'vote limit reached' });
     expect(insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('reward logging', () => {
+  test('logs message when reward ID fetched from DB', async () => {
+    const rewardId = 'abc';
+    const insertMock = jest.fn(() => Promise.resolve({ error: null }));
+    const supabase = {
+      from: jest.fn((table) => {
+        if (table === 'log_rewards') {
+          return { select: jest.fn(() => Promise.resolve({ data: [{ reward_id: rewardId }], error: null })) };
+        }
+        if (table === 'event_logs') {
+          return { insert: insertMock };
+        }
+        return { select: jest.fn(() => Promise.resolve({ data: [], error: null })), insert: jest.fn() };
+      }),
+    };
+    const on = jest.fn();
+    loadBotWithOn(supabase, on);
+
+    // wait for async reward fetch
+    await new Promise(setImmediate);
+
+    const messageHandler = on.mock.calls.find((c) => c[0] === 'message')[1];
+    await messageHandler('channel', { 'custom-reward-id': rewardId, 'display-name': 'User' }, 'Hello', false);
+
+    expect(insertMock).toHaveBeenCalledWith({ message: `Reward ${rewardId} redeemed by User: Hello` });
   });
 });


### PR DESCRIPTION
## Summary
- load reward IDs from `log_rewards` table
- periodically refresh reward IDs
- document automatic reward ID loading
- add unit test verifying reward redemption logging via DB fetched IDs

## Testing
- `npm test --prefix bot`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_688a9c3e3a7c8320b2e0089d80951296