### PR TITLE
Handle Twitch token refresh on 401

### DIFF
--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
 import { supabase } from "./supabase";
-import { fetchSubscriptionRole, getStoredProviderToken } from "./twitch";
+import {
+  fetchSubscriptionRole,
+  getStoredProviderToken,
+  refreshProviderToken,
+  storeProviderToken,
+} from "./twitch";
 
 export function useTwitchUserInfo(authId: string | null) {
   const [session, setSession] = useState<Session | null>(null);
@@ -30,13 +35,28 @@ export function useTwitchUserInfo(authId: string | null) {
     }
     const headers = { Authorization: `Bearer ${token}` } as Record<string, string>;
 
+    // Helper to fetch Twitch endpoints with automatic token refresh on 401
+    const fetchWithRefresh = async (url: string) => {
+      let resp = await fetch(url, { headers });
+      if (resp.status === 401) {
+        const newToken = await refreshProviderToken();
+        if (!newToken) {
+          await supabase.auth.signOut();
+          storeProviderToken(undefined);
+          return null;
+        }
+        headers.Authorization = `Bearer ${newToken}`;
+        resp = await fetch(url, { headers });
+      }
+      return resp;
+    };
+
     const fetchInfo = async () => {
       try {
-        const userRes = await fetch(
-          `${backendUrl}/api/get-stream?endpoint=users&id=${authId}`,
-          { headers }
+        const userRes = await fetchWithRefresh(
+          `${backendUrl}/api/get-stream?endpoint=users&id=${authId}`
         );
-        if (!userRes.ok) throw new Error("user");
+        if (!userRes || !userRes.ok) throw new Error("user");
         const userData = await userRes.json();
         const me = userData.data?.[0];
         if (!me) throw new Error("user");
@@ -49,11 +69,10 @@ export function useTwitchUserInfo(authId: string | null) {
         const query = `broadcaster_id=${channelId}&user_id=${uid}`;
         const checkRole = async (url: string, name: string) => {
           try {
-            const resp = await fetch(
-              `${backendUrl}/api/get-stream?endpoint=${url}&${query}`,
-              { headers }
+            const resp = await fetchWithRefresh(
+              `${backendUrl}/api/get-stream?endpoint=${url}&${query}`
             );
-            if (!resp.ok) return;
+            if (!resp || !resp.ok) return;
             const d = await resp.json();
             if (d.data && d.data.length > 0) r.push(name);
           } catch {


### PR DESCRIPTION
## Summary
- add `refreshProviderToken` helper that refreshes the Supabase session and stores the new provider token
- retry Twitch API requests when `/api/get-stream` responds with 401
- sign out and clear local provider token if refresh fails

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c5bc15c7883208babe51606233a88