### PR TITLE
Add darker overlay for background images

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -153,12 +153,15 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
               className="border p-2 rounded-lg bg-muted space-y-1 relative overflow-hidden"
             >
               {game.background_image && (
-                <div
-                  className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
-                  style={{ backgroundImage: `url(${proxiedImage(game.background_image)})` }}
-                />
+                <>
+                  <div className="absolute inset-0 bg-black/60 z-0" />
+                  <div
+                    className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
+                    style={{ backgroundImage: `url(${proxiedImage(game.background_image)})` }}
+                  />
+                </>
               )}
-              <div className="flex items-center space-x-2 relative z-10">
+              <div className="flex items-center space-x-2 relative z-10 text-white">
                 <Link
                   href={`/games/${game.id}`}
                   className="text-purple-600 underline"

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -100,12 +100,15 @@ export default function GamesPage() {
       className="border p-2 rounded-lg bg-muted space-y-1 relative overflow-hidden"
     >
       {g.background_image && (
-        <div
-          className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
-          style={{ backgroundImage: `url(${proxiedImage(g.background_image)})` }}
-        />
+        <>
+          <div className="absolute inset-0 bg-black/60 z-0" />
+          <div
+            className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
+            style={{ backgroundImage: `url(${proxiedImage(g.background_image)})` }}
+          />
+        </>
       )}
-      <div className="flex items-center space-x-2 relative z-10">
+      <div className="flex items-center space-x-2 relative z-10 text-white">
         <Link href={`/games/${g.id}`} className="flex-grow text-purple-600 underline">
           {g.name}
         </Link>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -456,12 +456,15 @@ export default function Home() {
               className="border p-2 rounded-lg bg-muted space-y-1 relative overflow-hidden"
             >
               {game.background_image && (
-                <div
-                  className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
-                  style={{ backgroundImage: `url(${proxiedImage(game.background_image)})` }}
-                />
+                <>
+                  <div className="absolute inset-0 bg-black/60 z-0" />
+                  <div
+                    className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
+                    style={{ backgroundImage: `url(${proxiedImage(game.background_image)})` }}
+                  />
+                </>
               )}
-              <div className="flex items-center space-x-2 relative z-10">
+              <div className="flex items-center space-x-2 relative z-10 text-white">
                 <button
                   className="px-2 py-1 bg-gray-300 rounded disabled:opacity-50"
                   onClick={() => adjustVote(game.id, -1)}


### PR DESCRIPTION
## Summary
- darken list item backgrounds with a black overlay
- ensure foreground text uses `text-white`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c7325bbe083208825acf2d2604350