### PR TITLE
Show blurred game backgrounds

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/RouletteWheel";
 import SpinResultModal from "@/components/SpinResultModal";
 import type { Poll } from "@/types";
+import { proxiedImage } from "@/lib/utils";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
@@ -147,7 +148,16 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
         )}
         <ul className="space-y-2">
           {poll.games.map((game) => (
-            <li key={game.id} className="border p-2 rounded-lg bg-muted space-y-1">
+            <li
+              key={game.id}
+              className="border p-2 rounded-lg bg-muted space-y-1 relative overflow-hidden"
+            >
+              {game.background_image && (
+                <div
+                  className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 -z-10"
+                  style={{ backgroundImage: `url(${proxiedImage(game.background_image)})` }}
+                />
+              )}
               <div className="flex items-center space-x-2">
                 <span>{game.name}</span>
                 <span className="font-mono">{game.count}</span>

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import type { Session } from "@supabase/supabase-js";
 import AddCatalogGameModal from "@/components/AddCatalogGameModal";
 import EditCatalogGameModal from "@/components/EditCatalogGameModal";
+import { proxiedImage } from "@/lib/utils";
 
 interface UserRef {
   id: number;
@@ -94,7 +95,16 @@ export default function GamesPage() {
   );
 
   const renderGame = (g: GameEntry) => (
-    <li key={g.id} className="border p-2 rounded-lg bg-muted space-y-1">
+    <li
+      key={g.id}
+      className="border p-2 rounded-lg bg-muted space-y-1 relative overflow-hidden"
+    >
+      {g.background_image && (
+        <div
+          className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 -z-10"
+          style={{ backgroundImage: `url(${proxiedImage(g.background_image)})` }}
+        />
+      )}
       <div className="flex items-center space-x-2">
         <span className="flex-grow">{g.name}</span>
         {g.rating !== null && <span className="font-mono">{g.rating}/10</span>}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,6 +9,7 @@ import SettingsModal from "@/components/SettingsModal";
 import SpinResultModal from "@/components/SpinResultModal";
 import type { Session } from "@supabase/supabase-js";
 import type { Game, Poll, Voter } from "@/types";
+import { proxiedImage } from "@/lib/utils";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 if (!backendUrl) {
@@ -450,7 +451,16 @@ export default function Home() {
           const count = slots.filter((s) => s === game.id).length;
           const totalSelected = slots.filter((s) => s !== null).length;
           return (
-            <li key={game.id} className="border p-2 rounded-lg bg-muted space-y-1">
+            <li
+              key={game.id}
+              className="border p-2 rounded-lg bg-muted space-y-1 relative overflow-hidden"
+            >
+              {game.background_image && (
+                <div
+                  className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 -z-10"
+                  style={{ backgroundImage: `url(${proxiedImage(game.background_image)})` }}
+                />
+              )}
               <div className="flex items-center space-x-2">
                 <button
                   className="px-2 py-1 bg-gray-300 rounded disabled:opacity-50"

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -4,3 +4,24 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function proxiedImage(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+  if (!backendUrl) return url;
+
+  try {
+    const { hostname } = new URL(url);
+    const allowed = [
+      "static-cdn.jtvnw.net",
+      "clips-media-assets2.twitch.tv",
+      "media.rawg.io",
+    ];
+    if (allowed.includes(hostname)) {
+      return `${backendUrl}/api/proxy?url=${encodeURIComponent(url)}`;
+    }
+  } catch {
+    // Ignore invalid URLs and return as is
+  }
+  return url;
+}


### PR DESCRIPTION
## Summary
- add proxiedImage helper to build proxied background URLs
- show each game's background image inside list containers on the home page
- show blurred game backgrounds on the archived roulette page
- use the same effect on the games catalog
- avoid proxying Supabase-hosted images so backgrounds load correctly

## Testing
- `npm test --silent --prefix frontend`
- `npm test --silent --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_688b576bd5008320bf1d29db26fe1d4d