### PR TITLE
Add id primary key to Twitch tokens table

### DIFF
--- a/backend/__tests__/twitch.test.js
+++ b/backend/__tests__/twitch.test.js
@@ -61,6 +61,7 @@ describe('/refresh-token', () => {
     const spy = jest.spyOn(global, 'fetch').mockResolvedValue(mockResp);
     const res = await request(app).get('/refresh-token');
     expect(res.status).toBe(200);
+    expect(mockBuilder.select).toHaveBeenCalledWith('id, refresh_token');
     expect(mockBuilder.update).toHaveBeenCalledWith(
       expect.objectContaining({
         access_token: 'new_access',

--- a/backend/server.js
+++ b/backend/server.js
@@ -172,7 +172,7 @@ app.get('/refresh-token', async (_req, res) => {
 
   const { data: row, error: selErr } = await supabase
     .from('twitch_tokens')
-    .select('refresh_token')
+    .select('id, refresh_token')
     .maybeSingle();
   if (selErr) return res.status(500).json({ error: selErr.message });
   if (row && row.refresh_token) refreshToken = row.refresh_token;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -106,6 +106,7 @@ create table if not exists event_logs (
 );
 
 create table if not exists twitch_tokens (
+  id serial primary key,
   access_token text,
   refresh_token text,
   expires_at timestamp,


### PR DESCRIPTION
## Summary
- add serial id column to `twitch_tokens`
- query and update Twitch tokens using `id`
- verify refresh-token flow with new tests

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68910e5484c88320bbeddd4c2bc676c7