### PR TITLE
Fix winner display in roulette archive list

### DIFF
--- a/frontend/app/archive/page.tsx
+++ b/frontend/app/archive/page.tsx
@@ -163,7 +163,7 @@ export default function ArchivePage() {
                 <Link
                   href={`/archive/${p.id}`}
                   className={cn(
-                    "underline",
+                    "block underline",
                     p.winnerBackground ? "text-white" : "text-purple-600"
                   )}
                 >
@@ -173,7 +173,7 @@ export default function ArchivePage() {
                   <Link
                     href={`/games/${p.winnerId}`}
                     className={cn(
-                      "text-sm underline",
+                      "block text-sm underline",
                       p.winnerBackground ? "text-white" : "text-purple-600"
                     )}
                   >


### PR DESCRIPTION
## Summary
- Ensure winner info appears on a new line below roulette title in archive list

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6893b38d98b48320ac56e182144e363f