### PR TITLE
Store Twitch login for users and query Twitch API by login

### DIFF
--- a/backend/__tests__/users.test.js
+++ b/backend/__tests__/users.test.js
@@ -4,9 +4,9 @@ process.env.SUPABASE_URL = 'http://localhost';
 process.env.SUPABASE_KEY = 'test';
 
 const users = [
-  { id: 1, username: 'Alice', auth_id: null },
-  { id: 2, username: 'Bob', auth_id: 'x' },
-  { id: 3, username: 'Charlie', auth_id: null },
+  { id: 1, username: 'Alice', auth_id: null, twitch_login: null },
+  { id: 2, username: 'Bob', auth_id: 'x', twitch_login: 'bob' },
+  { id: 3, username: 'Charlie', auth_id: null, twitch_login: null },
 ];
 
 const build = (data) => {
@@ -63,7 +63,13 @@ describe('GET /api/users', () => {
     const res = await request(app).get('/api/users?search=ali');
     expect(res.status).toBe(200);
     expect(res.body.users).toEqual([
-      { id: 1, username: 'Alice', auth_id: null, logged_in: false },
+      {
+        id: 1,
+        username: 'Alice',
+        auth_id: null,
+        twitch_login: null,
+        logged_in: false,
+      },
     ]);
   });
 });

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -12,6 +12,7 @@ interface UserInfo {
   id: number;
   username: string;
   auth_id: string | null;
+  twitch_login: string | null;
   logged_in: boolean;
 }
 
@@ -44,7 +45,7 @@ function UserRowBase({
 }
 
 function UserRow({ user }: { user: UserInfo }) {
-  const { roles } = useTwitchUserInfo(user.auth_id);
+  const { roles } = useTwitchUserInfo(user.twitch_login);
   return <UserRowBase user={user} roles={roles} />;
 }
 

--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -8,7 +8,7 @@ import {
   storeProviderToken,
 } from "./twitch";
 
-export function useTwitchUserInfo(authId: string | null) {
+export function useTwitchUserInfo(twitchLogin: string | null) {
   const [session, setSession] = useState<Session | null>(null);
   const [profileUrl, setProfileUrl] = useState<string | null>(null);
   const [roles, setRoles] = useState<string[]>([]);
@@ -22,7 +22,7 @@ export function useTwitchUserInfo(authId: string | null) {
   }, []);
 
   useEffect(() => {
-    if (!authId) {
+    if (!twitchLogin) {
       setProfileUrl(null);
       setRoles([]);
       return;
@@ -59,7 +59,7 @@ export function useTwitchUserInfo(authId: string | null) {
     const fetchInfo = async () => {
       try {
         const userRes = await fetchWithRefresh(
-          `${backendUrl}/api/get-stream?endpoint=users&id=${authId}`
+          `${backendUrl}/api/get-stream?endpoint=users&login=${twitchLogin}`
         );
         if (!userRes || !userRes.ok) throw new Error("user");
         const userData = await userRes.json();
@@ -120,7 +120,7 @@ export function useTwitchUserInfo(authId: string | null) {
     };
 
     fetchInfo();
-  }, [authId, session, enableRoles]);
+  }, [twitchLogin, session, enableRoles]);
 
   return { profileUrl, roles };
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -11,6 +11,9 @@ create table if not exists users (
   is_moderator boolean default false
 );
 
+alter table users
+  add column if not exists twitch_login text;
+
 create table if not exists games (
   id serial primary key,
   name text,


### PR DESCRIPTION
## Summary
- add `twitch_login` column to users table
- persist Twitch login during vote creation and expose it from `/api/users`
- update user info hook and listing to fetch Twitch data by saved login and skip when missing

## Testing
- `npm --prefix backend test --silent 2>&1 | grep -E "Test Suites|Tests:|Snapshots|Time|Ran all"`
- `npm --prefix frontend test --silent 2>&1 | grep -E "Test Suites|Tests:|Snapshots|Time|Ran all"`


------
https://chatgpt.com/codex/tasks/task_e_6891160f965c8320888ebf7241f8b2ee