### PR TITLE
Update grid layout across pages

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -232,7 +232,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
           ))}
         </ul>
       </div>
-      <div className="col-span-7 px-2 py-4 flex flex-col items-center justify-center">
+      <div className="col-span-6 px-2 py-4 flex flex-col items-center justify-center">
         {rouletteGames.length > 0 && !winner && (
           <>
             <RouletteWheel

--- a/frontend/app/archive/page.tsx
+++ b/frontend/app/archive/page.tsx
@@ -89,7 +89,7 @@ export default function ArchivePage() {
   }
 
   return (
-    <main className="col-span-10 p-4 max-w-xl space-y-4">
+    <main className="col-span-9 p-4 max-w-xl space-y-4">
       <h1 className="text-2xl font-semibold">Roulette Archive</h1>
       <ul className="space-y-2">
         <li className="border-2 border-purple-600 p-2 rounded-lg bg-purple-50">

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -68,7 +68,7 @@ export default function GamePage({ params }: { params: Promise<{ id: string }> }
   );
 
   return (
-    <main className="col-span-10 p-4 max-w-xl space-y-4">
+    <main className="col-span-9 p-4 max-w-xl space-y-4">
       <Link href="/games" className="text-purple-600 underline">
         Back to games
       </Link>

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -156,7 +156,7 @@ export default function GamesPage() {
 
   return (
     <>
-    <main className="col-span-10 p-4 max-w-xl space-y-6">
+    <main className="col-span-9 p-4 max-w-xl space-y-6">
       <h1 className="text-2xl font-semibold">Games</h1>
       {isModerator && (
         <button

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -96,7 +96,7 @@ export default function RootLayout({
         <main className="mt-4 flex-grow">
           <div className="container mx-auto px-0 grid grid-cols-12 gap-x-2 gap-y-4">
             {children}
-            <div className="col-span-2 col-start-11 space-y-4">
+            <div className="col-span-3 col-start-10 space-y-4">
               <EventLog />
               <TwitchVideos />
               <TwitchClips />

--- a/frontend/app/new-poll/page.tsx
+++ b/frontend/app/new-poll/page.tsx
@@ -122,7 +122,7 @@ function NewPollPageContent() {
 
   return (
     <>
-      <main className="col-span-10 p-4 max-w-xl space-y-4">
+      <main className="col-span-9 p-4 max-w-xl space-y-4">
       <h1 className="text-2xl font-semibold">New Roulette</h1>
       <div className="flex items-center space-x-2">
         <label className="text-sm">Add to archive only:</label>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -452,7 +452,7 @@ export default function Home() {
 
   return (
     <>
-      <main className="col-span-10 grid grid-cols-8 gap-x-2 gap-y-4 max-w-5xl">
+      <main className="col-span-9 grid grid-cols-9 gap-x-2 gap-y-4 max-w-5xl">
         <div className="col-span-3 px-2 py-4 space-y-4 overflow-y-auto">
         <h1 className="text-2xl font-semibold">Current Poll</h1>
         {isModerator && (
@@ -567,7 +567,7 @@ export default function Home() {
         You have used {usedVotes} of {voteLimit} votes.
       </p>
         </div>
-        <div className="col-span-5 px-2 py-4 flex flex-col items-center justify-center">
+        <div className="col-span-6 px-2 py-4 flex flex-col items-center justify-center">
         {rouletteGames.length > 0 && !winner && (
           <>
             <RouletteWheel

--- a/frontend/app/playlists/page.tsx
+++ b/frontend/app/playlists/page.tsx
@@ -156,7 +156,7 @@ export default function PlaylistsPage() {
   const tags = Object.keys(data).sort();
 
   return (
-    <main className="col-span-10 p-4 max-w-2xl space-y-6">
+    <main className="col-span-9 p-4 max-w-2xl space-y-6">
       <h1 className="text-2xl font-semibold">Playlists</h1>
       {tags.map((tag) => (
         <PlaylistRow key={tag} tag={tag} videos={data[tag]} />

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -121,7 +121,7 @@ export default function SettingsPage() {
   if (!isModerator) return <div className="p-4">Access denied.</div>;
 
   return (
-    <main className="col-span-10 p-4 max-w-xl space-y-4">
+    <main className="col-span-9 p-4 max-w-xl space-y-4">
       <h1 className="text-2xl font-semibold">Settings</h1>
       {rewards.length === 0 ? (
         <p>No rewards found.</p>

--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -56,7 +56,7 @@ export default function StatsPage() {
   if (loading) return <div className="p-4">Loading...</div>;
 
   return (
-    <main className="col-span-10 p-4 max-w-xl space-y-6">
+    <main className="col-span-9 p-4 max-w-xl space-y-6">
       <h1 className="text-2xl font-semibold">Statistics</h1>
       <section className="space-y-2">
         <h2 className="text-xl font-semibold mb-2">Most Popular Games</h2>

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -170,7 +170,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   if (!user) return <div className="p-4">User not found.</div>;
 
   return (
-    <main className="col-span-10 p-4 max-w-xl space-y-4">
+    <main className="col-span-9 p-4 max-w-xl space-y-4">
       <Link href="/users" className="text-purple-600 underline">
         Back to users
       </Link>

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -58,7 +58,7 @@ export default function UsersPage() {
   }
 
   return (
-    <main className="col-span-10 p-4 max-w-xl space-y-4">
+    <main className="col-span-9 p-4 max-w-xl space-y-4">
       <h1 className="text-2xl font-semibold">Users</h1>
       <input
         type="text"


### PR DESCRIPTION
## Summary
- adjust the sidebar to take 3 columns
- span main content over 9 columns
- split roulette/game areas on main & archive pages to 6/3 columns

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688d3bd7ee488320a37b900a260b8557