### PR TITLE
Fix vote alignment and colors

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -174,12 +174,12 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
                 >
                   {game.name}
                 </Link>
-                <span className="font-mono">{game.count}</span>
+                <span className="font-mono ml-auto text-right">{game.count}</span>
               </div>
               <ul className="pl-4 list-disc">
                 {game.nicknames.map((voter) => (
-                  <li key={voter.id}>
-                    {voter.count}{" "}
+                  <li key={voter.id} className="text-white">
+                    <span className="text-white">{voter.count}</span>{" "}
                     <Link
                       href={`/users/${voter.id}`}
                       className={cn(

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -492,12 +492,12 @@ export default function Home() {
                 >
                   {game.name}
                 </Link>
-                <span className="font-mono">{game.count}</span>
+                <span className="font-mono ml-auto text-right">{game.count}</span>
               </div>
               <ul className="pl-4 list-disc">
                 {game.nicknames.map((voter) => (
-                  <li key={voter.id}>
-                    {voter.count}{" "}
+                  <li key={voter.id} className="text-white">
+                    <span className="text-white">{voter.count}</span>{" "}
                     <Link
                       href={`/users/${voter.id}`}
                       className={cn(


### PR DESCRIPTION
## Summary
- right-align total vote count inside roulette containers
- make per-user vote count white on main and archive pages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c8998d9a0832084060cdec42cd039