### PR TITLE
test: verify roles after streamer token refresh

### DIFF
--- a/frontend/components/__tests__/AuthStatus.test.tsx
+++ b/frontend/components/__tests__/AuthStatus.test.tsx
@@ -105,3 +105,74 @@ describe('AuthStatus login/logout', () => {
   });
 });
 
+describe('AuthStatus roles', () => {
+  const backendUrl = 'https://backend';
+  const channelId = 'chan123';
+  let originalFetch: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES = 'true';
+    process.env.NEXT_PUBLIC_BACKEND_URL = backendUrl;
+    process.env.NEXT_PUBLIC_TWITCH_CHANNEL_ID = channelId;
+    (supabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: mockSession },
+    });
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('computes roles using streamer token', async () => {
+    const userId = 'user1';
+    const fetchMock = jest.fn(async (url: RequestInfo, options?: RequestInit) => {
+      if (url === `${backendUrl}/api/get-stream?endpoint=users`) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [{ id: userId, profile_image_url: 'p.png' }],
+          }),
+        } as Response;
+      }
+      if (url === `${backendUrl}/api/streamer-token`) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ token: 'st123' }),
+        } as Response;
+      }
+      if (
+        url ===
+        `${backendUrl}/api/get-stream?endpoint=moderation/moderators&broadcaster_id=${channelId}&user_id=${userId}`
+      ) {
+        expect(options?.headers).toMatchObject({
+          Authorization: 'Bearer st123',
+        });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [{}] }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+      } as Response;
+    });
+    global.fetch = fetchMock as any;
+
+    render(<AuthStatus />);
+
+    await waitFor(() => {
+      expect(screen.getByAltText('Mod')).toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${backendUrl}/api/streamer-token`
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add integration test for AuthStatus to ensure roles are computed after fetching a refreshed streamer token

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68907c8a71408320ab1c76c5ee8f6ba1