### PR TITLE
Group roulette voters by user

### DIFF
--- a/backend/__tests__/poll.test.js
+++ b/backend/__tests__/poll.test.js
@@ -11,6 +11,7 @@ const games = [
 ];
 const votes = [
   { game_id: 1, user_id: 1 },
+  { game_id: 1, user_id: 1 },
   { game_id: 1, user_id: 2 },
   { game_id: 2, user_id: 2 },
 ];
@@ -63,7 +64,10 @@ describe('GET /api/poll', () => {
     expect(res.status).toBe(200);
     expect(res.body.games.length).toBe(2);
     const game = res.body.games.find((g) => g.id === 1);
-    expect(game.count).toBe(2);
-    expect(game.nicknames).toEqual(expect.arrayContaining(['Alice', 'Bob']));
+    expect(game.count).toBe(3);
+    expect(game.nicknames).toEqual([
+      { username: 'Alice', count: 2 },
+      { username: 'Bob', count: 1 },
+    ]);
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -217,12 +217,20 @@ async function buildPollResponse(poll) {
     return acc;
   }, {});
 
-  const nicknames = votes.reduce((acc, v) => {
-    if (!acc[v.game_id]) acc[v.game_id] = [];
+  const voterMap = votes.reduce((acc, v) => {
     const name = userMap[v.user_id];
-    if (name) acc[v.game_id].push(name);
+    if (!name) return acc;
+    if (!acc[v.game_id]) acc[v.game_id] = {};
+    acc[v.game_id][name] = (acc[v.game_id][name] || 0) + 1;
     return acc;
   }, {});
+
+  const nicknames = {};
+  for (const [gid, map] of Object.entries(voterMap)) {
+    nicknames[gid] = Object.entries(map)
+      .map(([username, count]) => ({ username, count }))
+      .sort((a, b) => b.count - a.count);
+  }
 
   const results = games.map((g) => ({
     id: g.id,

--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -153,8 +153,8 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
                 <span className="font-mono">{game.count}</span>
               </div>
               <ul className="pl-4 list-disc">
-                {game.nicknames.map((name, i) => (
-                  <li key={name + i}>{name}</li>
+                {game.nicknames.map((voter) => (
+                  <li key={voter.username}>{voter.count} {voter.username}</li>
                 ))}
               </ul>
             </li>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -8,7 +8,7 @@ import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/Roul
 import SettingsModal from "@/components/SettingsModal";
 import SpinResultModal from "@/components/SpinResultModal";
 import type { Session } from "@supabase/supabase-js";
-import type { Game, Poll } from "@/types";
+import type { Game, Poll, Voter } from "@/types";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 if (!backendUrl) {
@@ -16,10 +16,6 @@ if (!backendUrl) {
 }
 
 
-interface PollGame extends Game {
-  count: number;
-  nicknames: string[];
-}
 
 
 export default function Home() {
@@ -475,8 +471,8 @@ export default function Home() {
                 <span className="font-mono">{game.count}</span>
               </div>
               <ul className="pl-4 list-disc">
-                {game.nicknames.map((name, i) => (
-                  <li key={name + i}>{name}</li>
+                {game.nicknames.map((voter) => (
+                  <li key={voter.username}>{voter.count} {voter.username}</li>
                 ))}
               </ul>
             </li>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -2,12 +2,16 @@ export interface Game {
   id: number;
   name: string;
   background_image?: string | null;
-  nicknames?: string[];
+}
+
+export interface Voter {
+  username: string;
+  count: number;
 }
 
 export interface PollGame extends Game {
   count: number;
-  nicknames: string[];
+  nicknames: Voter[];
 }
 
 export interface Poll {


### PR DESCRIPTION
## Summary
- aggregate poll usernames with vote counts on backend
- adjust types to return structured voter info
- update roulette pages to show `count username`
- test poll API with grouped voters

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b2bbf15dc83208069473f87c1fefb