### PR TITLE
Allow ytimg proxy

### DIFF
--- a/backend/__tests__/proxy.test.js
+++ b/backend/__tests__/proxy.test.js
@@ -33,6 +33,19 @@ describe('GET /api/proxy', () => {
     expect(res.status).toBe(200);
   });
 
+  it('allows i.ytimg.com host', async () => {
+    const mockResponse = new Response('img', {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+    jest.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+    const res = await request(app).get(
+      '/api/proxy?url=https://i.ytimg.com/vi/abc/default.jpg'
+    );
+    expect(res.status).toBe(200);
+  });
+
   it('rejects disallowed hosts', async () => {
     const res = await request(app).get(
       '/api/proxy?url=https://example.com/data'

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,6 +13,7 @@ const ALLOWED_PROXY_HOSTS = [
   'static-cdn.jtvnw.net',
   'clips-media-assets2.twitch.tv',
   'media.rawg.io',
+  'i.ytimg.com',
 ];
 
 app.get('/api/proxy', async (req, res) => {


### PR DESCRIPTION
## Summary
- add `i.ytimg.com` to list of proxy hosts so YouTube images work
- test that proxy accepts i.ytimg.com URLs

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688bd4c72a308320a5f120da0b2c1cf4