### PR TITLE
Adjust event log max height

### DIFF
--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -102,7 +102,7 @@ export default function EventLog() {
       <ul
         ref={listRef}
         className="space-y-2 text-sm overflow-y-auto scroll-smooth pr-1"
-        style={{ maxHeight: itemHeight ? itemHeight * 8 : 1600 }}
+        style={{ maxHeight: itemHeight ? itemHeight * 3.2 : 640 }}
       >
         {logs.map((l) => (
           <li


### PR DESCRIPTION
## Summary
- tweak `EventLog` scrollable region height
- run frontend tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ccc9aae8c8320bdd8b5508aeea4cc