### PR TITLE
Add playlist API and UI tests

### DIFF
--- a/backend/__tests__/playlist_game.test.js
+++ b/backend/__tests__/playlist_game.test.js
@@ -3,6 +3,9 @@ const request = require('supertest');
 process.env.SUPABASE_URL = 'http://localhost';
 process.env.SUPABASE_KEY = 'test';
 
+let isModerator = true;
+let upsertResult = { game_id: 1 };
+
 const mockSupabase = {
   auth: {
     getUser: jest.fn(() => ({ data: { user: { id: '1', email: 'mod@test' } }, error: null })),
@@ -12,27 +15,31 @@ const mockSupabase = {
       return {
         select: jest.fn(() => ({
           eq: jest.fn(() => ({
-            maybeSingle: jest.fn(() => Promise.resolve({ data: { is_moderator: true } }))
-          }))
-        }))
+            maybeSingle: jest.fn(() =>
+              Promise.resolve({ data: { is_moderator: isModerator } })
+            ),
+          })),
+        })),
       };
     }
     if (table === 'games') {
       return {
         select: jest.fn(() => ({
           eq: jest.fn(() => ({
-            maybeSingle: jest.fn(() => Promise.resolve({ data: { id: 1, name: 'Test Game' } }))
-          }))
-        }))
+            maybeSingle: jest.fn(() =>
+              Promise.resolve({ data: { id: 1, name: 'Test Game' } })
+            ),
+          })),
+        })),
       };
     }
     if (table === 'playlist_games') {
       return {
         upsert: jest.fn(() => ({
           select: jest.fn(() => ({
-            single: jest.fn(() => Promise.resolve({ data: { game_id: 1 } }))
-          }))
-        }))
+            single: jest.fn(() => Promise.resolve({ data: upsertResult })),
+          })),
+        })),
       };
     }
     if (table === 'event_logs') {
@@ -51,15 +58,22 @@ jest.mock('@supabase/supabase-js', () => ({
 const app = require('../server');
 
 describe('POST /api/playlist_game', () => {
-  it('requires tag and game_id', async () => {
+  beforeEach(() => {
+    isModerator = true;
+    upsertResult = { game_id: 1 };
+  });
+
+  it('forbids non-moderators', async () => {
+    isModerator = false;
     const res = await request(app)
       .post('/api/playlist_game')
       .set('Authorization', 'Bearer token')
-      .send({});
-    expect(res.status).toBe(400);
+      .send({ tag: 'rpg', game_id: 1 });
+    expect(res.status).toBe(403);
   });
 
-  it('upserts mapping', async () => {
+  it('creates mapping for a playlist tag', async () => {
+    upsertResult = { game_id: 1 };
     const res = await request(app)
       .post('/api/playlist_game')
       .set('Authorization', 'Bearer token')
@@ -67,4 +81,15 @@ describe('POST /api/playlist_game', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ game_id: 1 });
   });
+
+  it('updates existing mapping', async () => {
+    upsertResult = { game_id: 2 };
+    const res = await request(app)
+      .post('/api/playlist_game')
+      .set('Authorization', 'Bearer token')
+      .send({ tag: 'rpg', game_id: 2 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ game_id: 2 });
+  });
 });
+

--- a/backend/__tests__/playlists.test.js
+++ b/backend/__tests__/playlists.test.js
@@ -1,0 +1,60 @@
+const request = require('supertest');
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_KEY = 'test';
+process.env.YOUTUBE_API_KEY = 'key';
+process.env.YOUTUBE_CHANNEL_ID = 'channel';
+
+const tagMap = {
+  rpg: [
+    {
+      id: 'v1',
+      title: 'Video1',
+      description: '',
+      publishedAt: '2024-01-01',
+      thumbnail: null,
+    },
+  ],
+};
+
+jest.mock('../youtube', () => ({
+  getPlaylists: jest.fn(() => Promise.resolve(tagMap)),
+}));
+
+const build = (data) => ({
+  select: jest.fn(() => ({
+    in: jest.fn(() => Promise.resolve({ data, error: null })),
+  })),
+});
+
+const mockSupabase = {
+  from: jest.fn((table) => {
+    if (table === 'playlist_games') {
+      return build([{ tag: 'rpg', game_id: 1 }]);
+    }
+    if (table === 'games') {
+      return build([{ id: 1, name: 'Game1', background_image: 'img.png' }]);
+    }
+    return build([]);
+  }),
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => mockSupabase),
+}));
+
+const app = require('../server');
+
+describe('GET /api/playlists', () => {
+  it('returns playlists with game information', async () => {
+    const res = await request(app).get('/api/playlists');
+    expect(res.status).toBe(200);
+    expect(res.body.rpg.videos[0].id).toBe('v1');
+    expect(res.body.rpg.game).toEqual({
+      id: 1,
+      name: 'Game1',
+      background_image: 'img.png',
+    });
+  });
+});
+

--- a/frontend/components/__tests__/Playlists.test.tsx
+++ b/frontend/components/__tests__/Playlists.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+process.env.NEXT_PUBLIC_BACKEND_URL = 'http://backend';
+
+const PlaylistsPage = require('@/app/playlists/page').default;
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+    },
+    from: jest.fn(),
+  },
+}));
+
+const { supabase: mockSupabase } = require('@/lib/supabase');
+
+describe('PlaylistsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders game next to playlist', async () => {
+    mockSupabase.auth.getSession.mockResolvedValue({ data: { session: null } });
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          rpg: { videos: [], game: { id: 1, name: 'Game1' } },
+        }),
+      });
+
+    render(<PlaylistsPage />);
+
+    expect(await screen.findByText('Game1')).toBeInTheDocument();
+  });
+
+  it('opens modal and sends request as moderator', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ rpg: { videos: [], game: null } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ games: [{ id: 2, name: 'Game2', background_image: null }] }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          rpg: { videos: [], game: { id: 2, name: 'Game2', background_image: null } },
+        }),
+      });
+    (global as any).fetch = fetchMock;
+
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: { access_token: 'token', user: { id: '1' } } },
+    });
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'users') {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              maybeSingle: jest.fn(() =>
+                Promise.resolve({ data: { is_moderator: true } })
+              ),
+            })),
+          })),
+        };
+      }
+      return {} as any;
+    });
+
+    render(<PlaylistsPage />);
+
+    const editButton = await screen.findByText('Изменить игру');
+    fireEvent.click(editButton);
+
+    await screen.findByText('Select Game for #rpg');
+
+    fireEvent.click(screen.getByText('Search'));
+
+    const selectButton = await screen.findByText('Select');
+    fireEvent.click(selectButton);
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://backend/api/playlist_game',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ Authorization: 'Bearer token' }),
+          body: JSON.stringify({ tag: 'rpg', game_id: 2 }),
+        })
+      )
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add checks for moderator permissions and mapping updates in `POST /api/playlist_game`
- verify `GET /api/playlists` returns playlist videos with associated game info
- test playlists page UI for rendering game links and moderator edit flow

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933615092c8320beabd9509c9ad5d0