### PR TITLE
Add user search feature

### DIFF
--- a/backend/__tests__/users.test.js
+++ b/backend/__tests__/users.test.js
@@ -1,0 +1,69 @@
+const request = require('supertest');
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_KEY = 'test';
+
+const users = [
+  { id: 1, username: 'Alice', auth_id: null },
+  { id: 2, username: 'Bob', auth_id: 'x' },
+  { id: 3, username: 'Charlie', auth_id: null },
+];
+
+const build = (data) => {
+  const builder = {};
+  const chain = ['select', 'order', 'ilike'];
+  chain.forEach((m) => {
+    builder[m] = jest.fn(() => builder);
+  });
+  builder.then = (resolve) => Promise.resolve({ data, error: null }).then(resolve);
+  return builder;
+};
+
+const buildUsers = (all) => {
+  const builder = build(all);
+  builder.data = all;
+  builder.select = jest.fn(() => {
+    builder.data = all;
+    return builder;
+  });
+  builder.order = jest.fn(() => builder);
+  builder.ilike = jest.fn((_col, pattern) => {
+    const s = pattern.replace(/%/g, '').toLowerCase();
+    builder.data = all.filter((u) => u.username.toLowerCase().includes(s));
+    return builder;
+  });
+  builder.then = (resolve) => Promise.resolve({ data: builder.data, error: null }).then(resolve);
+  return builder;
+};
+
+const mockSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn((table) => {
+    if (table === 'users') {
+      return buildUsers(users);
+    }
+    return build(null);
+  }),
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => mockSupabase),
+}));
+
+const app = require('../server');
+
+describe('GET /api/users', () => {
+  it('returns all users', async () => {
+    const res = await request(app).get('/api/users');
+    expect(res.status).toBe(200);
+    expect(res.body.users.length).toBe(3);
+  });
+
+  it('filters by username', async () => {
+    const res = await request(app).get('/api/users?search=ali');
+    expect(res.status).toBe(200);
+    expect(res.body.users).toEqual([
+      { id: 1, username: 'Alice', auth_id: null, logged_in: false },
+    ]);
+  });
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -785,11 +785,16 @@ app.post('/api/log_reward_ids', requireModerator, async (req, res) => {
 });
 
 // List all users
-app.get('/api/users', async (_req, res) => {
-  const { data, error } = await supabase
+app.get('/api/users', async (req, res) => {
+  const search = req.query.search || req.query.q;
+  let builder = supabase
     .from('users')
-    .select('id, username, auth_id')
-    .order('username', { ascending: true });
+    .select('id, username, auth_id');
+  if (search) {
+    builder = builder.ilike('username', `%${search}%`);
+  }
+  builder = builder.order('username', { ascending: true });
+  const { data, error } = await builder;
   if (error) return res.status(500).json({ error: error.message });
   const users = (data || []).map((u) => ({
     id: u.id,

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -39,15 +39,19 @@ const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 export default function UsersPage() {
   const [users, setUsers] = useState<UserInfo[]>([]);
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
     if (!backendUrl) return;
-    fetch(`${backendUrl}/api/users`).then(async (res) => {
+    const url = query.trim()
+      ? `${backendUrl}/api/users?search=${encodeURIComponent(query.trim())}`
+      : `${backendUrl}/api/users`;
+    fetch(url).then(async (res) => {
       if (!res.ok) return;
       const data = await res.json();
       setUsers(data.users || []);
     });
-  }, []);
+  }, [query]);
 
   if (!backendUrl) {
     return <div className="p-4">Backend URL not configured.</div>;
@@ -56,6 +60,13 @@ export default function UsersPage() {
   return (
     <main className="col-span-10 p-4 max-w-xl space-y-4">
       <h1 className="text-2xl font-semibold">Users</h1>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search"
+        className="border p-1 rounded w-full text-black"
+      />
       <ul className="space-y-2">
         {users.map((u) => (
           <UserRow key={u.id} user={u} />


### PR DESCRIPTION
## Summary
- add optional `search` query for `/api/users`
- allow searching from UI with a textbox
- test new backend search logic

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cdd83042483209e8bebc24e9d8f6e