### PR TITLE
feat: attach YouTube playlists to game details

### DIFF
--- a/backend/__tests__/game.test.js
+++ b/backend/__tests__/game.test.js
@@ -74,8 +74,9 @@ jest.mock('@supabase/supabase-js', () => ({
   createClient: jest.fn(() => mockSupabase),
 }));
 
+const mockGetPlaylists = jest.fn(async () => playlistMap);
 jest.mock('../youtube', () => ({
-  getPlaylists: jest.fn(async () => playlistMap),
+  getPlaylists: (...args) => mockGetPlaylists(...args),
 }));
 
 const app = require('../server');
@@ -91,5 +92,6 @@ describe('GET /api/games/:id', () => {
     expect(poll.voters).toEqual([{ id: 1, username: 'Alice', count: 2 }]);
     expect(res.body.playlist.tag).toBe('rpg');
     expect(res.body.playlist.videos[0].title).toBe('Video1');
+    expect(mockGetPlaylists).toHaveBeenCalledWith('yt', 'chan', ['rpg']);
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -1330,9 +1330,14 @@ app.get('/api/games/:id', async (req, res) => {
     const { YOUTUBE_API_KEY, YOUTUBE_CHANNEL_ID } = process.env;
     if (YOUTUBE_API_KEY && YOUTUBE_CHANNEL_ID) {
       try {
-        const tagMap = await getPlaylists(YOUTUBE_API_KEY, YOUTUBE_CHANNEL_ID);
-        if (tagMap[pgRow.tag]) {
-          playlist = { tag: pgRow.tag, videos: tagMap[pgRow.tag] };
+        const tagMap = await getPlaylists(
+          YOUTUBE_API_KEY,
+          YOUTUBE_CHANNEL_ID,
+          [pgRow.tag]
+        );
+        const videos = tagMap[pgRow.tag];
+        if (videos && videos.length) {
+          playlist = { tag: pgRow.tag, videos };
         }
       } catch (err) {
         console.error('Failed to fetch playlist:', err);

--- a/backend/youtube.js
+++ b/backend/youtube.js
@@ -27,14 +27,27 @@ async function fetchVideos(apiKey, channelId) {
   }));
 }
 
-async function getPlaylists(apiKey, channelId) {
+async function getPlaylists(apiKey, channelId, filterTags) {
   const videos = await fetchVideos(apiKey, channelId);
+  let wanted = null;
+  if (filterTags) {
+    wanted = Array.isArray(filterTags)
+      ? filterTags.map((t) => t.toLowerCase())
+      : [filterTags.toLowerCase()];
+  }
   const map = {};
   videos.forEach((v) => {
     const tags = parseTags(v.description);
     tags.forEach((t) => {
+      if (wanted && !wanted.includes(t)) return;
       if (!map[t]) map[t] = [];
-      map[t].push({ id: v.id, title: v.title, description: v.description, publishedAt: v.publishedAt, thumbnail: v.thumbnail });
+      map[t].push({
+        id: v.id,
+        title: v.title,
+        description: v.description,
+        publishedAt: v.publishedAt,
+        thumbnail: v.thumbnail,
+      });
     });
   });
   return map;


### PR DESCRIPTION
## Summary
- load playlist tag for a game and fetch matching videos from YouTube
- allow `getPlaylists` to filter returned videos by tag
- verify playlist inclusion and proper `getPlaylists` call in game tests

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689366982ac48320bd88d14786bb7729