### PR TITLE
test: add double spin transform test

### DIFF
--- a/frontend/components/__tests__/RouletteWheel.test.tsx
+++ b/frontend/components/__tests__/RouletteWheel.test.tsx
@@ -18,3 +18,96 @@ test('calls onDone after spin', () => {
   });
   expect(onDone).toHaveBeenCalled();
 });
+
+test('spins twice to expected angles', () => {
+  const onDone = jest.fn();
+  const ref = { current: null as RouletteWheelHandle | null };
+  const { container } = render(
+    <RouletteWheel
+      ref={ref}
+      games={games}
+      onDone={onDone}
+      spinSeed="seed"
+    />
+  );
+
+  const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+
+  const mulberry32 = (a: number) => {
+    return function () {
+      let t = (a += 0x6d2b79f5);
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  };
+
+  let seed = 0;
+  for (const ch of 'seed') {
+    seed = (seed * 31 + ch.charCodeAt(0)) >>> 0;
+  }
+  const rand = mulberry32(seed);
+
+  const rotations: number[] = [];
+  let rotation = 0;
+
+  const computeExpectedRotation = () => {
+    const maxVotes = games.reduce((m, g) => Math.max(m, g.count), 0);
+    const weighted = games.map((g) => ({
+      ...g,
+      weight:
+        g.count === 0
+          ? 40
+          : 1 + 2 * (maxVotes - g.count),
+    }));
+    const totalWeight = weighted.reduce((sum, g) => sum + g.weight, 0);
+
+    const rnd = rand() * totalWeight;
+    let cumulative = 0;
+    let selected = weighted[0];
+    for (const item of weighted) {
+      cumulative += item.weight;
+      if (rnd <= cumulative) {
+        selected = item;
+        break;
+      }
+    }
+
+    let angle = -Math.PI / 2;
+    for (const item of weighted) {
+      const slice = (item.weight / totalWeight) * Math.PI * 2;
+      if (item.id === selected.id) {
+        angle += slice / 2;
+        break;
+      }
+      angle += slice;
+    }
+
+    rand(); // duration random
+
+    const spins = 4;
+    const normalized = rotation % (2 * Math.PI);
+    const target =
+      rotation + spins * 2 * Math.PI + (Math.PI * 3) / 2 - angle - normalized;
+    rotation = target;
+    rotations.push(target);
+  };
+
+  // First spin
+  act(() => {
+    ref.current!.spin();
+    jest.runAllTimers();
+  });
+  computeExpectedRotation();
+  const angle1 = parseFloat(canvas.style.transform.replace(/[^0-9.-]/g, ''));
+  expect(angle1).toBeCloseTo(rotations[0]);
+
+  // Second spin
+  act(() => {
+    ref.current!.spin();
+    jest.runAllTimers();
+  });
+  computeExpectedRotation();
+  const angle2 = parseFloat(canvas.style.transform.replace(/[^0-9.-]/g, ''));
+  expect(angle2).toBeCloseTo(rotations[1]);
+});


### PR DESCRIPTION
## Summary
- add test ensuring RouletteWheel canvas transform matches expected after two deterministic spins

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6890034e71a08320a6aa5850978d147c