### PR TITLE
Move Twitch clips into reusable component

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import AuthStatus from "@/components/AuthStatus";
 import SettingsLink from "@/components/SettingsLink";
 import TwitchVideos from "@/components/TwitchVideos";
+import TwitchClips from "@/components/TwitchClips";
 import EventLog from "@/components/EventLog";
 import "./globals.css";
 
@@ -48,7 +49,6 @@ export default function RootLayout({
               <Link href="/games">Games</Link>
               <Link href="/users">Users</Link>
               <Link href="/playlists">Playlists</Link>
-              <Link href="/clips">Clips</Link>
               <SettingsLink />
             </div>
             <div className="flex items-center space-x-4">
@@ -98,6 +98,7 @@ export default function RootLayout({
             <div className="col-span-2 col-start-11 space-y-4">
               <EventLog />
               <TwitchVideos />
+              <TwitchClips />
             </div>
           </div>
         </main>

--- a/frontend/components/TwitchClips.tsx
+++ b/frontend/components/TwitchClips.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/card";
 import { proxiedImage } from "@/lib/utils";
 
 interface Clip {
@@ -12,7 +13,7 @@ interface Clip {
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
-export default function ClipsPage() {
+export default function TwitchClips() {
   const [clips, setClips] = useState<Clip[]>([]);
 
   useEffect(() => {
@@ -26,18 +27,16 @@ export default function ClipsPage() {
     });
   }, []);
 
-  if (!backendUrl) {
-    return <div className="p-4">Backend URL not configured.</div>;
-  }
+  if (!backendUrl || clips.length === 0) return null;
 
   return (
-    <main className="col-span-10 p-4 max-w-xl space-y-4">
-      <h1 className="text-2xl font-semibold">Twitch Clips</h1>
-      <ul className="space-y-4">
+    <Card className="space-y-2">
+      <h2 className="text-lg font-semibold">Twitch Clips</h2>
+      <ul className="space-y-2">
         {clips.map((clip) => {
           const thumb = clip.thumbnail_url
-            .replace("%{width}", "480")
-            .replace("%{height}", "272");
+            .replace("%{width}", "320")
+            .replace("%{height}", "180");
           const src = proxiedImage(thumb) ?? thumb;
           return (
             <li key={clip.id} className="space-y-1">
@@ -54,6 +53,6 @@ export default function ClipsPage() {
           );
         })}
       </ul>
-    </main>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- refactor Twitch clips page into `TwitchClips` component
- display `TwitchClips` in sidebar below videos
- remove old Clips navigation link and route

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ccb58e4f08320981b7795cb6352ba