### PR TITLE
Add playlist to game mapping table

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -147,3 +147,10 @@ create trigger enforce_lowercase_twitch_login_trigger
 before insert or update on users
 for each row
 execute procedure enforce_lowercase_twitch_login();
+
+create table if not exists playlist_games (
+  tag text primary key,
+  game_id integer references games(id),
+  unique(tag)
+);
+


### PR DESCRIPTION
## Summary
- add `playlist_games` table to map playlist tags to a single game

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68932d97c06c832086ebe1c7d91a4bc9