### PR TITLE
feat: include extra game fields

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1176,7 +1176,7 @@ app.get('/api/games/:id', async (req, res) => {
 
   const { data: game, error: gameErr } = await supabase
     .from('games')
-    .select('id, name, status, rating, selection_method, background_image')
+    .select('id, name, status, rating, selection_method, background_image, released_year, genres')
     .eq('id', gameId)
     .maybeSingle();
   if (gameErr) return res.status(500).json({ error: gameErr.message });


### PR DESCRIPTION
## Summary
- extend game query to include release year and genres for a single game

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890cc841bcc832094f5f66b5d8b2f39