### PR TITLE
Wrap spin buttons flex container

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -508,20 +508,22 @@ export default function Home() {
               zeroWeight={zeroWeight}
               spinSeed={spinSeed ?? undefined}
             />
-            <button
-              className="px-4 py-2 bg-purple-600 text-white rounded"
-              onClick={handleSpin}
-            >
-              Spin
-            </button>
-            {showReset && (
+            <div className="flex gap-2 mt-2">
               <button
-                className="px-4 py-2 bg-gray-300 rounded"
-                onClick={resetWheel}
+                className="px-4 py-2 bg-purple-600 text-white rounded"
+                onClick={handleSpin}
               >
-                Reset
+                Spin
               </button>
-            )}
+              {showReset && (
+                <button
+                  className="px-4 py-2 bg-gray-300 rounded"
+                  onClick={resetWheel}
+                >
+                  Reset
+                </button>
+              )}
+            </div>
           </>
         )}
         {winner && (


### PR DESCRIPTION
## Summary
- adjust page layout so spin and reset buttons are grouped horizontally

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688aa8008ad48320a0f8797dae9887a7