### PR TITLE
Increase VOD block height

### DIFF
--- a/frontend/components/TwitchVideos.tsx
+++ b/frontend/components/TwitchVideos.tsx
@@ -78,7 +78,7 @@ export default function TwitchVideos() {
       <ul
         ref={listRef}
         className="space-y-2 overflow-y-auto scroll-smooth pr-1"
-        style={{ maxHeight: itemHeight ? itemHeight * 3 : 640 }}
+        style={{ maxHeight: itemHeight ? itemHeight * 8 : 1600 }}
       >
         {videos.map((v) => {
           const thumb = v.thumbnail_url


### PR DESCRIPTION
## Summary
- extend Twitch video block height to show more items

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688bd91c7a788320be8d8ac983a835a8