### PR TITLE
Ensure refresh token updates target existing Twitch token row

### DIFF
--- a/backend/__tests__/twitch.test.js
+++ b/backend/__tests__/twitch.test.js
@@ -1,11 +1,12 @@
 const request = require('supertest');
 
-const mockTokenRow = { access_token: 'token', refresh_token: 'ref' };
+const mockTokenRow = { id: 1, access_token: 'token', refresh_token: 'ref' };
 const mockBuilder = {
   select: jest.fn(() => mockBuilder),
-  update: jest.fn(async () => ({ data: null, error: null })),
+  update: jest.fn(() => mockBuilder),
   insert: jest.fn(async () => ({ data: null, error: null })),
   maybeSingle: jest.fn(async () => ({ data: mockTokenRow, error: null })),
+  eq: jest.fn(async () => ({ data: null, error: null })),
 };
 const mockFrom = jest.fn(() => mockBuilder);
 
@@ -66,6 +67,7 @@ describe('/refresh-token', () => {
         refresh_token: 'new_refresh',
       })
     );
+    expect(mockBuilder.eq).toHaveBeenCalledWith('id', mockTokenRow.id);
     spy.mockRestore();
   });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -222,7 +222,8 @@ app.get('/refresh-token', async (_req, res) => {
     if (row) {
       ({ error: upErr } = await supabase
         .from('twitch_tokens')
-        .update(update));
+        .update(update)
+        .eq('id', row.id));
     } else {
       ({ error: upErr } = await supabase
         .from('twitch_tokens')


### PR DESCRIPTION
## Summary
- restrict Twitch token refresh updates to the existing row with `.eq('id', row.id)`
- adjust tests to mock and verify `eq` usage when saving new tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68910cdb3db483209b8bcca66bcf6bb7