### PR TITLE
Start roulette content at top

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -232,7 +232,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
           ))}
         </ul>
       </div>
-      <div className="col-span-6 px-2 py-4 flex flex-col items-center justify-center">
+      <div className="col-span-6 px-2 py-4 flex flex-col items-center justify-start">
         {rouletteGames.length > 0 && !winner && (
           <>
             <RouletteWheel

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -567,7 +567,7 @@ export default function Home() {
         You have used {usedVotes} of {voteLimit} votes.
       </p>
         </div>
-        <div className="col-span-6 px-2 py-4 flex flex-col items-center justify-center">
+        <div className="col-span-6 px-2 py-4 flex flex-col items-center justify-start">
         {rouletteGames.length > 0 && !winner && (
           <>
             <RouletteWheel


### PR DESCRIPTION
## Summary
- Align roulette wheel container at top on homepage
- Align roulette wheel container at top on archive game page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688da97232b08320ab5e191c435311b1