### PR TITLE
Fix log column alignment

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -78,7 +78,7 @@ export default function RootLayout({
         <main className="mt-4 flex-grow">
           <div className="container mx-auto px-0 grid grid-cols-12 gap-x-2 gap-y-4">
             {children}
-            <div className="col-span-2 space-y-4">
+            <div className="col-span-2 col-start-11 space-y-4">
               <EventLog />
               <TwitchVideos />
             </div>


### PR DESCRIPTION
## Summary
- keep the log/videos column anchored on the right even when the main content hasn't loaded

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688aa113a18c8320a30d3f901f88a435