### PR TITLE
Add helmet middleware to backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,8 @@
         "@supabase/supabase-js": "^2.43.4",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "helmet": "^8.1.0"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -2614,6 +2615,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,11 +12,12 @@
     "express": "^4.19.2",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
-    "@supabase/supabase-js": "^2.43.4"
+    "@supabase/supabase-js": "^2.43.4",
+    "helmet": "^8.1.0"
   },
   "devDependencies": {
-    "nodemon": "^3.1.0",
     "jest": "^29.7.0",
+    "nodemon": "^3.1.0",
     "supertest": "^6.3.4"
   },
   "engines": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,11 +1,15 @@
 const express = require('express');
 const cors = require('cors');
+const helmet = require('helmet');
 const { createClient } = require('@supabase/supabase-js');
 const { getPlaylists } = require('./youtube');
 require('dotenv').config();
 
 const app = express();
 app.use(cors());
+app.use(helmet({
+  crossOriginResourcePolicy: false,
+}));
 app.use(express.json());
 
 // Exchange Twitch OAuth code for an access token


### PR DESCRIPTION
## Summary
- install `helmet`
- use `helmet` middleware in the express server with `crossOriginResourcePolicy` disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cc95515fc8320994b56039683b0af