### PR TITLE
Make archive result fields optional

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -27,9 +27,9 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
   const wheelRef = useRef<RouletteWheelHandle>(null);
   const [result, setResult] = useState<{
     poll_id: number;
-    winner_id: number | null;
-    eliminated_order: number[];
-    spin_seed: string | null;
+    winner_id?: number | null;
+    eliminated_order?: number[] | null;
+    spin_seed?: string | null;
   } | null>(null);
   const [replaySeed, setReplaySeed] = useState<string | null>(null);
   const [isReplay, setIsReplay] = useState(false);
@@ -72,7 +72,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
       const res = await fetch(`${backendUrl}/api/poll/${id}/result`);
       if (res.ok) {
         const rdata = await res.json();
-        setResult(rdata);
+        setResult({ ...rdata, eliminated_order: rdata.eliminated_order ?? [] });
       }
       setLoading(false);
     };
@@ -124,7 +124,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
   };
 
   const handleReplay = () => {
-    if (!result || !poll) return;
+    if (!result?.spin_seed || !poll) return;
     setRouletteGames(poll.games);
     setWinner(null);
     setReplaySeed(result.spin_seed);
@@ -176,16 +176,16 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
         </h1>
         {result && (
           <div className="space-y-2">
-            {result.winner_id && (
+            {result?.winner_id != null && (
               <p className="font-semibold">
-                Winning game: {poll.games.find((g) => g.id === result.winner_id)?.name}
+                Winning game: {poll.games.find((g) => g.id === result?.winner_id)?.name}
               </p>
             )}
-            {result.eliminated_order.length > 0 && (
+            {result?.eliminated_order?.length > 0 && (
               <div>
                 <p>Elimination order:</p>
                 <ol className="list-decimal pl-4">
-                  {result.eliminated_order.map((id) => (
+                  {result.eliminated_order?.map((id) => (
                     <li key={id}>{poll.games.find((g) => g.id === id)?.name}</li>
                   ))}
                 </ol>


### PR DESCRIPTION
## Summary
- Make archived poll result fields optional and handle missing winner, eliminated order, and spin seed data
- Render winners and eliminations defensively with optional chaining

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68927d0926b08320967da5ff800abf81