### PR TITLE
Update styling for game entries

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -152,7 +152,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
               key={game.id}
               className={cn(
                 "border p-2 rounded-lg space-y-1 relative overflow-hidden",
-                game.background_image ? "bg-muted" : "bg-gray-800"
+                game.background_image ? "bg-muted" : "bg-gray-700"
               )}
             >
               {game.background_image && (
@@ -164,10 +164,13 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
                   />
                 </>
               )}
-              <div className="flex items-center space-x-2 relative z-10 text-white text-outline">
+              <div className="flex items-center space-x-2 relative z-10 text-white">
                 <Link
                   href={`/games/${game.id}`}
-                  className="text-purple-600 underline"
+                  className={cn(
+                    "underline",
+                    game.background_image ? "text-white" : "text-purple-600"
+                  )}
                 >
                   {game.name}
                 </Link>
@@ -179,7 +182,10 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
                     {voter.count}{" "}
                     <Link
                       href={`/users/${voter.id}`}
-                      className="text-purple-600 underline"
+                      className={cn(
+                        "underline",
+                        game.background_image ? "text-white" : "text-purple-600"
+                      )}
                     >
                       {voter.username}
                     </Link>

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -75,7 +75,7 @@ export default function GamePage({ params }: { params: Promise<{ id: string }> }
       <h1
         className={cn(
           "text-2xl font-semibold relative overflow-hidden",
-          game.background_image ? "text-white text-outline" : "bg-gray-800 p-2 text-white"
+          game.background_image ? "text-white" : "bg-gray-700 p-2 text-white"
         )}
       >
         {game.background_image && (

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -83,10 +83,14 @@ export default function GamesPage() {
   const completed = games.filter((g) => g.status === "completed");
   const backlog = games.filter((g) => g.status !== "completed" && g.status !== "active");
 
-  const renderInitiators = (inits: UserRef[]) => (
+  const renderInitiators = (inits: UserRef[], white?: boolean) => (
     <span className="space-x-1">
       {inits.map((u, i) => (
-        <Link key={u.id} href={`/users/${u.id}`} className="underline text-purple-600">
+        <Link
+          key={u.id}
+          href={`/users/${u.id}`}
+          className={cn("underline", white ? "text-white" : "text-purple-600")}
+        >
           {u.username}
           {i < inits.length - 1 ? "," : ""}
         </Link>
@@ -99,7 +103,7 @@ export default function GamesPage() {
       key={g.id}
       className={cn(
         "border p-2 rounded-lg space-y-1 relative overflow-hidden",
-        g.background_image ? "bg-muted" : "bg-gray-800"
+        g.background_image ? "bg-muted" : "bg-gray-700"
       )}
     >
       {g.background_image && (
@@ -111,8 +115,14 @@ export default function GamesPage() {
           />
         </>
       )}
-      <div className="flex items-center space-x-2 relative z-10 text-white text-outline">
-        <Link href={`/games/${g.id}`} className="flex-grow text-purple-600 underline">
+      <div className="flex items-center space-x-2 relative z-10 text-white">
+        <Link
+          href={`/games/${g.id}`}
+          className={cn(
+            "flex-grow underline",
+            g.background_image ? "text-white" : "text-purple-600"
+          )}
+        >
           {g.name}
         </Link>
         {g.rating !== null && <span className="font-mono">{g.rating}/10</span>}
@@ -121,7 +131,10 @@ export default function GamesPage() {
         )}
         {isModerator && (
           <button
-            className="text-sm underline text-purple-600"
+            className={cn(
+              "text-sm underline",
+              g.background_image ? "text-white" : "text-purple-600"
+            )}
             onClick={() => setEditingGame(g)}
           >
             Edit
@@ -129,7 +142,14 @@ export default function GamesPage() {
         )}
       </div>
       {g.initiators.length > 0 && (
-        <div className="text-sm text-gray-700">Initiators: {renderInitiators(g.initiators)}</div>
+        <div
+          className={cn(
+            "text-sm",
+            g.background_image ? "text-white" : "text-gray-700"
+          )}
+        >
+          Initiators: {renderInitiators(g.initiators, !!g.background_image)}
+        </div>
       )}
     </li>
   );

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -79,8 +79,3 @@
   }
 }
 
-@layer utilities {
-  .text-outline {
-    -webkit-text-stroke: 1px #000;
-  }
-}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -455,7 +455,7 @@ export default function Home() {
               key={game.id}
               className={cn(
                 "border p-2 rounded-lg space-y-1 relative overflow-hidden",
-                game.background_image ? "bg-muted" : "bg-gray-800"
+                game.background_image ? "bg-muted" : "bg-gray-700"
               )}
             >
               {game.background_image && (
@@ -467,7 +467,7 @@ export default function Home() {
                   />
                 </>
               )}
-              <div className="flex items-center space-x-2 relative z-10 text-white text-outline">
+              <div className="flex items-center space-x-2 relative z-10 text-white">
                 <button
                   className="px-2 py-1 bg-gray-300 rounded disabled:opacity-50"
                   onClick={() => adjustVote(game.id, -1)}
@@ -483,7 +483,13 @@ export default function Home() {
                 >
                   +
                 </button>
-                <Link href={`/games/${game.id}`} className="text-purple-600 underline">
+                <Link
+                  href={`/games/${game.id}`}
+                  className={cn(
+                    "underline",
+                    game.background_image ? "text-white" : "text-purple-600"
+                  )}
+                >
                   {game.name}
                 </Link>
                 <span className="font-mono">{game.count}</span>
@@ -494,7 +500,10 @@ export default function Home() {
                     {voter.count}{" "}
                     <Link
                       href={`/users/${voter.id}`}
-                      className="text-purple-600 underline"
+                      className={cn(
+                        "underline",
+                        game.background_image ? "text-white" : "text-purple-600"
+                      )}
                     >
                       {voter.username}
                     </Link>


### PR DESCRIPTION
## Summary
- make image-backed game items use white text
- lighten game containers without images
- drop unused text-outline style

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688c81fda45c832081559d1aa560fe61