### PR TITLE
Add Twitch link on user page

### DIFF
--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -202,6 +202,16 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
           </span>
         )}
       </h1>
+      <p>
+        <a
+          href={`https://twitch.tv/${user.username}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-purple-600 underline"
+        >
+          twitch.tv/{user.username}
+        </a>
+      </p>
       {history.length === 0 ? (
         <p>No votes yet.</p>
       ) : (


### PR DESCRIPTION
## Summary
- add a Twitch link below the user heading in `[id]/page.tsx`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688cd9d8ec188320b3c3496fd6bec59c