### PR TITLE
feat: improve playlist game selection

### DIFF
--- a/backend/__tests__/playlist_game.test.js
+++ b/backend/__tests__/playlist_game.test.js
@@ -154,6 +154,21 @@ describe('POST /api/playlist_game', () => {
       .send({ tag: 'new', game_name: 'Brand New Game', rawg_id: 10 });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ game_id: 4 });
+    expect(gamesInsert).toHaveBeenCalledWith({
+      name: 'Brand New Game',
+      rawg_id: 10,
+    });
+  });
+
+  it('links tag to existing game by rawg_id', async () => {
+    existingGame = { id: 6, name: 'RAWG Game' };
+    upsertResult = { game_id: 6 };
+    const res = await request(app)
+      .post('/api/playlist_game')
+      .set('Authorization', 'Bearer token')
+      .send({ tag: 'rawg', rawg_id: 99 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ game_id: 6 });
   });
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1200,7 +1200,7 @@ app.get('/api/games', async (_req, res) => {
   const { data: games, error: gamesErr } = await supabase
     .from('games')
     .select(
-      'id, name, status, rating, selection_method, background_image, released_year, genres'
+      'id, rawg_id, name, status, rating, selection_method, background_image, released_year, genres'
     );
   if (gamesErr) return res.status(500).json({ error: gamesErr.message });
 
@@ -1230,6 +1230,7 @@ app.get('/api/games', async (_req, res) => {
 
   const result = games.map((g) => ({
     id: g.id,
+    rawg_id: g.rawg_id,
     name: g.name,
     background_image: g.background_image,
     released_year: g.released_year,

--- a/frontend/components/__tests__/EditPlaylistGameModal.test.tsx
+++ b/frontend/components/__tests__/EditPlaylistGameModal.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import EditPlaylistGameModal from '../EditPlaylistGameModal';
+
+const backend = 'http://example.com';
+process.env.NEXT_PUBLIC_BACKEND_URL = backend;
+
+let origFetch: any;
+
+beforeEach(() => {
+  origFetch = (global as any).fetch;
+});
+
+afterEach(() => {
+  (global as any).fetch = origFetch;
+});
+
+test('selects existing game', async () => {
+  const fetchMock = jest.fn((url: string, opts?: any) => {
+    if (url === `${backend}/api/games`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ games: [{ id: 1, rawg_id: 10, name: 'Foo', background_image: null }] }),
+      });
+    }
+    if (url === `${backend}/api/rawg_search?query=Foo`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ results: [{ rawg_id: 10, name: 'Foo', background_image: null }] }),
+      });
+    }
+    if (url === `${backend}/api/playlist_game`) {
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+  (global as any).fetch = fetchMock;
+
+  render(
+    <EditPlaylistGameModal tag="tag" session={null} onClose={() => {}} onUpdated={() => {}} />
+  );
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(`${backend}/api/games`));
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Foo' } });
+  fireEvent.click(screen.getByText('Search'));
+  await screen.findByText('Foo');
+  expect(screen.getByText('Уже в базе')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Select'));
+  await waitFor(() =>
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      `${backend}/api/playlist_game`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ tag: 'tag', game_id: 1 }),
+      })
+    )
+  );
+});
+
+test('selects new game', async () => {
+  const fetchMock = jest.fn((url: string, opts?: any) => {
+    if (url === `${backend}/api/games`) {
+      return Promise.resolve({ ok: true, json: async () => ({ games: [] }) });
+    }
+    if (url === `${backend}/api/rawg_search?query=Bar`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ results: [{ rawg_id: 20, name: 'Bar', background_image: 'img' }] }),
+      });
+    }
+    if (url === `${backend}/api/playlist_game`) {
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+  (global as any).fetch = fetchMock;
+
+  render(
+    <EditPlaylistGameModal tag="tag" session={null} onClose={() => {}} onUpdated={() => {}} />
+  );
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(`${backend}/api/games`));
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Bar' } });
+  fireEvent.click(screen.getByText('Search'));
+  await screen.findByText('Bar');
+  expect(screen.getByText('Новая')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Select'));
+  await waitFor(() =>
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      `${backend}/api/playlist_game`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          tag: 'tag',
+          game_name: 'Bar',
+          rawg_id: 20,
+          background_image: 'img',
+        }),
+      })
+    )
+  );
+});

--- a/frontend/components/__tests__/Playlists.test.tsx
+++ b/frontend/components/__tests__/Playlists.test.tsx
@@ -48,7 +48,15 @@ describe('PlaylistsPage', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ games: [{ id: 2, name: 'Game2', background_image: null }] }),
+        json: async () => ({
+          games: [{ id: 2, rawg_id: 20, name: 'Game2', background_image: null }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [{ rawg_id: 20, name: 'Game2', background_image: null }],
+        }),
       })
       .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
       .mockResolvedValueOnce({
@@ -84,6 +92,8 @@ describe('PlaylistsPage', () => {
 
     await screen.findByText('Select Game for #rpg');
 
+    const searchBox = screen.getByRole('textbox');
+    fireEvent.change(searchBox, { target: { value: 'Game2' } });
     fireEvent.click(screen.getByText('Search'));
 
     const selectButton = await screen.findByText('Select');


### PR DESCRIPTION
## Summary
- flag RAWG search results already in the database when editing playlist games
- expose rawg_id in GET /api/games for better cross-referencing
- test selecting existing and new games through playlist modal and API

## Testing
- `cd backend && npm test --silent`
- `cd frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689353157264832080d8dd13ed38c835