### PR TITLE
Handle existing session and restart auth on missing code verifier

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -14,6 +14,14 @@ export default function AuthCallback() {
     const exchange = async () => {
       if (exchanged.current) return;
       exchanged.current = true;
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (session) {
+        router.replace("/");
+        return;
+      }
+
       const url = new URL(window.location.href);
 
       let code = url.searchParams.get("code");
@@ -30,7 +38,8 @@ export default function AuthCallback() {
       const { error } = await supabase.auth.exchangeCodeForSession(code);
       if (error) {
         if (error.message.toLowerCase().includes("code verifier")) {
-          setAuthError("Missing code verifier. Please restart the login flow.");
+          await supabase.auth.signOut();
+          router.replace("/");
           return;
         }
         setAuthError(error.message);


### PR DESCRIPTION
## Summary
- Avoid redundant auth exchange by checking for an existing Supabase session before processing the callback.
- On missing PKCE code verifier, sign out and redirect to restart authentication.

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_688e0d23f73c83208f7a0f6cc20c2051