### PR TITLE
Improve Twitch role visuals

### DIFF
--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
 
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
+import { ROLE_ICONS } from "@/lib/roleIcons";
 import type { Session } from "@supabase/supabase-js";
 
 interface PollHistory {
@@ -159,6 +160,22 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         Back to users
       </Link>
       <h1 className="text-2xl font-semibold flex items-center space-x-2">
+        {user.logged_in && session && session.user.id === user.auth_id && (
+          <>
+            {roles.map((r) =>
+              ROLE_ICONS[r] ? (
+                <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-6 h-6" />
+              ) : null
+            )}
+            {profileUrl && (
+              <img
+                src={profileUrl}
+                alt="profile"
+                className="w-10 h-10 rounded-full"
+              />
+            )}
+          </>
+        )}
         <span>{user.username}</span>
         {user.logged_in ? (
           <span className="px-2 py-0.5 text-xs bg-green-600 text-white rounded">
@@ -170,18 +187,6 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
           </span>
         )}
       </h1>
-      {user.logged_in && session && session.user.id === user.auth_id && (
-        <div className="flex items-center space-x-2">
-          {profileUrl && (
-            <img
-              src={profileUrl}
-              alt="profile"
-              className="w-10 h-10 rounded-full"
-            />
-          )}
-          {roles.length > 0 && <span>({roles.join(', ')})</span>}
-        </div>
-      )}
       {history.length === 0 ? (
         <p>No votes yet.</p>
       ) : (

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -2,12 +2,37 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { ROLE_ICONS } from "@/lib/roleIcons";
+import { useTwitchUserInfo } from "@/lib/useTwitchUserInfo";
 
 interface UserInfo {
   id: number;
   username: string;
   auth_id: string | null;
   logged_in: boolean;
+}
+
+function UserRow({ user }: { user: UserInfo }) {
+  const { roles } = useTwitchUserInfo(user.auth_id);
+  return (
+    <li className="flex items-center space-x-2 border p-2 rounded-lg bg-muted">
+      <span className="flex items-center space-x-1">
+        {roles.map((r) =>
+          ROLE_ICONS[r] ? (
+            <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
+          ) : null
+        )}
+        <Link href={`/users/${user.id}`} className="text-purple-600 underline">
+          {user.username}
+        </Link>
+      </span>
+      {user.logged_in ? (
+        <span className="text-green-600 text-sm">(logged in)</span>
+      ) : (
+        <span className="text-gray-500 text-sm">(never logged in)</span>
+      )}
+    </li>
+  );
 }
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
@@ -33,16 +58,7 @@ export default function UsersPage() {
       <h1 className="text-2xl font-semibold">Users</h1>
       <ul className="space-y-2">
         {users.map((u) => (
-          <li key={u.id} className="flex items-center space-x-2 border p-2 rounded-lg bg-muted">
-            <Link href={`/users/${u.id}`} className="text-purple-600 underline">
-              {u.username}
-            </Link>
-            {u.logged_in ? (
-              <span className="text-green-600 text-sm">(logged in)</span>
-            ) : (
-              <span className="text-gray-500 text-sm">(never logged in)</span>
-            )}
-          </li>
+          <UserRow key={u.id} user={u} />
         ))}
       </ul>
     </main>

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -8,6 +8,7 @@ import {
   storeProviderToken,
 } from "@/lib/twitch";
 import { Button } from "@/components/ui/button";
+import { ROLE_ICONS } from "@/lib/roleIcons";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -137,9 +138,13 @@ export default function AuthStatus() {
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" className="flex items-center space-x-2">
-          <span className="truncate max-w-xs">
+          <span className="flex items-center space-x-1 truncate max-w-xs">
+            {roles.map((r) =>
+              ROLE_ICONS[r] ? (
+                <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
+              ) : null
+            )}
             {username}
-            {roles.length > 0 && <> ({roles.join(', ')})</>}
           </span>
           {profileUrl && (
             <img

--- a/frontend/lib/roleIcons.ts
+++ b/frontend/lib/roleIcons.ts
@@ -1,0 +1,6 @@
+export const ROLE_ICONS: Record<string, string> = {
+  Sub: "/icons/roles/1.svg",
+  Streamer: "/icons/roles/broadcaster.svg",
+  Mod: "/icons/roles/moderator.svg",
+  VIP: "/icons/roles/vip.svg",
+};

--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import type { Session } from "@supabase/supabase-js";
+import { supabase } from "./supabase";
+import { fetchSubscriptionRole, getStoredProviderToken } from "./twitch";
+
+export function useTwitchUserInfo(authId: string | null) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [profileUrl, setProfileUrl] = useState<string | null>(null);
+  const [roles, setRoles] = useState<string[]>([]);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => setSession(session));
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, sess) => setSession(sess));
+    return () => subscription.unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (!authId) {
+      setProfileUrl(null);
+      setRoles([]);
+      return;
+    }
+    const token = (session as any)?.provider_token as string | undefined || getStoredProviderToken();
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+    const channelId = process.env.NEXT_PUBLIC_TWITCH_CHANNEL_ID;
+    if (!token || !backendUrl) {
+      setProfileUrl(null);
+      setRoles([]);
+      return;
+    }
+    const headers = { Authorization: `Bearer ${token}` } as Record<string, string>;
+
+    const fetchInfo = async () => {
+      try {
+        const userRes = await fetch(
+          `${backendUrl}/api/get-stream?endpoint=users&id=${authId}`,
+          { headers }
+        );
+        if (!userRes.ok) throw new Error("user");
+        const userData = await userRes.json();
+        const me = userData.data?.[0];
+        if (!me) throw new Error("user");
+        setProfileUrl(me.profile_image_url);
+        const uid = me.id as string;
+
+        const r: string[] = [];
+        if (channelId && uid === channelId) r.push("Streamer");
+
+        const query = `broadcaster_id=${channelId}&user_id=${uid}`;
+        const checkRole = async (url: string, name: string) => {
+          try {
+            const resp = await fetch(
+              `${backendUrl}/api/get-stream?endpoint=${url}&${query}`,
+              { headers }
+            );
+            if (!resp.ok) return;
+            const d = await resp.json();
+            if (d.data && d.data.length > 0) r.push(name);
+          } catch {
+            // ignore
+          }
+        };
+
+        if (channelId) {
+          await checkRole("moderation/moderators", "Mod");
+          await checkRole("channels/vips", "VIP");
+          await fetchSubscriptionRole(backendUrl, query, headers, r);
+        }
+
+        setRoles(r);
+      } catch (e) {
+        console.error("Twitch API error", e);
+        setProfileUrl(null);
+        setRoles([]);
+      }
+    };
+
+    fetchInfo();
+  }, [authId, session]);
+
+  return { profileUrl, roles };
+}


### PR DESCRIPTION
## Summary
- show Twitch role icons for logged-in user in header
- add helper utilities for Twitch role detection
- display role icons next to user names on user pages and in the user list

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688bf92ae96c8320bbaddd20ddd20844