### PR TITLE
Add shared auth listener

### DIFF
--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -12,3 +12,15 @@ if (!supabaseUrl || !supabaseAnonKey) {
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: { flowType: 'pkce' },
 });
+
+// Global auth listener to handle token refresh failures
+export const authListener = supabase.auth.onAuthStateChange(async (event) => {
+  if (event === 'TOKEN_REFRESH_FAILED') {
+    await supabase.auth.signOut();
+    try {
+      localStorage.removeItem('twitch_provider_token');
+    } catch {
+      // ignore storage errors (e.g. server-side rendering)
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- register a global `onAuthStateChange` listener in `frontend/lib/supabase.ts`
- sign out and clear the saved Twitch token if refresh fails
- export the listener for use across components

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_688bac8ef980832086eedb9f73f8401d