### PR TITLE
Fix OAuth callback race

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { supabase } from "@/lib/supabase";
 
 export default function AuthCallback() {
   const router = useRouter();
+  const exchanged = useRef(false);
 
   useEffect(() => {
     const exchange = async () => {
+      if (exchanged.current) return;
+      exchanged.current = true;
       const url = new URL(window.location.href);
       const code = url.searchParams.get("code");
       if (code) {


### PR DESCRIPTION
## Summary
- prevent running the PKCE token exchange twice on the auth callback page

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c5b0bcfb88320825d0446c5e70dab