### PR TITLE
Fix archive page links

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -159,7 +159,12 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
                 />
               )}
               <div className="flex items-center space-x-2 relative z-10">
-                <span>{game.name}</span>
+                <Link
+                  href={`/games/${game.id}`}
+                  className="text-purple-600 underline"
+                >
+                  {game.name}
+                </Link>
                 <span className="font-mono">{game.count}</span>
               </div>
               <ul className="pl-4 list-disc">


### PR DESCRIPTION
## Summary
- link game names in archive page to their details page

## Testing
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_688c6ebeba788320a4e1ada22b77f84c