### PR TITLE
Add Twitch streamer token configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ These allow the frontend to check whether the user is a moderator, VIP or
 subscriber of the configured channel and fetch channel point rewards when
 authorized as the streamer.
 
+To avoid requesting these scopes from every viewer, generate a Twitch OAuth
+token for the streamer account (for example via https://twitchapps.com/tmi/)
+and store it in the backend `.env` file as `TWITCH_STREAMER_TOKEN`. When
+deploying to Render or another hosting platform, set the `TWITCH_STREAMER_TOKEN`
+environment variable there with a valid token.
+
 3. Run the backend and frontend:
 
 ```bash
@@ -105,7 +111,10 @@ Use the “New Roulette” button on the `/archive` page to open `/new-poll` and
 
 ## Deployment
 
- - **Render**: Create a new Web Service, set Node 18, and point it to the `backend/` folder. The backend has a no-op `build` script so you can keep the default build command `npm run build`.
+- **Render**: Create a new Web Service, set Node 18, and point it to the
+  `backend/` folder. The backend has a no-op `build` script so you can keep the
+  default build command `npm run build`. Add `TWITCH_STREAMER_TOKEN` and other
+  required variables in the service's environment settings.
 - **Vercel**: Import the repository, set the project root to `frontend/`, and add
   `NEXT_PUBLIC_BACKEND_URL` in the environment variables (e.g.
   `https://terrenkur.onrender.com`).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,8 @@ FRONTEND_URLS=http://localhost:3000
 TWITCH_CLIENT_ID=
 TWITCH_SECRET=
 TWITCH_CHANNEL_ID=81300263
+# OAuth token for the streamer account (generate via https://twitchapps.com/tmi/)
+TWITCH_STREAMER_TOKEN=
 # OAuth callback URL, e.g. http://localhost:3000/auth/callback
 OAUTH_CALLBACK_URL=http://localhost:3000/auth/callback
 ADMIN_TOKEN=


### PR DESCRIPTION
## Summary
- document how to obtain a Twitch streamer OAuth token and record it in `TWITCH_STREAMER_TOKEN`
- include `TWITCH_STREAMER_TOKEN` in backend env example and deployment instructions

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb9f62f448320804d8880c9d3b25b