### PR TITLE
Add rawg_id to games table

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -17,7 +17,8 @@ alter table users
 create table if not exists games (
   id serial primary key,
   name text,
-  background_image text
+  background_image text,
+  rawg_id integer unique
 );
 
 alter table games
@@ -31,6 +32,9 @@ alter table games
 alter table games
   add column if not exists released_year integer,
   add column if not exists genres text[];
+
+alter table games
+  add column if not exists rawg_id integer unique;
 
 create table if not exists polls (
   id serial primary key,


### PR DESCRIPTION
## Summary
- add `rawg_id` column to `games` table and migrations

## Testing
- `su postgres -c "psql -d terrenkur_db -c '\d games'"`
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935949f7a08320a34bfb06c980bbbf