### PR TITLE
Add DonationAlerts logging

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -8,3 +8,4 @@ TWITCH_SECRET=
 TWITCH_CHANNEL_ID=
 # Comma separated reward IDs to log, leave empty to log all
 LOG_REWARD_IDS=
+DONATIONALERTS_TOKEN=


### PR DESCRIPTION
## Summary
- connect DonationAlerts via `DONATIONALERTS_TOKEN`
- log donations with optional media links
- include new env var in example file
- test donation logging in the bot

## Testing
- `cd backend && npm test`
- `cd bot && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a9ed7ed3c83208e29193bbd780a46