### PR TITLE
Expand Twitch OAuth scopes and scope warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,23 +65,23 @@ TWITCH_SECRET=your-client-secret
 NEXT_PUBLIC_TWITCH_CHANNEL_ID=your-channel-id
 ```
 Configure the same URLs in the Supabase dashboard for both local development
-and production. The app requests the following Twitch OAuth scope for normal
+and production. The app requests the following Twitch OAuth scopes for normal
 logins:
 
 ```
 user:read:email
-```
-The streamer should use the "Streamer login" option to grant these additional
-scopes:
-
-```
 moderation:read
 channel:read:vips
 channel:read:subscriptions
+```
+The streamer can use the "Streamer login" option to grant the additional scope:
+
+```
 channel:read:redemptions
 ```
 These allow the frontend to check whether the user is a moderator, VIP or
-subscriber of the configured channel.
+subscriber of the configured channel and fetch channel point rewards when
+authorized as the streamer.
 
 3. Run the backend and frontend:
 

--- a/frontend/components/__tests__/AuthStatus.test.tsx
+++ b/frontend/components/__tests__/AuthStatus.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, act } from '@testing-library/react';
+import { render, waitFor, act, screen } from '@testing-library/react';
 
 const mockSession = {
   user: { id: '123', user_metadata: {} },
@@ -192,6 +192,9 @@ describe('AuthStatus role checks', () => {
     expect(urls.some((u: string) => u.includes('channels/vips'))).toBe(false);
     expect(fetchSubscriptionRole).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByText(/Missing Twitch scopes/)
+    ).toBeInTheDocument();
 
     warnSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- expand login OAuth scopes to include moderation, VIP, and subscription reads
- warn in the UI when required Twitch scopes are missing and prompt users to reauthorize
- document new default OAuth scopes in README

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f6943a7388320b7df88bd40210ed4