### PR TITLE
Ensure voter list visible over game background

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -176,7 +176,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
                 </Link>
                 <span className="font-mono ml-auto text-right">{game.count}</span>
               </div>
-              <ul className="pl-4 list-disc">
+              <ul className="pl-4 list-disc relative z-10">
                 {game.nicknames.map((voter) => (
                   <li key={voter.id} className="text-white">
                     <span className="text-white">{voter.count}</span>{" "}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -494,7 +494,7 @@ export default function Home() {
                 </Link>
                 <span className="font-mono ml-auto text-right">{game.count}</span>
               </div>
-              <ul className="pl-4 list-disc">
+              <ul className="pl-4 list-disc relative z-10">
                 {game.nicknames.map((voter) => (
                   <li key={voter.id} className="text-white">
                     <span className="text-white">{voter.count}</span>{" "}


### PR DESCRIPTION
## Summary
- keep voter lists visible by raising their z-index

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688cf427920483209e87b6530ab4601f