### PR TITLE
Make event logs public

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Games are linked to polls through the new `poll_games` table defined in `supabas
 The `games` table now also stores `background_image` URLs for thumbnails.
 The `/api/games/:id` endpoint returns details for a single game including
 its initiators and a list of roulettes with the voters for that game.
-The `/api/logs` endpoint returns recent entries from the `event_logs` table and
-requires a moderator `Authorization` token. Pass a numeric `limit` between 1 and
-100 to control how many entries are returned.
+The `/api/logs` endpoint returns recent entries from the `event_logs` table.
+Pass a numeric `limit` between 1 and 100 to control how many entries are
+returned.
 
 Moderators can toggle accepting votes and vote editing via the `/api/accept_votes` and `/api/allow_edit` endpoints (also available in the Settings modal). When voting is closed or editing disabled, the frontend disables the vote controls.
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1362,8 +1362,8 @@ app.get('/api/playlists', async (_req, res) => {
   }
 });
 
-// Fetch recent event logs (moderators only)
-app.get('/api/logs', requireModerator, async (req, res) => {
+// Fetch recent event logs
+app.get('/api/logs', async (req, res) => {
   let limit = parseInt(req.query.limit, 10);
   if (Number.isNaN(limit) || limit <= 0 || limit > 100) {
     return res.status(400).json({ error: 'Invalid limit' });

--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -73,11 +73,6 @@ export default function EventLog() {
       fetch(`${backendUrl}/api/logs?limit=10`, {
         headers: token ? { Authorization: `Bearer ${token}` } : undefined,
       }).then(async (res) => {
-        if (res.status === 401 || res.status === 403) {
-          setError("Moderator access required");
-          setLogs([]);
-          return;
-        }
         if (!res.ok) {
           setError("Failed to fetch logs");
           return;


### PR DESCRIPTION
## Summary
- allow anyone to access `/api/logs`
- stop showing a moderator error when fetching logs in the frontend
- document the updated API behavior

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688cd187cb548320ac97e5deb1489063