### PR TITLE
Only query Twitch roles for channel owner

### DIFF
--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -129,26 +129,27 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         const uid = me.id as string;
 
         const r: string[] = [];
-        if (channelId && uid === channelId) r.push('Streamer');
 
-        const query = `broadcaster_id=${channelId}&user_id=${uid}`;
-        const checkRole = async (url: string, name: string) => {
-          try {
-            const resp = await fetchWithRefresh(
-              `${backendUrl}/api/get-stream?endpoint=${url}&${query}`
-            );
-            if (!resp || !resp.ok) return;
-            const d = await resp.json();
-            if (d.data && d.data.length > 0) r.push(name);
-          } catch {
-            // ignore
-          }
-        };
+        if (channelId && uid === channelId) {
+          r.push('Streamer');
 
-        const checkSub = () =>
-          fetchSubscriptionRole(backendUrl, query, headers, r);
+          const query = `broadcaster_id=${channelId}&user_id=${uid}`;
+          const checkRole = async (url: string, name: string) => {
+            try {
+              const resp = await fetchWithRefresh(
+                `${backendUrl}/api/get-stream?endpoint=${url}&${query}`
+              );
+              if (!resp || !resp.ok) return;
+              const d = await resp.json();
+              if (d.data && d.data.length > 0) r.push(name);
+            } catch {
+              // ignore
+            }
+          };
 
-        if (channelId) {
+          const checkSub = () =>
+            fetchSubscriptionRole(backendUrl, query, headers, r);
+
           await checkRole('moderation/moderators', 'Mod');
           await checkRole('channels/vips', 'VIP');
           await checkSub();
@@ -177,11 +178,12 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       <h1 className="text-2xl font-semibold flex items-center space-x-2">
         {user.logged_in && session && session.user.id === user.auth_id && (
           <>
-            {roles.map((r) =>
-              ROLE_ICONS[r] ? (
-                <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-6 h-6" />
-              ) : null
-            )}
+            {roles.length > 0 &&
+              roles.map((r) =>
+                ROLE_ICONS[r] ? (
+                  <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-6 h-6" />
+                ) : null
+              )}
             {profileUrl && (
               <img
                 src={profileUrl}

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -107,26 +107,27 @@ export default function AuthStatus() {
         const uid = me.id as string;
 
         const r: string[] = [];
-        if (channelId && uid === channelId) r.push('Streamer');
 
-        const query = `broadcaster_id=${channelId}&user_id=${uid}`;
-        const checkRole = async (url: string, name: string) => {
-          try {
-            const resp = await fetchWithRefresh(
-              `${backendUrl}/api/get-stream?endpoint=${url}&${query}`
-            );
-            if (!resp || !resp.ok) return; // likely missing scope
-            const d = await resp.json();
-            if (d.data && d.data.length > 0) r.push(name);
-          } catch {
-            // ignore
-          }
-        };
+        if (channelId && uid === channelId) {
+          r.push('Streamer');
 
-        const checkSub = () =>
-          fetchSubscriptionRole(backendUrl, query, headers, r);
+          const query = `broadcaster_id=${channelId}&user_id=${uid}`;
+          const checkRole = async (url: string, name: string) => {
+            try {
+              const resp = await fetchWithRefresh(
+                `${backendUrl}/api/get-stream?endpoint=${url}&${query}`
+              );
+              if (!resp || !resp.ok) return; // likely missing scope
+              const d = await resp.json();
+              if (d.data && d.data.length > 0) r.push(name);
+            } catch {
+              // ignore
+            }
+          };
 
-        if (channelId) {
+          const checkSub = () =>
+            fetchSubscriptionRole(backendUrl, query, headers, r);
+
           await checkRole('moderation/moderators', 'Mod');
           await checkRole('channels/vips', 'VIP');
           await checkSub();
@@ -184,11 +185,12 @@ export default function AuthStatus() {
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" className="flex items-center space-x-2">
           <span className="flex items-center space-x-1 truncate max-w-xs">
-            {roles.map((r) =>
-              ROLE_ICONS[r] ? (
-                <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
-              ) : null
-            )}
+            {roles.length > 0 &&
+              roles.map((r) =>
+                ROLE_ICONS[r] ? (
+                  <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
+                ) : null
+              )}
             {username}
           </span>
           {profileUrl && (

--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -64,23 +64,24 @@ export function useTwitchUserInfo(authId: string | null) {
         const uid = me.id as string;
 
         const r: string[] = [];
-        if (channelId && uid === channelId) r.push("Streamer");
 
-        const query = `broadcaster_id=${channelId}&user_id=${uid}`;
-        const checkRole = async (url: string, name: string) => {
-          try {
-            const resp = await fetchWithRefresh(
-              `${backendUrl}/api/get-stream?endpoint=${url}&${query}`
-            );
-            if (!resp || !resp.ok) return;
-            const d = await resp.json();
-            if (d.data && d.data.length > 0) r.push(name);
-          } catch {
-            // ignore
-          }
-        };
+        if (channelId && uid === channelId) {
+          r.push("Streamer");
 
-        if (channelId) {
+          const query = `broadcaster_id=${channelId}&user_id=${uid}`;
+          const checkRole = async (url: string, name: string) => {
+            try {
+              const resp = await fetchWithRefresh(
+                `${backendUrl}/api/get-stream?endpoint=${url}&${query}`
+              );
+              if (!resp || !resp.ok) return;
+              const d = await resp.json();
+              if (d.data && d.data.length > 0) r.push(name);
+            } catch {
+              // ignore
+            }
+          };
+
           await checkRole("moderation/moderators", "Mod");
           await checkRole("channels/vips", "VIP");
           await fetchSubscriptionRole(backendUrl, query, headers, r);


### PR DESCRIPTION
## Summary
- Only run Twitch role and subscription lookups when the authenticated user matches the channel owner
- Guard role icon rendering so empty role lists don't produce errors

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688ddb3d75348320a2ebdda23d624f68