### PR TITLE
Handle missing PKCE verifier in auth callback

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -26,19 +26,13 @@ export default function AuthCallback() {
         return;
       }
 
-      const hasVerifier = Object.keys(localStorage).some((key) =>
-        key.startsWith("sb-cv-")
-      );
-
-      if (!hasVerifier) {
-        console.error("Missing PKCE code verifier in localStorage");
-        setAuthError("Missing code verifier");
-        return;
-      }
-
       const { error } = await supabase.auth.exchangeCodeForSession(code);
       if (error) {
         console.error(error.message);
+        if (error.message.toLowerCase().includes("code verifier")) {
+          setAuthError("Missing code verifier. Please restart the login flow.");
+          return;
+        }
         setAuthError(error.message);
         return;
       }


### PR DESCRIPTION
## Summary
- remove manual localStorage scan for PKCE verifier
- handle `exchangeCodeForSession` errors and prompt user to restart login when verifier missing

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e0148a4a48320b3098c4aa2977a8e