### PR TITLE
Trigger Twitch reauth when scopes are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ The streamer can use the "Streamer login" option to grant the additional scope:
 ```
 channel:read:redemptions
 ```
+To enable these scopes, open the Supabase dashboard and navigate to
+**Authentication → Providers → Twitch**. Enter the scopes above in the
+**Additional scopes** field so Supabase includes them during OAuth.
 These allow the frontend to check whether the user is a moderator, VIP or
 subscriber of the configured channel and fetch channel point rewards when
 authorized as the streamer.

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -113,7 +113,7 @@ export default function AuthStatus() {
           setRoles([]);
           setProfileUrl(null);
           setScopeWarning(
-            'Authorization is missing required Twitch scopes. Please reauthorize.'
+            'Authorization is missing required Twitch scopes. Please log in again.'
           );
           return;
         }
@@ -154,8 +154,11 @@ export default function AuthStatus() {
             `Missing scopes: ${missing.join(', ')}; skipping corresponding role checks`
           );
           setScopeWarning(
-            `Missing Twitch scopes (${missing.join(', ')}). Reauthorize to grant them.`
+            `Missing Twitch scopes (${missing.join(', ')}). Redirecting to log in again to grant them.`
           );
+          if (typeof (supabase.auth as any).signInWithOAuth === 'function') {
+            handleLogin();
+          }
         } else {
           setScopeWarning(null);
         }


### PR DESCRIPTION
## Summary
- trigger Twitch OAuth login automatically when required scopes are absent and inform users to log in again
- document required Twitch scopes and how to configure them in Supabase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f6cc71e908320b88d518ac63962ab