### PR TITLE
Remove real Supabase URL from bot example

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,5 +1,5 @@
-SUPABASE_URL=https://bsiiyuwbzhwrflsdpoud.supabase.co
-SUPABASE_KEY=your-supabase-service-key
+SUPABASE_URL=<SUPABASE_URL>
+SUPABASE_KEY=<SUPABASE_SERVICE_KEY>
 BOT_USERNAME=your-bot-username
 BOT_OAUTH_TOKEN=oauth:your-oauth-token
 TWITCH_CHANNEL=terrenkur


### PR DESCRIPTION
## Summary
- sanitize `bot/.env.example` so it only contains placeholders

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_688cbe8b23648320a6756d34f2e93328