### PR TITLE
refactor: centralize twitch info handling with hook

### DIFF
--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -27,7 +27,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   const [user, setUser] = useState<UserInfo | null>(null);
   const [history, setHistory] = useState<PollHistory[]>([]);
   const [loading, setLoading] = useState(true);
-  const { profileUrl, roles } = useTwitchUserInfo(user ? user.twitch_login : null);
+  const { profileUrl, roles, error } = useTwitchUserInfo(user ? user.twitch_login : null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -54,6 +54,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       <Link href="/users" className="text-purple-600 underline">
         Back to users
       </Link>
+      {error && <p className="text-red-600">{error}</p>}
       <h1 className="text-2xl font-semibold flex items-center space-x-2">
         {enableTwitchRoles &&
           roles.length > 0 &&

--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -12,6 +12,7 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
   const [session, setSession] = useState<Session | null>(null);
   const [profileUrl, setProfileUrl] = useState<string | null>(null);
   const [roles, setRoles] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   const enableRoles = process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES === "true";
 
@@ -25,6 +26,7 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
     if (!twitchLogin) {
       setProfileUrl(null);
       setRoles([]);
+      setError(null);
       return;
     }
     const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
@@ -34,6 +36,7 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
     if (!backendUrl) {
       setProfileUrl(null);
       setRoles([]);
+      setError("Backend URL not configured.");
       return;
     }
 
@@ -87,6 +90,7 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
         console.error("Twitch API error", e);
         setProfileUrl(null);
         setRoles([]);
+        setError("Failed to fetch Twitch info.");
       }
     };
 
@@ -184,12 +188,14 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
         setRoles(r);
       } catch (e) {
         console.error("Twitch API error", e);
+        setError("Failed to fetch Twitch info.");
         await fetchStreamerInfo();
       }
     };
 
+    setError(null);
     fetchInfo();
   }, [twitchLogin, session, enableRoles]);
 
-  return { profileUrl, roles };
+  return { profileUrl, roles, error };
 }


### PR DESCRIPTION
## Summary
- expose error state in `useTwitchUserInfo`
- use `useTwitchUserInfo` on user page for avatar and roles

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689126bcb66c8320945b8728c80a7ae9