### PR TITLE
Clear stored provider token without session

### DIFF
--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -59,6 +59,10 @@ export default function AuthStatus() {
 
   // Persist the provider token for page reloads
   useEffect(() => {
+    if (!session) {
+      storeProviderToken(undefined);
+      return;
+    }
     const token = (session as any)?.provider_token as string | undefined;
     if (token) {
       storeProviderToken(token);
@@ -70,6 +74,13 @@ export default function AuthStatus() {
       setProfileUrl(null);
       setRoles([]);
       setScopeWarning(null);
+      return;
+    }
+    if (!session) {
+      setProfileUrl(null);
+      setRoles([]);
+      setScopeWarning(null);
+      storeProviderToken(undefined);
       return;
     }
     const token =


### PR DESCRIPTION
## Summary
- Clear stored Twitch provider token whenever no session exists
- Guard role checks to only run with a valid session and token

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891a9b2e9b08320beca18da3d98ae4f