### PR TITLE
Avoid repeated streamer token fetch

### DIFF
--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -25,6 +25,7 @@ export default function AuthStatus() {
   const [roles, setRoles] = useState<string[]>([]);
   const [userId, setUserId] = useState<number | null>(null);
   const [scopeWarning, setScopeWarning] = useState<string | null>(null);
+  const [streamerTokenMissing, setStreamerTokenMissing] = useState(false);
   const rolesEnabled =
     process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES === "true";
 
@@ -140,14 +141,18 @@ export default function AuthStatus() {
         }
 
         let stToken: string | undefined;
-        try {
-          const stRes = await fetch(`${backendUrl}/api/streamer-token`);
-          if (stRes.ok) {
-            const stData = await stRes.json();
-            stToken = stData.token;
+        if (!streamerTokenMissing) {
+          try {
+            const stRes = await fetch(`${backendUrl}/api/streamer-token`);
+            if (stRes.status === 404) {
+              setStreamerTokenMissing(true);
+            } else if (stRes.ok) {
+              const stData = await stRes.json();
+              stToken = stData.token;
+            }
+          } catch {
+            // ignore
           }
-        } catch {
-          // ignore
         }
 
         if (!stToken) {
@@ -220,7 +225,7 @@ export default function AuthStatus() {
     };
 
     fetchInfo();
-  }, [session, rolesEnabled]);
+  }, [session, rolesEnabled, streamerTokenMissing]);
 
   const debugPkceCheck = () => {
     if (process.env.NODE_ENV === "production") return;


### PR DESCRIPTION
## Summary
- track missing streamer tokens to avoid repetitive requests
- stop requesting `/api/streamer-token` after a 404
- test fetch skipping when streamer token is unavailable

## Testing
- `npm test --silent`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6890b0493eb883208c392ffc057d2d51