### PR TITLE
refactor: add PlaylistRow props interface

### DIFF
--- a/frontend/components/PlaylistRow.tsx
+++ b/frontend/components/PlaylistRow.tsx
@@ -15,19 +15,21 @@ export interface GameRef {
   name: string;
 }
 
+export interface PlaylistRowProps {
+  tag: string;
+  videos: Video[];
+  game: GameRef | null;
+  isModerator: boolean;
+  onEdit: () => void;
+}
+
 export default function PlaylistRow({
   tag,
   videos,
   game,
   isModerator,
   onEdit,
-}: {
-  tag: string;
-  videos: Video[];
-  game: GameRef | null;
-  isModerator: boolean;
-  onEdit: () => void;
-}) {
+}: PlaylistRowProps) {
   const listRef = useRef<HTMLUListElement | null>(null);
   const headerRef = useRef<HTMLDivElement | null>(null);
   const [headerHeight, setHeaderHeight] = useState(0);


### PR DESCRIPTION
## Summary
- add explicit `PlaylistRowProps` interface

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893645146f883208b297c13ae2a393d