### PR TITLE
Handle provider token refresh errors

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -72,8 +72,8 @@ export default function SettingsPage() {
             { headers }
           );
           if (r.status === 401) {
-            const newToken = await refreshProviderToken();
-            if (!newToken) {
+            const { token: newToken, error } = await refreshProviderToken();
+            if (error || !newToken) {
               await supabase.auth.signOut();
               storeProviderToken(undefined);
               throw new Error('unauthorized');

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -104,8 +104,8 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
     const fetchWithRefresh = async (url: string) => {
       let resp = await fetch(url, { headers });
       if (resp.status === 401) {
-        const newToken = await refreshProviderToken();
-        if (!newToken) {
+        const { token: newToken, error } = await refreshProviderToken();
+        if (error || !newToken) {
           await supabase.auth.signOut();
           storeProviderToken(undefined);
           return null;

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -82,10 +82,11 @@ export default function AuthStatus() {
     const fetchWithRefresh = async (url: string) => {
       let resp = await fetch(url, { headers });
       if (resp.status === 401) {
-        const newToken = await refreshProviderToken();
-        if (!newToken) {
+        const { token: newToken, error } = await refreshProviderToken();
+        if (error || !newToken) {
           await supabase.auth.signOut();
           storeProviderToken(undefined);
+          alert('Session expired. Please log in again.');
           return null;
         }
         headers.Authorization = `Bearer ${newToken}`;

--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -39,8 +39,8 @@ export function useTwitchUserInfo(authId: string | null) {
     const fetchWithRefresh = async (url: string) => {
       let resp = await fetch(url, { headers });
       if (resp.status === 401) {
-        const newToken = await refreshProviderToken();
-        if (!newToken) {
+        const { token: newToken, error } = await refreshProviderToken();
+        if (error || !newToken) {
           await supabase.auth.signOut();
           storeProviderToken(undefined);
           return null;


### PR DESCRIPTION
## Summary
- make refreshProviderToken return structured result with error flag and log refresh time
- stop actions and alert user when Twitch token refresh fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688de9480ed883208065f6a1ae76d5b8