### PR TITLE
Optimize user fetch for poll results

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -240,9 +240,11 @@ async function buildPollResponse(poll) {
     .eq('poll_id', poll.id);
   if (votesError) return { error: votesError };
 
+  const userIds = [...new Set(votes.map((v) => v.user_id))];
   const { data: users, error: usersError } = await supabase
     .from('users')
-    .select('id, username');
+    .select('id, username')
+    .in('id', userIds.length > 0 ? userIds : [0]);
   if (usersError) return { error: usersError };
 
   const userMap = users.reduce((acc, u) => {


### PR DESCRIPTION
## Summary
- fetch only relevant users when building poll responses
- ensure users beyond Supabase default limits are processed correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c8e93740c8320b644b2d2362a44a6