### PR TITLE
Handle Twitch token refresh errors and prompt reauthentication

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -72,10 +72,13 @@ export default function SettingsPage() {
             { headers }
           );
           if (r.status === 401) {
-            const newToken = await refreshProviderToken();
-            if (!newToken) {
+            const { token: newToken, error } = await refreshProviderToken();
+            if (error || !newToken) {
               await supabase.auth.signOut();
               storeProviderToken(undefined);
+              if (typeof window !== 'undefined') {
+                alert('Session expired. Please authorize again.');
+              }
               throw new Error('unauthorized');
             }
             headers.Authorization = `Bearer ${newToken}`;

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -104,10 +104,13 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
     const fetchWithRefresh = async (url: string) => {
       let resp = await fetch(url, { headers });
       if (resp.status === 401) {
-        const newToken = await refreshProviderToken();
-        if (!newToken) {
+        const { token: newToken, error } = await refreshProviderToken();
+        if (error || !newToken) {
           await supabase.auth.signOut();
           storeProviderToken(undefined);
+          if (typeof window !== 'undefined') {
+            alert('Session expired. Please authorize again.');
+          }
           return null;
         }
         headers.Authorization = `Bearer ${newToken}`;

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -82,10 +82,11 @@ export default function AuthStatus() {
     const fetchWithRefresh = async (url: string) => {
       let resp = await fetch(url, { headers });
       if (resp.status === 401) {
-        const newToken = await refreshProviderToken();
-        if (!newToken) {
+        const { token: newToken, error } = await refreshProviderToken();
+        if (error || !newToken) {
           await supabase.auth.signOut();
           storeProviderToken(undefined);
+          alert('Session expired. Please authorize again.');
           return null;
         }
         headers.Authorization = `Bearer ${newToken}`;

--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -39,10 +39,13 @@ export function useTwitchUserInfo(authId: string | null) {
     const fetchWithRefresh = async (url: string) => {
       let resp = await fetch(url, { headers });
       if (resp.status === 401) {
-        const newToken = await refreshProviderToken();
-        if (!newToken) {
+        const { token: newToken, error } = await refreshProviderToken();
+        if (error || !newToken) {
           await supabase.auth.signOut();
           storeProviderToken(undefined);
+          if (typeof window !== 'undefined') {
+            alert('Session expired. Please authorize again.');
+          }
           return null;
         }
         headers.Authorization = `Bearer ${newToken}`;


### PR DESCRIPTION
## Summary
- Return structured result from `refreshProviderToken` with error flag and log refresh time
- Check error flag when refreshing tokens in Twitch helpers and components; alert users to reauthenticate on failure
- Update various token refresh call sites to use new error-aware logic

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dedd8940c8320ab5d657a425b3dfd