### PR TITLE
Fix twitch token handling when session missing

### DIFF
--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -32,8 +32,13 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
     }
     const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
     const channelId = process.env.NEXT_PUBLIC_TWITCH_CHANNEL_ID;
-    const token = (session as any)?.provider_token as string | undefined ||
-      getStoredProviderToken();
+    const token = session
+      ? ((session as any)?.provider_token as string | undefined) ||
+        getStoredProviderToken()
+      : undefined;
+    if (!session) {
+      storeProviderToken(undefined);
+    }
     if (!backendUrl) {
       setProfileUrl(null);
       setRoles([]);


### PR DESCRIPTION
## Summary
- avoid loading stored Twitch token when no session
- clear stale Twitch provider token when session missing

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6891a7ad0edc8320a153231856ca7945