### PR TITLE
Handle missing Twitch scopes for privileged users

### DIFF
--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -128,6 +128,7 @@ export default function AuthStatus() {
         }
 
         const r: string[] = [];
+        let missingScopes = false;
         if (uid === channelId) {
           r.push('Streamer');
         }
@@ -158,6 +159,9 @@ export default function AuthStatus() {
             }
             if (!resp || resp.status === 401) {
               console.warn(`${name} role check unauthorized`);
+              if (!useStreamer) {
+                missingScopes = true;
+              }
               return;
             }
             if (!resp.ok) {
@@ -193,6 +197,9 @@ export default function AuthStatus() {
               headers,
               r
             );
+            if (res === 'unauthorized') {
+              missingScopes = true;
+            }
             if (res !== 'ok') {
               console.warn(`Subscription role check result: ${res}`);
             }
@@ -204,6 +211,13 @@ export default function AuthStatus() {
         await checkSub();
 
         setRoles(r);
+        if (missingScopes && (r.includes('Streamer') || r.includes('Mod'))) {
+          setScopeWarning(
+            'Для проверки ролей нужен повторный вход с дополнительными правами…'
+          );
+        } else {
+          setScopeWarning(null);
+        }
       } catch (e) {
         console.error('Twitch API error', e);
         setRoles([]);


### PR DESCRIPTION
## Summary
- Detect missing Twitch authorization scopes in `AuthStatus`
- Warn only streamers and mods to reauthorize with extra scopes
- Expand tests for auth status and Twitch token refresh

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fb647801c83208c38d6e9cab7721a