### PR TITLE
Expose poll winners for game details endpoint

### DIFF
--- a/backend/__tests__/game.test.js
+++ b/backend/__tests__/game.test.js
@@ -12,6 +12,7 @@ const polls = [
   { id: 10, created_at: '2024-01-01', archived: false },
   { id: 11, created_at: '2024-02-01', archived: true },
 ];
+const pollResults = [{ poll_id: 10, winner_id: 2 }];
 const votes = [
   { poll_id: 10, user_id: 1 },
   { poll_id: 10, user_id: 1 },
@@ -34,6 +35,11 @@ const playlistMap = {
   ],
 };
 
+const winnerGames = [
+  { id: 2, name: 'WinnerGame', background_image: 'win.jpg' },
+];
+let gamesCall = 0;
+
 const build = (data) => {
   const builder = {};
   const chain = ['select', 'eq', 'order', 'limit', 'in', 'insert', 'update', 'upsert', 'delete'];
@@ -51,7 +57,7 @@ const mockSupabase = {
   from: jest.fn((table) => {
     switch (table) {
       case 'games':
-        return build(game);
+        return build(gamesCall++ === 0 ? game : winnerGames);
       case 'game_initiators':
         return build(initRows);
       case 'users':
@@ -60,6 +66,8 @@ const mockSupabase = {
         return build(pollGames);
       case 'polls':
         return build(polls);
+      case 'poll_results':
+        return build(pollResults);
       case 'votes':
         return build(votes);
       case 'playlist_games':
@@ -89,6 +97,9 @@ describe('GET /api/games/:id', () => {
     expect(res.body.game.initiators).toEqual([{ id: 1, username: 'Alice' }]);
     expect(res.body.polls.length).toBe(2);
     const poll = res.body.polls.find((p) => p.id === 10);
+    expect(poll.winnerId).toBe(2);
+    expect(poll.winnerName).toBe('WinnerGame');
+    expect(poll.winnerBackground).toBe('win.jpg');
     expect(poll.voters).toEqual([{ id: 1, username: 'Alice', count: 2 }]);
     expect(res.body.playlist.tag).toBe('rpg');
     expect(res.body.playlist.videos[0].title).toBe('Video1');


### PR DESCRIPTION
## Summary
- fetch poll_results and winner game details when requesting a game's polls
- include winnerId, winnerName and winnerBackground in each poll entry
- test game detail endpoint for winner information

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ab4b50588320ac3e94dbd685c5b4