### PR TITLE
Add links to voter profiles

### DIFF
--- a/backend/__tests__/poll.test.js
+++ b/backend/__tests__/poll.test.js
@@ -66,8 +66,8 @@ describe('GET /api/poll', () => {
     const game = res.body.games.find((g) => g.id === 1);
     expect(game.count).toBe(3);
     expect(game.nicknames).toEqual([
-      { username: 'Alice', count: 2 },
-      { username: 'Bob', count: 1 },
+      { id: 1, username: 'Alice', count: 2 },
+      { id: 2, username: 'Bob', count: 1 },
     ]);
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -221,15 +221,16 @@ async function buildPollResponse(poll) {
     const name = userMap[v.user_id];
     if (!name) return acc;
     if (!acc[v.game_id]) acc[v.game_id] = {};
-    acc[v.game_id][name] = (acc[v.game_id][name] || 0) + 1;
+    if (!acc[v.game_id][v.user_id]) {
+      acc[v.game_id][v.user_id] = { id: v.user_id, username: name, count: 0 };
+    }
+    acc[v.game_id][v.user_id].count += 1;
     return acc;
   }, {});
 
   const nicknames = {};
   for (const [gid, map] of Object.entries(voterMap)) {
-    nicknames[gid] = Object.entries(map)
-      .map(([username, count]) => ({ username, count }))
-      .sort((a, b) => b.count - a.count);
+    nicknames[gid] = Object.values(map).sort((a, b) => b.count - a.count);
   }
 
   const results = games.map((g) => ({

--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -154,7 +154,15 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
               </div>
               <ul className="pl-4 list-disc">
                 {game.nicknames.map((voter) => (
-                  <li key={voter.username}>{voter.count} {voter.username}</li>
+                  <li key={voter.id}>
+                    {voter.count}{" "}
+                    <Link
+                      href={`/users/${voter.id}`}
+                      className="text-purple-600 underline"
+                    >
+                      {voter.username}
+                    </Link>
+                  </li>
                 ))}
               </ul>
             </li>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -472,7 +472,15 @@ export default function Home() {
               </div>
               <ul className="pl-4 list-disc">
                 {game.nicknames.map((voter) => (
-                  <li key={voter.username}>{voter.count} {voter.username}</li>
+                  <li key={voter.id}>
+                    {voter.count}{" "}
+                    <Link
+                      href={`/users/${voter.id}`}
+                      className="text-purple-600 underline"
+                    >
+                      {voter.username}
+                    </Link>
+                  </li>
                 ))}
               </ul>
             </li>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -5,6 +5,7 @@ export interface Game {
 }
 
 export interface Voter {
+  id: number;
   username: string;
   count: number;
 }


### PR DESCRIPTION
## Summary
- include voter ids when building poll responses
- link to user pages from current and archived roulette pages
- add tests for new voter info structure

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688b32e4dae08320aa65183c8ac1e903