### PR TITLE
Add Twitch OAuth token route

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Use the “New Roulette” button on the `/archive` page to open `/new-poll` and
 
 This setup provides a simple API route `/api/data` that reads from the `items` table in Supabase.
 The `/api/get-stream` endpoint proxies requests to the Twitch Helix API using your server's `TWITCH_CLIENT_ID`. When calling the `subscriptions` endpoint it falls back to the broadcaster token (`TWITCH_BROADCASTER_TOKEN` or `getTwitchToken()`) so that responses include fields like `cumulative_months`.
+The `/auth/twitch-token` endpoint exchanges a Twitch OAuth `code` for access and refresh tokens using `TWITCH_CLIENT_ID`, `TWITCH_SECRET` and `OAUTH_CALLBACK_URL`.
 The `/api/poll` endpoint aggregates votes for each game and now also includes the usernames of voters.
 The `/api/poll/:id` endpoint returns results for a specific poll and `/api/polls` lists all polls.
 Games are linked to polls through the new `poll_games` table defined in `supabase/schema.sql`.

--- a/backend/__tests__/auth.test.js
+++ b/backend/__tests__/auth.test.js
@@ -1,0 +1,33 @@
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_KEY = 'test';
+process.env.TWITCH_CLIENT_ID = 'id';
+process.env.TWITCH_SECRET = 'secret';
+process.env.OAUTH_CALLBACK_URL = 'http://localhost/auth/callback';
+
+const request = require('supertest');
+const app = require('../server');
+
+describe('POST /auth/twitch-token', () => {
+  it('proxies code exchange to Twitch', async () => {
+    const mockResp = new Response('{"access_token":"t"}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue(mockResp);
+
+    const res = await request(app)
+      .post('/auth/twitch-token')
+      .send({ code: 'abc' });
+
+    expect(res.status).toBe(200);
+    expect(spy).toHaveBeenCalledWith(
+      'https://id.twitch.tv/oauth2/token',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('requires code parameter', async () => {
+    const res = await request(app).post('/auth/twitch-token').send({});
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- allow exchanging a Twitch OAuth code for tokens
- test the new `/auth/twitch-token` endpoint
- document the endpoint in the README

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be3aca8988320801b57f5d0e0dd09