### PR TITLE
docs: document streamer token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ Archived roulettes now store the elimination order and the winning game. When vi
 With a YouTube API key configured you can also visit `/playlists` to see videos from your channel grouped by tags extracted from their descriptions.
 The `/stats` page visualizes the most popular games, top voters and the number of roulettes each game has appeared in using these aggregated counts.
 
+## Streamer token refresh
+
+When deployed on Render, the backend exposes a `https://<your-service>.onrender.com/refresh-token` endpoint (for example `https://terrenkur.onrender.com/refresh-token`) that refreshes the streamer’s Twitch access token. Schedule [EasyCron](https://www.easycron.com/) or a similar service to `GET` this URL every 3–4 hours.
+
+The job requires `TWITCH_REFRESH_TOKEN`, `TWITCH_CLIENT_ID`, and `TWITCH_SECRET` to be configured in the backend environment. Only the dedicated streamer token is refreshed – regular user logins continue to use their own tokens and are unaffected.
+
 ## Updating the Supabase schema
 
 If you modify `supabase/schema.sql` (for example to add a column like `slot`), reapply the file to your Supabase database so it stays in sync:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -44,6 +44,14 @@ including those scopes and store the resulting access token in a secure place,
 for example the `TWITCH_STREAMER_TOKEN` environment variable used by the
 backend. Refresh or replace the token when it expires.
 
+Deployments that set `TWITCH_REFRESH_TOKEN`, `TWITCH_CLIENT_ID`, and
+`TWITCH_SECRET` in the backend can refresh this token automatically. When the
+backend is hosted on Render, schedule a job in a service like
+[EasyCron](https://www.easycron.com/) to call
+`https://<your-service>.onrender.com/refresh-token` (e.g.
+`https://terrenkur.onrender.com/refresh-token`) every 3–4 hours. The refresh
+only applies to the dedicated streamer token; normal user logins are unaffected.
+
 ### Manual auth callback test
 
 1. Run the app with `npm run dev` and start the login flow.


### PR DESCRIPTION
## Summary
- describe automatic streamer token refresh endpoint and cron schedule
- outline backend env vars needed for refresh

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68907b32329c8320baa7e458826c3c3a