### PR TITLE
feat: add twitch roles toggle

### DIFF
--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -13,6 +13,8 @@ export function useTwitchUserInfo(authId: string | null) {
   const [profileUrl, setProfileUrl] = useState<string | null>(null);
   const [roles, setRoles] = useState<string[]>([]);
 
+  const enableRoles = process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES === "true";
+
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => setSession(session));
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, sess) => setSession(sess));
@@ -64,8 +66,13 @@ export function useTwitchUserInfo(authId: string | null) {
         const me = userData.data?.[0];
         if (!me) throw new Error("user");
         setProfileUrl(me.profile_image_url);
-        const uid = me.id as string;
 
+        if (!enableRoles) {
+          setRoles([]);
+          return;
+        }
+
+        const uid = me.id as string;
         const r: string[] = [];
 
         const validateRes = await fetchWithRefresh(
@@ -113,7 +120,7 @@ export function useTwitchUserInfo(authId: string | null) {
     };
 
     fetchInfo();
-  }, [authId, session]);
+  }, [authId, session, enableRoles]);
 
   return { profileUrl, roles };
 }


### PR DESCRIPTION
## Summary
- allow disabling Twitch role lookups via NEXT_PUBLIC_ENABLE_TWITCH_ROLES
- return empty roles when disabled while still fetching profile image

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_688ff6e439c083209486d0af17d7d0c6