### PR TITLE
Improve readability with new outlines

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import RouletteWheel, { RouletteWheelHandle, WheelGame } from "@/components/RouletteWheel";
 import SpinResultModal from "@/components/SpinResultModal";
 import type { Poll } from "@/types";
-import { proxiedImage } from "@/lib/utils";
+import { proxiedImage, cn } from "@/lib/utils";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
@@ -150,7 +150,10 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
           {poll.games.map((game) => (
             <li
               key={game.id}
-              className="border p-2 rounded-lg bg-muted space-y-1 relative overflow-hidden"
+              className={cn(
+                "border p-2 rounded-lg space-y-1 relative overflow-hidden",
+                game.background_image ? "bg-muted" : "bg-gray-800"
+              )}
             >
               {game.background_image && (
                 <>
@@ -161,7 +164,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
                   />
                 </>
               )}
-              <div className="flex items-center space-x-2 relative z-10 text-white">
+              <div className="flex items-center space-x-2 relative z-10 text-white text-outline">
                 <Link
                   href={`/games/${game.id}`}
                   className="text-purple-600 underline"

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useEffect, useState } from "react";
 import Link from "next/link";
-import { proxiedImage } from "@/lib/utils";
+import { proxiedImage, cn } from "@/lib/utils";
 
 interface UserRef {
   id: number;
@@ -72,7 +72,12 @@ export default function GamePage({ params }: { params: Promise<{ id: string }> }
       <Link href="/games" className="text-purple-600 underline">
         Back to games
       </Link>
-      <h1 className="text-2xl font-semibold relative overflow-hidden">
+      <h1
+        className={cn(
+          "text-2xl font-semibold relative overflow-hidden",
+          game.background_image ? "text-white text-outline" : "bg-gray-800 p-2 text-white"
+        )}
+      >
         {game.background_image && (
           <div
             className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import type { Session } from "@supabase/supabase-js";
 import AddCatalogGameModal from "@/components/AddCatalogGameModal";
 import EditCatalogGameModal from "@/components/EditCatalogGameModal";
-import { proxiedImage } from "@/lib/utils";
+import { proxiedImage, cn } from "@/lib/utils";
 
 interface UserRef {
   id: number;
@@ -97,7 +97,10 @@ export default function GamesPage() {
   const renderGame = (g: GameEntry) => (
     <li
       key={g.id}
-      className="border p-2 rounded-lg bg-muted space-y-1 relative overflow-hidden"
+      className={cn(
+        "border p-2 rounded-lg space-y-1 relative overflow-hidden",
+        g.background_image ? "bg-muted" : "bg-gray-800"
+      )}
     >
       {g.background_image && (
         <>
@@ -108,7 +111,7 @@ export default function GamesPage() {
           />
         </>
       )}
-      <div className="flex items-center space-x-2 relative z-10 text-white">
+      <div className="flex items-center space-x-2 relative z-10 text-white text-outline">
         <Link href={`/games/${g.id}`} className="flex-grow text-purple-600 underline">
           {g.name}
         </Link>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -78,3 +78,9 @@
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }
+
+@layer utilities {
+  .text-outline {
+    -webkit-text-stroke: 1px #000;
+  }
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,7 +9,7 @@ import SettingsModal from "@/components/SettingsModal";
 import SpinResultModal from "@/components/SpinResultModal";
 import type { Session } from "@supabase/supabase-js";
 import type { Game, Poll, Voter } from "@/types";
-import { proxiedImage } from "@/lib/utils";
+import { proxiedImage, cn } from "@/lib/utils";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 if (!backendUrl) {
@@ -453,7 +453,10 @@ export default function Home() {
           return (
             <li
               key={game.id}
-              className="border p-2 rounded-lg bg-muted space-y-1 relative overflow-hidden"
+              className={cn(
+                "border p-2 rounded-lg space-y-1 relative overflow-hidden",
+                game.background_image ? "bg-muted" : "bg-gray-800"
+              )}
             >
               {game.background_image && (
                 <>
@@ -464,7 +467,7 @@ export default function Home() {
                   />
                 </>
               )}
-              <div className="flex items-center space-x-2 relative z-10 text-white">
+              <div className="flex items-center space-x-2 relative z-10 text-white text-outline">
                 <button
                   className="px-2 py-1 bg-gray-300 rounded disabled:opacity-50"
                   onClick={() => adjustVote(game.id, -1)}


### PR DESCRIPTION
## Summary
- outline text over game backgrounds for better readability
- darken list items when no game background image

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_688c7be218b08320a5672aba26d67b23