### PR TITLE
Handle EventLog fetch errors gracefully

### DIFF
--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -68,11 +68,12 @@ export default function EventLog() {
   useEffect(() => {
     if (!backendUrl) return;
 
-    const fetchLogs = () => {
+    const fetchLogs = async () => {
       const token = session?.access_token;
-      fetch(`${backendUrl}/api/logs?limit=10`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-      }).then(async (res) => {
+      try {
+        const res = await fetch(`${backendUrl}/api/logs?limit=10`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        });
         if (!res.ok) {
           setError("Failed to fetch logs");
           return;
@@ -80,7 +81,9 @@ export default function EventLog() {
         const data = await res.json();
         setError(null);
         setLogs((data.logs || []) as LogEntry[]);
-      });
+      } catch {
+        setError("Failed to fetch logs");
+      }
     };
 
     fetchLogs();

--- a/frontend/components/__tests__/EventLog.test.tsx
+++ b/frontend/components/__tests__/EventLog.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+process.env.NEXT_PUBLIC_BACKEND_URL = 'http://backend';
+
+import EventLog from '../EventLog';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: jest.fn(() => ({ data: { subscription: { unsubscribe: jest.fn() } } })),
+    },
+  },
+}));
+
+describe('EventLog', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockRejectedValue(new Error('network'));
+  });
+
+  it('handles fetch errors gracefully', async () => {
+    render(<EventLog />);
+    await waitFor(() =>
+      expect(screen.getByText('Failed to fetch logs')).toBeInTheDocument()
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- handle network errors when fetching event logs
- add EventLog test covering failed fetches

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e57766a4083208eecc22ad8ce5f95