### PR TITLE
Use backend URL for Twitch auth listener

### DIFF
--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -23,17 +23,24 @@ export const authListener = supabase.auth.onAuthStateChange(
       } catch {
         // ignore storage errors (e.g. server-side rendering)
       }
-    } else if (
+  } else if (
       session &&
       ((event as string) === 'SIGNED_IN' || (event as string) === 'TOKEN_REFRESHED')
     ) {
-      try {
-        await fetch('/api/ensure-twitch-login', {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${session.access_token}` },
-        });
-      } catch {
-        // Ignore network errors
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+      if (!backendUrl) {
+        console.warn(
+          'NEXT_PUBLIC_BACKEND_URL is not set; skipping ensure-twitch-login'
+        );
+      } else {
+        try {
+          await fetch(`${backendUrl}/api/ensure-twitch-login`, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${session.access_token}` },
+          });
+        } catch {
+          // Ignore network errors
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Post ensure-twitch-login using full NEXT_PUBLIC_BACKEND_URL
- Warn and skip when backend URL is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891326bbf848320b731ac35bb919a25