### PR TITLE
Disable font preloading for Geist fonts

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -11,11 +11,13 @@ import "./globals.css";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  preload: false,
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  preload: false,
 });
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary
- disable font preloading for Geist fonts to silence preload warnings

## Testing
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e54d963088320a9a2fa2c04f88088