### PR TITLE
feat: validate pkce exchange

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,6 +27,13 @@ set the required values. The build step (`npm run build`) relies on variables su
 `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` being defined.
 See `.env.example` for the full list.
 
+### Manual auth callback test
+
+1. Run the app with `npm run dev` and start the login flow.
+2. After being redirected back to `/auth/callback`, verify the URL contains a `code` parameter.
+3. Check `localStorage` for a key starting with `sb-cv-` – it stores the `code_verifier` used for PKCE.
+4. If both values exist, the app should redirect to `/` and create a session without a 400 error.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -14,15 +14,35 @@ export default function AuthCallback() {
       if (exchanged.current) return;
       exchanged.current = true;
       const url = new URL(window.location.href);
-      const code = url.searchParams.get("code");
-      if (code) {
-        const { error } = await supabase.auth.exchangeCodeForSession(code);
-        if (error) {
-          console.error(error.message);
-          setAuthError(error.message);
-          return;
-        }
+
+      let code = url.searchParams.get("code");
+      if (!code) {
+        const hashParams = new URLSearchParams(url.hash.slice(1));
+        code = hashParams.get("code");
       }
+
+      if (!code) {
+        setAuthError("Missing code parameter");
+        return;
+      }
+
+      const hasVerifier = Object.keys(localStorage).some((key) =>
+        key.startsWith("sb-cv-")
+      );
+
+      if (!hasVerifier) {
+        console.error("Missing PKCE code verifier in localStorage");
+        setAuthError("Missing code verifier");
+        return;
+      }
+
+      const { error } = await supabase.auth.exchangeCodeForSession(code);
+      if (error) {
+        console.error(error.message);
+        setAuthError(error.message);
+        return;
+      }
+
       router.replace("/");
     };
     exchange();


### PR DESCRIPTION
## Summary
- handle `code` from query or hash and ensure a PKCE `code_verifier` exists before exchanging
- document manual auth callback test steps

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_688df1caaf148320a78ec13faa25d91a