### PR TITLE
Normalize Twitch login casing in user info hook

### DIFF
--- a/frontend/lib/__tests__/useTwitchUserInfo.test.tsx
+++ b/frontend/lib/__tests__/useTwitchUserInfo.test.tsx
@@ -61,4 +61,19 @@ describe('useTwitchUserInfo fallback', () => {
     );
     expect(screen.getByTestId('roles').textContent).toContain('Sub');
   });
+
+  test('uses lowercase login when fetching user info', async () => {
+    function Comp() {
+      useTwitchUserInfo('FoO');
+      return null;
+    }
+    render(<Comp />);
+    await waitFor(() =>
+      expect((global as any).fetch).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('login=foo'),
+        expect.any(Object)
+      )
+    );
+  });
 });

--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -23,7 +23,8 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
   }, []);
 
   useEffect(() => {
-    if (!twitchLogin) {
+    const login = twitchLogin?.toLowerCase();
+    if (!login) {
       setProfileUrl(null);
       setRoles([]);
       setError(null);
@@ -51,7 +52,7 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
         if (!streamerToken) throw new Error("token");
         const sHeaders = { Authorization: `Bearer ${streamerToken}` };
         const userResp = await fetch(
-          `${backendUrl}/api/get-stream?endpoint=users&login=${twitchLogin}`,
+          `${backendUrl}/api/get-stream?endpoint=users&login=${login}`,
           { headers: sHeaders }
         );
         if (!userResp.ok) throw new Error("user");
@@ -123,7 +124,7 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
     const fetchInfo = async () => {
       try {
         const userRes = await fetchWithRefresh(
-          `${backendUrl}/api/get-stream?endpoint=users&login=${twitchLogin}`
+          `${backendUrl}/api/get-stream?endpoint=users&login=${login}`
         );
         if (!userRes || !userRes.ok) throw new Error("user");
         const userData = await userRes.json();


### PR DESCRIPTION
## Summary
- normalize twitch login to lowercase before querying API
- reuse normalized login for all user info requests
- test lowercase login handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891294656148320b06918a0481e6d82