### PR TITLE
Fix text visibility on background images

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -157,7 +157,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
             >
               {game.background_image && (
                 <>
-                  <div className="absolute inset-0 bg-black/60 z-0" />
+                    <div className="absolute inset-0 bg-black/80 z-0" />
                   <div
                     className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
                     style={{ backgroundImage: `url(${proxiedImage(game.background_image)})` }}

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -106,13 +106,13 @@ export default function GamesPage() {
         g.background_image ? "bg-muted" : "bg-gray-700"
       )}
     >
-      {g.background_image && (
-        <>
-          <div className="absolute inset-0 bg-black/60 z-0" />
-          <div
-            className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
-            style={{ backgroundImage: `url(${proxiedImage(g.background_image)})` }}
-          />
+        {g.background_image && (
+          <>
+            <div className="absolute inset-0 bg-black/80 z-0" />
+            <div
+              className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
+              style={{ backgroundImage: `url(${proxiedImage(g.background_image)})` }}
+            />
         </>
       )}
       <div className="flex items-center space-x-2 relative z-10 text-white">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -460,7 +460,7 @@ export default function Home() {
             >
               {game.background_image && (
                 <>
-                  <div className="absolute inset-0 bg-black/60 z-0" />
+                  <div className="absolute inset-0 bg-black/80 z-0" />
                   <div
                     className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
                     style={{ backgroundImage: `url(${proxiedImage(game.background_image)})` }}


### PR DESCRIPTION
## Summary
- darken background overlay on game containers so text stands out

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688c921b26788320983d6ce6380b46dc