### PR TITLE
Handle missing session before refreshing provider token

### DIFF
--- a/frontend/lib/twitch.ts
+++ b/frontend/lib/twitch.ts
@@ -63,6 +63,15 @@ export function getStoredProviderToken(): string | undefined {
 // that subsequent requests can reuse it without another refresh.
 export async function refreshProviderToken(): Promise<string | undefined> {
   try {
+    const {
+      data: sessionData,
+      error: sessionError,
+    } = await supabase.auth.getSession();
+    if (sessionError || !sessionData.session) {
+      storeProviderToken(undefined);
+      return undefined;
+    }
+
     const { data, error } = await supabase.auth.refreshSession();
     if (error) throw error;
     const token = (data.session as any)?.provider_token as string | undefined;


### PR DESCRIPTION
## Summary
- Prevent refresh attempts when no Supabase session is available
- Clear stored provider token when session is absent
- Persist refreshed token only when session exists

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688ddc91c9e88320960d4aca3dac75b7