### PR TITLE
feat: add optional Twitch role support

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,6 +3,7 @@ NEXT_PUBLIC_SUPABASE_URL=<SUPABASE_URL>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<SUPABASE_ANON_KEY>
 TWITCH_SECRET=
 NEXT_PUBLIC_TWITCH_CHANNEL_ID=<TWITCH_CHANNEL_ID>
+NEXT_PUBLIC_ENABLE_TWITCH_ROLES=false
 # OAuth callback URL. Configure this in the Twitch dashboard as
 # http://localhost:3000/auth/callback for local development
 OAUTH_CALLBACK_URL=http://localhost:3000/auth/callback

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,7 +25,9 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 Before running the app or building for production, copy `.env.example` to `.env.local` and
 set the required values. The build step (`npm run build`) relies on variables such as
 `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` being defined.
-See `.env.example` for the full list.
+See `.env.example` for the full list. Set `NEXT_PUBLIC_ENABLE_TWITCH_ROLES=true`
+to enable Twitch role fetching and the streamer login menu; it defaults to
+`false`.
 
 ### Streamer token
 

--- a/frontend/components/__tests__/AuthStatus.test.tsx
+++ b/frontend/components/__tests__/AuthStatus.test.tsx
@@ -67,6 +67,7 @@ describe('AuthStatus role checks', () => {
     (fetchSubscriptionRole as jest.Mock).mockResolvedValue('ok');
     process.env.NEXT_PUBLIC_BACKEND_URL = 'http://backend';
     process.env.NEXT_PUBLIC_TWITCH_CHANNEL_ID = '123';
+    process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES = 'true';
     authStateChangeCb = null;
     mockSession.user.id = '123';
   });
@@ -187,6 +188,24 @@ describe('AuthStatus role checks', () => {
       false
     );
     expect(fetchSubscriptionRole).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText(/Для проверки ролей нужен повторный вход/)
+    ).toBeNull();
+  });
+
+  it('disables role checks when flag is off', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES = 'false';
+    const fetchMock = jest.fn();
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    render(<AuthStatus />);
+
+    await waitFor(() => {
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText('Streamer login')).toBeNull();
     expect(
       screen.queryByText(/Для проверки ролей нужен повторный вход/)
     ).toBeNull();


### PR DESCRIPTION
## Summary
- gate Twitch role fetching behind `NEXT_PUBLIC_ENABLE_TWITCH_ROLES`
- request minimal OAuth scope when roles are disabled and hide streamer login UI
- document new env var and add tests for toggling roles

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688ff412c54c8320a7a86d7754d81dbb