### PR TITLE
Normalize Twitch logins to lowercase

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -576,10 +576,11 @@ app.post('/api/vote', async (req, res) => {
     return res.status(401).json({ error: 'Invalid session' });
   }
 
-  const twitchLogin =
+  const twitchLogin = (
     authUser.user_metadata?.preferred_username ||
     authUser.user_metadata?.name ||
-    null;
+    null
+  )?.toLowerCase();
 
   const { data: acc, error: accErr } = await supabase
     .from('settings')

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -126,3 +126,8 @@ set auth_id = u.id
 from auth.users u
 where users.auth_id is null
   and u.email = users.username;
+
+-- Ensure Twitch logins are stored in lowercase
+update users
+set twitch_login = lower(twitch_login)
+where twitch_login is not null;


### PR DESCRIPTION
## Summary
- Normalize Twitch login extracted from auth metadata to lowercase before use
- Ensure user inserts/updates use normalized `twitch_login`
- Add SQL migration to lower-case existing `twitch_login` entries

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689128241abc832086b9cac597eb7128