### PR TITLE
Show Settings link only for moderators

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
 import AuthStatus from "@/components/AuthStatus";
+import SettingsLink from "@/components/SettingsLink";
 import TwitchVideos from "@/components/TwitchVideos";
 import EventLog from "@/components/EventLog";
 import "./globals.css";
@@ -47,7 +48,7 @@ export default function RootLayout({
               <Link href="/games">Games</Link>
               <Link href="/users">Users</Link>
               <Link href="/playlists">Playlists</Link>
-              <Link href="/settings">Settings</Link>
+              <SettingsLink />
             </div>
             <div className="flex items-center space-x-4">
               <a

--- a/frontend/components/SettingsLink.tsx
+++ b/frontend/components/SettingsLink.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import type { Session } from "@supabase/supabase-js";
+
+export default function SettingsLink() {
+  const [session, setSession] = useState<Session | null>(null);
+  const [isModerator, setIsModerator] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session);
+    });
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_e, sess) => {
+      setSession(sess);
+    });
+    return () => subscription.unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    const checkMod = async () => {
+      setIsModerator(false);
+      if (!session) return;
+      const { data } = await supabase
+        .from("users")
+        .select("is_moderator")
+        .eq("auth_id", session.user.id)
+        .maybeSingle();
+      setIsModerator(!!data?.is_moderator);
+    };
+    checkMod();
+  }, [session]);
+
+  if (!isModerator) return null;
+
+  return <Link href="/settings">Settings</Link>;
+}


### PR DESCRIPTION
## Summary
- add `SettingsLink` component that checks the logged-in user's moderator status
- use `SettingsLink` in layout so the Settings menu item only renders for moderators

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688aa9b6fd0c83208680c35ac38dd1fc