### PR TITLE
feat: size twitch icon in user profile

### DIFF
--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -111,7 +111,11 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
           target="_blank"
           rel="noopener noreferrer"
         >
-          <img src="/icons/socials/twitch.svg" alt="Twitch" />
+          <img
+            src="/icons/socials/twitch.svg"
+            alt="Twitch"
+            className="inline-block h-[1em] w-[1em]"
+          />
         </a>
         <span>{user.username}</span>
         {user.logged_in ? (


### PR DESCRIPTION
## Summary
- size Twitch icon beside username to match text

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894460f90ec8320bf3b2096ed243e71