### PR TITLE
Add statistics endpoints and page

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ its initiators and a list of roulettes with the voters for that game.
 The `/api/logs` endpoint returns recent entries from the `event_logs` table.
 Pass a numeric `limit` between 1 and 100 to control how many entries are
 returned.
+The `/api/stats/popular-games` and `/api/stats/top-voters` endpoints aggregate
+vote counts across all roulettes.
 
 Moderators can toggle accepting votes and vote editing via the `/api/accept_votes` and `/api/allow_edit` endpoints (also available in the Settings modal). When voting is closed or editing disabled, the frontend disables the vote controls.
 
@@ -122,6 +124,7 @@ To see the current poll visualized as a spinning wheel, open the homepage. Games
 Archived roulettes now store the elimination order and the winning game. When viewing an entry in the archive you will see the full elimination sequence and a button to replay the wheel using the recorded seed so the spins reproduce exactly.
 
 With a YouTube API key configured you can also visit `/playlists` to see videos from your channel grouped by tags extracted from their descriptions.
+The `/stats` page visualizes the most popular games and top voters using these aggregated counts.
 
 ## Updating the Supabase schema
 

--- a/backend/__tests__/stats.test.js
+++ b/backend/__tests__/stats.test.js
@@ -1,0 +1,92 @@
+const request = require('supertest');
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_KEY = 'test';
+
+const votes = [
+  { game_id: 1, user_id: 1 },
+  { game_id: 1, user_id: 2 },
+  { game_id: 2, user_id: 1 },
+];
+const games = [
+  { id: 1, name: 'Game1' },
+  { id: 2, name: 'Game2' },
+];
+const users = [
+  { id: 1, username: 'Alice' },
+  { id: 2, username: 'Bob' },
+];
+
+const build = (data) => {
+  const builder = {};
+  const chain = ['select', 'eq', 'order', 'limit', 'in', 'insert', 'update', 'upsert', 'delete'];
+  chain.forEach((m) => {
+    builder[m] = jest.fn(() => builder);
+  });
+  builder.maybeSingle = jest.fn(async () => ({ data: builder.data ?? data, error: null }));
+  builder.single = jest.fn(async () => ({ data: builder.data ?? data, error: null }));
+  builder.then = (resolve) => Promise.resolve({ data: builder.data ?? data, error: null }).then(resolve);
+  return builder;
+};
+
+const buildGames = (all) => {
+  const builder = build(all);
+  builder.data = all;
+  builder.in = jest.fn((_col, ids) => {
+    builder.data = all.filter((g) => ids.includes(g.id));
+    return builder;
+  });
+  return builder;
+};
+
+const buildUsers = (all) => {
+  const builder = build(all);
+  builder.data = all;
+  builder.in = jest.fn((_col, ids) => {
+    builder.data = all.filter((u) => ids.includes(u.id));
+    return builder;
+  });
+  return builder;
+};
+
+const mockSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn((table) => {
+    switch (table) {
+      case 'votes':
+        return build(votes);
+      case 'games':
+        return buildGames(games);
+      case 'users':
+        return buildUsers(users);
+      default:
+        return build(null);
+    }
+  }),
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => mockSupabase),
+}));
+
+const app = require('../server');
+
+describe('stats endpoints', () => {
+  it('returns aggregated game votes', async () => {
+    const res = await request(app).get('/api/stats/popular-games');
+    expect(res.status).toBe(200);
+    expect(res.body.games).toEqual([
+      { id: 1, name: 'Game1', votes: 2 },
+      { id: 2, name: 'Game2', votes: 1 },
+    ]);
+  });
+
+  it('returns aggregated user votes', async () => {
+    const res = await request(app).get('/api/stats/top-voters');
+    expect(res.status).toBe(200);
+    expect(res.body.users).toEqual([
+      { id: 1, username: 'Alice', votes: 2 },
+      { id: 2, username: 'Bob', votes: 1 },
+    ]);
+  });
+});

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -48,6 +48,7 @@ export default function RootLayout({
               <Link href="/archive">Archive</Link>
               <Link href="/games">Games</Link>
               <Link href="/users">Users</Link>
+              <Link href="/stats">Stats</Link>
               <Link href="/playlists">Playlists</Link>
               <SettingsLink />
             </div>

--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface PopularGame {
+  id: number;
+  name: string;
+  votes: number;
+}
+
+interface TopVoter {
+  id: number;
+  username: string;
+  votes: number;
+}
+
+const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+export default function StatsPage() {
+  const [games, setGames] = useState<PopularGame[]>([]);
+  const [voters, setVoters] = useState<TopVoter[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!backendUrl) return;
+    Promise.all([
+      fetch(`${backendUrl}/api/stats/popular-games`).then((r) =>
+        r.ok ? r.json() : { games: [] }
+      ),
+      fetch(`${backendUrl}/api/stats/top-voters`).then((r) =>
+        r.ok ? r.json() : { users: [] }
+      ),
+    ]).then(([g, u]) => {
+      setGames(g.games || []);
+      setVoters(u.users || []);
+      setLoading(false);
+    });
+  }, []);
+
+  if (!backendUrl) {
+    return <div className="p-4">Backend URL not configured.</div>;
+  }
+
+  if (loading) return <div className="p-4">Loading...</div>;
+
+  return (
+    <main className="col-span-10 p-4 max-w-xl space-y-6">
+      <h1 className="text-2xl font-semibold">Statistics</h1>
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold mb-2">Most Popular Games</h2>
+        {games.length === 0 ? (
+          <p>No data.</p>
+        ) : (
+          <table className="min-w-full border">
+            <thead>
+              <tr className="bg-muted">
+                <th className="p-2 text-left">Game</th>
+                <th className="p-2 text-right">Votes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {games.map((g) => (
+                <tr key={g.id} className="border-t">
+                  <td className="p-2">{g.name}</td>
+                  <td className="p-2 text-right">{g.votes}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold mb-2">Top Voters</h2>
+        {voters.length === 0 ? (
+          <p>No data.</p>
+        ) : (
+          <table className="min-w-full border">
+            <thead>
+              <tr className="bg-muted">
+                <th className="p-2 text-left">User</th>
+                <th className="p-2 text-right">Votes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {voters.map((v) => (
+                <tr key={v.id} className="border-t">
+                  <td className="p-2">{v.username}</td>
+                  <td className="p-2 text-right">{v.votes}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add aggregated stats endpoints in the backend
- display a `/stats` page in the frontend
- link Stats in the navigation bar
- test the new endpoints
- document the statistics page and API

## Testing
- `npm test --prefix backend`
- `npm test --prefix bot`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_688cd3070c8c8320895dc19a62f72cf4