### PR TITLE
fix: adjust game header overlay order

### DIFF
--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -94,13 +94,13 @@ export default function GamePage({ params }: { params: Promise<{ id: string }> }
       >
         {game.background_image && (
           <>
+            <div className="absolute inset-0 bg-black/80 z-0" />
             <div
-              className="absolute inset-0 bg-cover bg-center blur-sm opacity-50"
+              className="absolute inset-0 bg-cover bg-center blur-sm opacity-50 z-0"
               style={{
                 backgroundImage: `url(${proxiedImage(game.background_image)})`,
               }}
             />
-            <div className="absolute inset-0 bg-black/80 z-0" />
           </>
         )}
         <div className="relative z-10 space-y-1">


### PR DESCRIPTION
## Summary
- move dark overlay before background image on game page so layers match list cards

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893a25e1df88320b7b396d25da5dc11