### PR TITLE
feat: gate streamer token route behind flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ authorized as the streamer.
 
 To avoid requesting these scopes from every viewer, generate a Twitch OAuth
 token for the streamer account (for example via https://twitchapps.com/tmi/)
-and store it in the backend `.env` file as `TWITCH_STREAMER_TOKEN`. When
-deploying to Render or another hosting platform, set the `TWITCH_STREAMER_TOKEN`
-environment variable there with a valid token.
+and store it in the backend `.env` file as `TWITCH_STREAMER_TOKEN`. The
+`/api/streamer-token` endpoint is disabled by default; set
+`ENABLE_TWITCH_ROLE_CHECKS=true` alongside `TWITCH_STREAMER_TOKEN` to enable it.
+When deploying to Render or another hosting platform, set these environment
+variables there as well.
 
 3. Run the backend and frontend:
 
@@ -113,8 +115,9 @@ Use the “New Roulette” button on the `/archive` page to open `/new-poll` and
 
 - **Render**: Create a new Web Service, set Node 18, and point it to the
   `backend/` folder. The backend has a no-op `build` script so you can keep the
-  default build command `npm run build`. Add `TWITCH_STREAMER_TOKEN` and other
-  required variables in the service's environment settings.
+  default build command `npm run build`. Add `TWITCH_STREAMER_TOKEN` and, if
+  role checks are needed, set `ENABLE_TWITCH_ROLE_CHECKS=true` in the service's
+  environment settings along with other required variables.
 - **Vercel**: Import the repository, set the project root to `frontend/`, and add
   `NEXT_PUBLIC_BACKEND_URL` in the environment variables (e.g.
   `https://terrenkur.onrender.com`).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,8 @@ TWITCH_SECRET=
 TWITCH_CHANNEL_ID=81300263
 # OAuth token for the streamer account (generate via https://twitchapps.com/tmi/)
 TWITCH_STREAMER_TOKEN=
+# Enable Twitch role checks and the /api/streamer-token route
+ENABLE_TWITCH_ROLE_CHECKS=false
 # OAuth callback URL, e.g. http://localhost:3000/auth/callback
 OAUTH_CALLBACK_URL=http://localhost:3000/auth/callback
 ADMIN_TOKEN=

--- a/backend/server.js
+++ b/backend/server.js
@@ -139,14 +139,21 @@ app.get('/api/get-stream', async (req, res) => {
   }
 });
 
+const ENABLE_TWITCH_ROLE_CHECKS =
+  process.env.ENABLE_TWITCH_ROLE_CHECKS === 'true';
+
 // Provide a pre-authorized streamer token for role checks
-app.get('/api/streamer-token', (_req, res) => {
-  const token = process.env.TWITCH_STREAMER_TOKEN;
-  if (!token) {
-    return res.status(404).json({ error: 'Streamer token not configured' });
-  }
-  res.json({ token });
-});
+if (ENABLE_TWITCH_ROLE_CHECKS) {
+  app.get('/api/streamer-token', (_req, res) => {
+    const token = process.env.TWITCH_STREAMER_TOKEN;
+    if (!token) {
+      return res
+        .status(404)
+        .json({ error: 'Streamer token not configured' });
+    }
+    res.json({ token });
+  });
+}
 
 let twitchToken = null;
 let twitchExpiry = 0;

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -35,7 +35,9 @@ Some Twitch role checks require elevated scopes such as `moderation:read`,
 `channel:read:vips` and `channel:read:subscriptions`. Instead of requesting
 these scopes from every viewer, the application can use a dedicated streamer
 token. The backend exposes `/api/streamer-token`, which should return a Twitch
-access token for the channel owner with the scopes listed above.
+access token for the channel owner with the scopes listed above. This route is
+disabled by default; set `ENABLE_TWITCH_ROLE_CHECKS=true` and provide
+`TWITCH_STREAMER_TOKEN` in the backend to enable it.
 
 Obtain a token by authorizing the streamer account with the Twitch OAuth flow
 including those scopes and store the resulting access token in a secure place,


### PR DESCRIPTION
## Summary
- add `ENABLE_TWITCH_ROLE_CHECKS` env flag (default `false`)
- register `/api/streamer-token` only when flag is enabled
- document how to enable Twitch role checks

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ffc932d4c83208d9c36d16787d7cf