### PR TITLE
Simplify sub role parsing

### DIFF
--- a/frontend/lib/twitch.ts
+++ b/frontend/lib/twitch.ts
@@ -12,14 +12,7 @@ export async function fetchSubscriptionRole(
     if (!resp.ok) return; // likely missing scope or not subscribed
     const d = await resp.json();
     if (d.data && d.data.length > 0) {
-      const info = d.data[0] || {};
-      const monthsRaw = info.cumulative_months ?? info.cumulativeMonths;
-      const months = Number(monthsRaw);
-      if (Number.isFinite(months)) {
-        roles.push(`Sub ${months}`);
-      } else {
-        roles.push('Sub');
-      }
+      roles.push('Sub');
     }
   } catch {
     // ignore errors


### PR DESCRIPTION
## Summary
- simplify Twitch subscription role detection
- drop unused cumulative months logic

## Testing
- `npm test --prefix backend`
- `npm test --prefix bot`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688bf5ff5f008320ba30a81c9fca33c3