### PR TITLE
Fix TwitchVideos layout

### DIFF
--- a/frontend/components/TwitchVideos.tsx
+++ b/frontend/components/TwitchVideos.tsx
@@ -14,9 +14,24 @@ const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 export default function TwitchVideos() {
   const [videos, setVideos] = useState<TwitchVideo[]>([]);
   const listRef = useRef<HTMLUListElement | null>(null);
+  const headerRef = useRef<HTMLHeadingElement | null>(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
   const [canUp, setCanUp] = useState(false);
   const [canDown, setCanDown] = useState(false);
   const [itemHeight, setItemHeight] = useState(0);
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.clientHeight);
+    }
+    const handleResize = () => {
+      if (headerRef.current) {
+        setHeaderHeight(headerRef.current.clientHeight);
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   useEffect(() => {
     if (!backendUrl) return;
@@ -59,10 +74,11 @@ export default function TwitchVideos() {
 
   return (
     <Card className="space-y-2 relative">
-      <h2 className="text-lg font-semibold">Stream VODs</h2>
+      <h2 ref={headerRef} className="text-lg font-semibold">Stream VODs</h2>
       <ul
         ref={listRef}
-        className="space-y-2 overflow-y-auto max-h-[640px] scroll-smooth pr-1"
+        className="space-y-2 overflow-y-auto scroll-smooth pr-1"
+        style={{ maxHeight: itemHeight ? itemHeight * 3 : 640 }}
       >
         {videos.map((v) => {
           const thumb = v.thumbnail_url
@@ -88,14 +104,16 @@ export default function TwitchVideos() {
         })}
       </ul>
       <button
-        className="absolute left-1/2 -translate-x-1/2 -translate-y-1/2 top-0 bg-gray-300 rounded-full p-1 disabled:opacity-50"
+        className="absolute left-1/2 -translate-x-1/2 bg-gray-300 rounded-full p-1 disabled:opacity-50"
+        style={{ top: headerHeight }}
         onClick={up}
         disabled={!canUp}
       >
         <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 15l-6-6-6 6" /></svg>
       </button>
       <button
-        className="absolute left-1/2 -translate-x-1/2 translate-y-1/2 bottom-0 bg-gray-300 rounded-full p-1 disabled:opacity-50"
+        className="absolute left-1/2 -translate-x-1/2 bg-gray-300 rounded-full p-1 disabled:opacity-50"
+        style={{ bottom: 0 }}
         onClick={down}
         disabled={!canDown}
       >


### PR DESCRIPTION
## Summary
- ensure Stream VODs buttons stay inside the card
- measure header height and use it when positioning buttons
- size the list container so only three items are visible

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688b51ff5d348320a1fb1f9dd8501c80