### PR TITLE
Add game detail page with API

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ The `/api/poll` endpoint aggregates votes for each game and now also includes th
 The `/api/poll/:id` endpoint returns results for a specific poll and `/api/polls` lists all polls.
 Games are linked to polls through the new `poll_games` table defined in `supabase/schema.sql`.
 The `games` table now also stores `background_image` URLs for thumbnails.
+The `/api/games/:id` endpoint returns details for a single game including
+its initiators and a list of roulettes with the voters for that game.
 
 Moderators can toggle accepting votes and vote editing via the `/api/accept_votes` and `/api/allow_edit` endpoints (also available in the Settings modal). When voting is closed or editing disabled, the frontend disables the vote controls.
 

--- a/backend/__tests__/game.test.js
+++ b/backend/__tests__/game.test.js
@@ -1,0 +1,73 @@
+const request = require('supertest');
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_KEY = 'test';
+
+const game = { id: 1, name: 'Game1', status: 'backlog', rating: 5, selection_method: 'donation', background_image: null };
+const initRows = [{ user_id: 1 }];
+const pollGames = [{ poll_id: 10 }, { poll_id: 11 }];
+const polls = [
+  { id: 10, created_at: '2024-01-01', archived: false },
+  { id: 11, created_at: '2024-02-01', archived: true },
+];
+const votes = [
+  { poll_id: 10, user_id: 1 },
+  { poll_id: 10, user_id: 1 },
+  { poll_id: 11, user_id: 2 },
+];
+const users = [
+  { id: 1, username: 'Alice' },
+  { id: 2, username: 'Bob' },
+];
+
+const build = (data) => {
+  const builder = {};
+  const chain = ['select', 'eq', 'order', 'limit', 'in', 'insert', 'update', 'upsert', 'delete'];
+  chain.forEach((m) => {
+    builder[m] = jest.fn(() => builder);
+  });
+  builder.maybeSingle = jest.fn(async () => ({ data, error: null }));
+  builder.single = jest.fn(async () => ({ data, error: null }));
+  builder.then = (resolve) => Promise.resolve({ data, error: null }).then(resolve);
+  return builder;
+};
+
+const mockSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn((table) => {
+    switch (table) {
+      case 'games':
+        return build(game);
+      case 'game_initiators':
+        return build(initRows);
+      case 'users':
+        return build(users);
+      case 'poll_games':
+        return build(pollGames);
+      case 'polls':
+        return build(polls);
+      case 'votes':
+        return build(votes);
+      default:
+        return build(null);
+    }
+  }),
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => mockSupabase),
+}));
+
+const app = require('../server');
+
+describe('GET /api/games/:id', () => {
+  it('returns game info with polls and voters', async () => {
+    const res = await request(app).get('/api/games/1');
+    expect(res.status).toBe(200);
+    expect(res.body.game.name).toBe('Game1');
+    expect(res.body.game.initiators).toEqual([{ id: 1, username: 'Alice' }]);
+    expect(res.body.polls.length).toBe(2);
+    const poll = res.body.polls.find((p) => p.id === 10);
+    expect(poll.voters).toEqual([{ id: 1, username: 'Alice', count: 2 }]);
+  });
+});

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+import { proxiedImage } from "@/lib/utils";
+
+interface UserRef {
+  id: number;
+  username: string;
+  count?: number;
+}
+
+interface PollInfo {
+  id: number;
+  created_at: string;
+  archived: boolean;
+  voters: UserRef[];
+}
+
+interface GameInfo {
+  id: number;
+  name: string;
+  background_image: string | null;
+  status: string;
+  rating: number | null;
+  selection_method: string | null;
+  initiators: UserRef[];
+}
+
+const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+export default function GamePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [game, setGame] = useState<GameInfo | null>(null);
+  const [polls, setPolls] = useState<PollInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!backendUrl) return;
+      const res = await fetch(`${backendUrl}/api/games/${id}`);
+      if (!res.ok) {
+        setLoading(false);
+        return;
+      }
+      const data = await res.json();
+      setGame(data.game);
+      setPolls(data.polls || []);
+      setLoading(false);
+    };
+    fetchData();
+  }, [id]);
+
+  if (!backendUrl) return <div className="p-4">Backend URL not configured.</div>;
+  if (loading) return <div className="p-4">Loading...</div>;
+  if (!game) return <div className="p-4">Game not found.</div>;
+
+  const renderUsers = (list: UserRef[]) => (
+    <span className="space-x-1">
+      {list.map((u, i) => (
+        <Link key={u.id} href={`/users/${u.id}`} className="underline text-purple-600">
+          {u.username}
+          {u.count ? ` (${u.count})` : ""}
+          {i < list.length - 1 ? "," : ""}
+        </Link>
+      ))}
+    </span>
+  );
+
+  return (
+    <main className="col-span-10 p-4 max-w-xl space-y-4">
+      <Link href="/games" className="text-purple-600 underline">
+        Back to games
+      </Link>
+      <h1 className="text-2xl font-semibold flex items-center space-x-2 relative overflow-hidden">
+        {game.background_image && (
+          <div
+            className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 -z-10"
+            style={{ backgroundImage: `url(${proxiedImage(game.background_image)})` }}
+          />
+        )}
+        <span>{game.name}</span>
+        {game.rating !== null && <span className="font-mono">{game.rating}/10</span>}
+        {game.selection_method && (
+          <span className="text-sm text-gray-600">({game.selection_method})</span>
+        )}
+      </h1>
+      <p>Status: {game.status}</p>
+      {game.initiators.length > 0 && <p>Initiators: {renderUsers(game.initiators)}</p>}
+      {polls.length === 0 ? (
+        <p>No roulettes yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {polls.map((p) => (
+            <li key={p.id} className="border p-2 rounded-lg bg-muted space-y-1">
+              <Link href={`/archive/${p.id}`} className="text-purple-600 underline">
+                Roulette from {new Date(p.created_at).toLocaleString()}
+              </Link>
+              <div className="pl-4">
+                {p.voters.map((v) => (
+                  <div key={v.id} className="text-sm">
+                    {v.count} <Link href={`/users/${v.id}`} className="underline text-purple-600">{v.username}</Link>
+                  </div>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -106,7 +106,9 @@ export default function GamesPage() {
         />
       )}
       <div className="flex items-center space-x-2">
-        <span className="flex-grow">{g.name}</span>
+        <Link href={`/games/${g.id}`} className="flex-grow text-purple-600 underline">
+          {g.name}
+        </Link>
         {g.rating !== null && <span className="font-mono">{g.rating}/10</span>}
         {g.selection_method && (
           <span className="text-sm text-gray-600">({g.selection_method})</span>


### PR DESCRIPTION
## Summary
- provide `/api/games/:id` endpoint for game details and poll history
- add tests for the new API
- show link to each game page in the games list
- create dynamic Next.js page to display a game's roulettes and voters
- document the endpoint in README

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688b75d38b5c832084bfa074d3cd5e8e