### PR TITLE
Add helper for Twitch token storage

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import type { Session } from "@supabase/supabase-js";
+import { getStoredProviderToken } from "@/lib/twitch";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 const channelId = process.env.NEXT_PUBLIC_TWITCH_CHANNEL_ID;
-const TOKEN_KEY = 'twitch_provider_token';
 
 interface Reward {
   id: string;
@@ -57,9 +57,7 @@ export default function SettingsPage() {
       }
       const token =
         ((session as any)?.provider_token as string | undefined) ||
-        (typeof localStorage !== 'undefined'
-          ? localStorage.getItem(TOKEN_KEY) || undefined
-          : undefined);
+        getStoredProviderToken();
       if (token && channelId) {
         try {
           const r = await fetch(

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { use, useEffect, useState } from "react";
-import { fetchSubscriptionRole } from "@/lib/twitch";
+import {
+  fetchSubscriptionRole,
+  getStoredProviderToken,
+  storeProviderToken,
+} from "@/lib/twitch";
 
-const TOKEN_KEY = 'twitch_provider_token';
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import type { Session } from "@supabase/supabase-js";
@@ -64,11 +67,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   useEffect(() => {
     const token = (session as any)?.provider_token as string | undefined;
     if (token) {
-      try {
-        localStorage.setItem(TOKEN_KEY, token);
-      } catch {
-        // ignore
-      }
+      storeProviderToken(token);
     }
   }, [session]);
 
@@ -86,9 +85,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
     }
     const token =
       ((session as any)?.provider_token as string | undefined) ||
-      (typeof localStorage !== 'undefined'
-        ? localStorage.getItem(TOKEN_KEY) || undefined
-        : undefined);
+      getStoredProviderToken();
     const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
     const channelId = process.env.NEXT_PUBLIC_TWITCH_CHANNEL_ID;
     if (!token || !backendUrl) {

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -2,7 +2,11 @@
 
 import { supabase } from "@/lib/supabase";
 import { useEffect, useState } from "react";
-import { fetchSubscriptionRole } from "@/lib/twitch";
+import {
+  fetchSubscriptionRole,
+  getStoredProviderToken,
+  storeProviderToken,
+} from "@/lib/twitch";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -11,7 +15,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-const TOKEN_KEY = 'twitch_provider_token';
 import type { Session } from "@supabase/supabase-js";
 
 export default function AuthStatus() {
@@ -35,20 +38,14 @@ export default function AuthStatus() {
   useEffect(() => {
     const token = (session as any)?.provider_token as string | undefined;
     if (token) {
-      try {
-        localStorage.setItem(TOKEN_KEY, token);
-      } catch {
-        // ignore storage failures
-      }
+      storeProviderToken(token);
     }
   }, [session]);
 
   useEffect(() => {
     const token =
       ((session as any)?.provider_token as string | undefined) ||
-      (typeof localStorage !== 'undefined'
-        ? localStorage.getItem(TOKEN_KEY) || undefined
-        : undefined);
+      getStoredProviderToken();
     const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
     const channelId = process.env.NEXT_PUBLIC_TWITCH_CHANNEL_ID;
     if (!token || !backendUrl) {
@@ -126,11 +123,7 @@ export default function AuthStatus() {
   const handleLogout = async () => {
     await supabase.auth.signOut();
     setSession(null);
-    try {
-      localStorage.removeItem(TOKEN_KEY);
-    } catch {
-      // ignore storage failures
-    }
+    storeProviderToken(undefined);
   };
 
   const username =

--- a/frontend/lib/twitch.ts
+++ b/frontend/lib/twitch.ts
@@ -26,3 +26,27 @@ export async function fetchSubscriptionRole(
   }
 }
 
+const TOKEN_KEY = 'twitch_provider_token';
+
+export function storeProviderToken(token: string | undefined) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (token) {
+      window.localStorage.setItem(TOKEN_KEY, token);
+    } else {
+      window.localStorage.removeItem(TOKEN_KEY);
+    }
+  } catch {
+    // ignore storage errors (e.g. server-side rendering or quota issues)
+  }
+}
+
+export function getStoredProviderToken(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return window.localStorage.getItem(TOKEN_KEY) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+


### PR DESCRIPTION
## Summary
- create `storeProviderToken` and `getStoredProviderToken` helpers
- refactor components to use the new helper instead of accessing `localStorage`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bcae88008832081e15a8f1df0b2fb