### PR TITLE
Improve UI block backgrounds

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -147,7 +147,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
         )}
         <ul className="space-y-2">
           {poll.games.map((game) => (
-            <li key={game.id} className="border p-2 rounded space-y-1">
+            <li key={game.id} className="border p-2 rounded-lg bg-muted space-y-1">
               <div className="flex items-center space-x-2">
                 <span>{game.name}</span>
                 <span className="font-mono">{game.count}</span>

--- a/frontend/app/archive/page.tsx
+++ b/frontend/app/archive/page.tsx
@@ -72,7 +72,7 @@ export default function ArchivePage() {
         {polls
           .filter((p) => p.archived)
           .map((p) => (
-            <li key={p.id}>
+            <li key={p.id} className="border p-2 rounded-lg bg-muted">
               <Link href={`/archive/${p.id}`} className="text-purple-600 underline">
                 Roulette from {new Date(p.created_at).toLocaleString()}
               </Link>

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -94,7 +94,7 @@ export default function GamesPage() {
   );
 
   const renderGame = (g: GameEntry) => (
-    <li key={g.id} className="border p-2 rounded space-y-1">
+    <li key={g.id} className="border p-2 rounded-lg bg-muted space-y-1">
       <div className="flex items-center space-x-2">
         <span className="flex-grow">{g.name}</span>
         {g.rating !== null && <span className="font-mono">{g.rating}/10</span>}

--- a/frontend/app/new-poll/page.tsx
+++ b/frontend/app/new-poll/page.tsx
@@ -137,7 +137,7 @@ function NewPollPageContent() {
         ) : (
           <ul className="space-y-2">
             {games.map((g) => (
-              <li key={g.id} className="flex items-center space-x-2 border p-2 rounded">
+              <li key={g.id} className="flex items-center space-x-2 border p-2 rounded-lg bg-muted">
                 <span className="flex-grow">{g.name}</span>
                 <button className="px-2 py-1 bg-gray-300 rounded" onClick={() => removeGame(g.id)}>
                   Remove

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -450,7 +450,7 @@ export default function Home() {
           const count = slots.filter((s) => s === game.id).length;
           const totalSelected = slots.filter((s) => s !== null).length;
           return (
-            <li key={game.id} className="border p-2 rounded space-y-1">
+            <li key={game.id} className="border p-2 rounded-lg bg-muted space-y-1">
               <div className="flex items-center space-x-2">
                 <button
                   className="px-2 py-1 bg-gray-300 rounded disabled:opacity-50"

--- a/frontend/app/playlists/page.tsx
+++ b/frontend/app/playlists/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/card";
 
 interface Video {
   id: string;
@@ -38,7 +39,8 @@ export default function PlaylistsPage() {
     <main className="col-span-10 p-4 max-w-2xl space-y-6">
       <h1 className="text-2xl font-semibold">Playlists</h1>
       {tags.map((tag) => (
-        <section key={tag} className="space-y-2">
+        <section key={tag}>
+          <Card className="space-y-2">
           <h2 className="text-xl font-medium">#{tag}</h2>
           <ul className="pl-4 list-disc space-y-1">
             {data[tag].map((v) => (
@@ -54,6 +56,7 @@ export default function PlaylistsPage() {
               </li>
             ))}
           </ul>
+        </Card>
         </section>
       ))}
     </main>

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -190,7 +190,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       ) : (
         <ul className="space-y-2">
           {history.map((poll) => (
-            <li key={poll.id} className="border p-2 rounded space-y-1">
+            <li key={poll.id} className="border p-2 rounded-lg bg-muted space-y-1">
               <h2 className="font-semibold">
                 Roulette from {new Date(poll.created_at).toLocaleString()}
               </h2>

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -33,7 +33,7 @@ export default function UsersPage() {
       <h1 className="text-2xl font-semibold">Users</h1>
       <ul className="space-y-2">
         {users.map((u) => (
-          <li key={u.id} className="flex items-center space-x-2">
+          <li key={u.id} className="flex items-center space-x-2 border p-2 rounded-lg bg-muted">
             <Link href={`/users/${u.id}`} className="text-purple-600 underline">
               {u.username}
             </Link>

--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/card";
 
 interface LogEntry {
   id: number;
@@ -32,7 +33,7 @@ export default function EventLog() {
   if (!backendUrl) return null;
 
   return (
-    <div className="space-y-2">
+    <Card className="space-y-2">
       <h2 className="text-lg font-semibold">Recent Events</h2>
       <ul className="space-y-1 text-sm">
         {logs.map((l) => (
@@ -41,6 +42,6 @@ export default function EventLog() {
           </li>
         ))}
       </ul>
-    </div>
+    </Card>
   );
 }

--- a/frontend/components/TwitchVideos.tsx
+++ b/frontend/components/TwitchVideos.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/card";
 
 interface TwitchVideo {
   id: string;
@@ -35,7 +36,7 @@ export default function TwitchVideos() {
   const down = () => setIndex((i) => Math.min(videos.length - 3, i + 1));
 
   return (
-    <div className="space-y-2">
+    <Card className="space-y-2">
       <h2 className="text-lg font-semibold">Stream VODs</h2>
       <ul className="space-y-2">
         {visible.map((v) => {
@@ -77,6 +78,6 @@ export default function TwitchVideos() {
           Down
         </button>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-lg bg-muted p-4 border",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+export { Card };


### PR DESCRIPTION
## Summary
- add a reusable `Card` component for muted blocks
- wrap event log and twitch videos with cards
- give list items and sections a muted background and rounded edges

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688b38b14180832099a6cf8ea4e1ea30