### PR TITLE
Integrate Twitch token refresh via Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,13 @@ subscriber of the configured channel and fetch channel point rewards when
 authorized as the streamer.
 
 To avoid requesting these scopes from every viewer, generate a Twitch OAuth
-token for the streamer account (for example via https://twitchapps.com/tmi/)
-and store it in the backend `.env` file as `TWITCH_STREAMER_TOKEN`. The
-`/api/streamer-token` endpoint is disabled by default; set
-`ENABLE_TWITCH_ROLE_CHECKS=true` alongside `TWITCH_STREAMER_TOKEN` to enable it.
-When deploying to Render or another hosting platform, set these environment
-variables there as well.
+refresh token for the streamer account and store it in the backend `.env` file
+as `TWITCH_REFRESH_TOKEN`. The server keeps the current access token in the
+`twitch_tokens` table and the `/api/streamer-token` endpoint reads from there
+when `ENABLE_TWITCH_ROLE_CHECKS=true`. Supply your `TWITCH_CLIENT_ID` and
+`TWITCH_SECRET` as well and set up a cron job that periodically calls
+`/refresh-token` (e.g. `https://your-backend.example/refresh-token`) to refresh
+the token before it expires.
 
 3. Run the backend and frontend:
 
@@ -115,9 +116,10 @@ Use the “New Roulette” button on the `/archive` page to open `/new-poll` and
 
 - **Render**: Create a new Web Service, set Node 18, and point it to the
   `backend/` folder. The backend has a no-op `build` script so you can keep the
-  default build command `npm run build`. Add `TWITCH_STREAMER_TOKEN` and, if
+  default build command `npm run build`. Add `TWITCH_REFRESH_TOKEN`, and if
   role checks are needed, set `ENABLE_TWITCH_ROLE_CHECKS=true` in the service's
-  environment settings along with other required variables.
+  environment settings along with `TWITCH_CLIENT_ID` and `TWITCH_SECRET`. Run a
+  cron job against `/refresh-token` to keep the access token updated.
 - **Vercel**: Import the repository, set the project root to `frontend/`, and add
   `NEXT_PUBLIC_BACKEND_URL` in the environment variables (e.g.
   `https://terrenkur.onrender.com`).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,8 +6,8 @@ FRONTEND_URLS=http://localhost:3000
 TWITCH_CLIENT_ID=
 TWITCH_SECRET=
 TWITCH_CHANNEL_ID=81300263
-# OAuth token for the streamer account (generate via https://twitchapps.com/tmi/)
-TWITCH_STREAMER_TOKEN=
+# Initial refresh token for the streamer account
+TWITCH_REFRESH_TOKEN=
 # Enable Twitch role checks and the /api/streamer-token route
 ENABLE_TWITCH_ROLE_CHECKS=false
 # OAuth callback URL, e.g. http://localhost:3000/auth/callback

--- a/backend/__tests__/twitch.test.js
+++ b/backend/__tests__/twitch.test.js
@@ -1,0 +1,81 @@
+const request = require('supertest');
+
+const mockTokenRow = { access_token: 'token', refresh_token: 'ref' };
+const mockBuilder = {
+  select: jest.fn(() => mockBuilder),
+  update: jest.fn(async () => ({ data: null, error: null })),
+  insert: jest.fn(async () => ({ data: null, error: null })),
+  maybeSingle: jest.fn(async () => ({ data: mockTokenRow, error: null })),
+};
+const mockFrom = jest.fn(() => mockBuilder);
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ from: mockFrom })),
+}));
+
+describe('/api/streamer-token', () => {
+  let app;
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = 'http://localhost';
+    process.env.SUPABASE_KEY = 'test';
+    process.env.ENABLE_TWITCH_ROLE_CHECKS = 'true';
+    mockTokenRow.access_token = 'abc';
+    app = require('../server');
+  });
+
+  it('returns the stored token', async () => {
+    const res = await request(app).get('/api/streamer-token');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ token: 'abc' });
+    expect(mockFrom).toHaveBeenCalledWith('twitch_tokens');
+  });
+});
+
+describe('/refresh-token', () => {
+  let app;
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = 'http://localhost';
+    process.env.SUPABASE_KEY = 'test';
+    process.env.TWITCH_CLIENT_ID = 'id';
+    process.env.TWITCH_SECRET = 'secret';
+    process.env.TWITCH_REFRESH_TOKEN = 'env';
+    delete process.env.ENABLE_TWITCH_ROLE_CHECKS;
+    mockTokenRow.refresh_token = 'old';
+    app = require('../server');
+  });
+
+  it('writes new tokens to supabase', async () => {
+    const mockResp = new Response(
+      JSON.stringify({
+        access_token: 'new_access',
+        refresh_token: 'new_refresh',
+        expires_in: 60,
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue(mockResp);
+    const res = await request(app).get('/refresh-token');
+    expect(res.status).toBe(200);
+    expect(mockBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        access_token: 'new_access',
+        refresh_token: 'new_refresh',
+      })
+    );
+    spy.mockRestore();
+  });
+
+  it('handles failed refreshes', async () => {
+    const mockResp = new Response('bad', { status: 400 });
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue(mockResp);
+    const res = await request(app).get('/refresh-token');
+    expect(res.status).toBe(400);
+    expect(mockBuilder.update).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -105,6 +105,17 @@ create table if not exists event_logs (
   created_at timestamp default now()
 );
 
+create table if not exists twitch_tokens (
+  access_token text,
+  refresh_token text,
+  expires_at timestamp,
+  updated_at timestamp default now()
+);
+
+insert into twitch_tokens (access_token, refresh_token, expires_at)
+  select null, null, null
+  where not exists (select 1 from twitch_tokens);
+
 -- Populate auth_id for existing users based on matching email
 update users
 set auth_id = u.id


### PR DESCRIPTION
## Summary
- store Twitch access and refresh tokens in new `twitch_tokens` table
- fetch streamer token from Supabase and add endpoint to refresh tokens
- document Twitch refresh flow and cron requirements

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689078ca61fc8320a28b005f9d695599