### PR TITLE
Secure event logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Games are linked to polls through the new `poll_games` table defined in `supabas
 The `games` table now also stores `background_image` URLs for thumbnails.
 The `/api/games/:id` endpoint returns details for a single game including
 its initiators and a list of roulettes with the voters for that game.
+The `/api/logs` endpoint returns recent entries from the `event_logs` table and
+requires a moderator `Authorization` token. Pass a numeric `limit` between 1 and
+100 to control how many entries are returned.
 
 Moderators can toggle accepting votes and vote editing via the `/api/accept_votes` and `/api/allow_edit` endpoints (also available in the Settings modal). When voting is closed or editing disabled, the frontend disables the vote controls.
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1358,9 +1358,12 @@ app.get('/api/playlists', async (_req, res) => {
   }
 });
 
-// Fetch recent event logs
-app.get('/api/logs', async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 10;
+// Fetch recent event logs (moderators only)
+app.get('/api/logs', requireModerator, async (req, res) => {
+  let limit = parseInt(req.query.limit, 10);
+  if (Number.isNaN(limit) || limit <= 0 || limit > 100) {
+    return res.status(400).json({ error: 'Invalid limit' });
+  }
   const { data, error } = await supabase
     .from('event_logs')
     .select('*')


### PR DESCRIPTION
## Summary
- protect the `/api/logs` endpoint by requiring moderator authentication
- validate the logs `limit` parameter
- fetch logs with auth token on the frontend and show errors
- mention the new `/api/logs` requirement in documentation

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cc68db4548320ad3f88b38c3ba240