### PR TITLE
docs: clarify Twitch OAuth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,14 @@ TWITCH_SECRET=your-client-secret
 NEXT_PUBLIC_TWITCH_CHANNEL_ID=your-channel-id
 ```
 Configure the same URLs in the Supabase dashboard for both local development
-and production. The app requests the following Twitch OAuth scopes when logging
-in:
+and production. The app requests the following Twitch OAuth scope for normal
+logins:
+
+```
+user:read:email
+```
+The streamer should use the "Streamer login" option to grant these additional
+scopes:
 
 ```
 moderation:read


### PR DESCRIPTION
## Summary
- document that normal logins only request `user:read:email`
- note that streamers should use **Streamer login** to grant `moderation:read`, `channel:read:vips`, `channel:read:subscriptions`, and `channel:read:redemptions`

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e50bbee5c8320b21ab41550ce9c05