### PR TITLE
Handle Supabase auth callback errors

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { supabase } from "@/lib/supabase";
 
 export default function AuthCallback() {
   const router = useRouter();
   const exchanged = useRef(false);
+  const [authError, setAuthError] = useState<string | null>(null);
 
   useEffect(() => {
     const exchange = async () => {
@@ -15,12 +16,21 @@ export default function AuthCallback() {
       const url = new URL(window.location.href);
       const code = url.searchParams.get("code");
       if (code) {
-        await (supabase.auth as any).exchangeCodeForSession(code);
+        const { error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error) {
+          console.error(error.message);
+          setAuthError(error.message);
+          return;
+        }
       }
       router.replace("/");
     };
     exchange();
   }, [router]);
+
+  if (authError) {
+    return <p className="p-4">Login failed: {authError}</p>;
+  }
 
   return <p className="p-4">Logging in...</p>;
 }


### PR DESCRIPTION
## Summary
- log Supabase auth callback failures
- show error message to the user instead of redirecting

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688de8c97df8832088238484f0045e48