### PR TITLE
Handle command prefix case-insensitively

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -122,6 +122,20 @@ describe('parseCommand', () => {
     });
   });
 
+  test('parses uppercase !GAME prefix', () => {
+    expect(parseCommand('!GAME Doom')).toEqual({
+      prefix: '!game',
+      gameName: 'Doom',
+    });
+  });
+
+  test('parses mixed-case !ИгрА prefix', () => {
+    expect(parseCommand('  !ИгрА  Ведьмак  ')).toEqual({
+      prefix: '!игра',
+      gameName: 'Ведьмак',
+    });
+  });
+
   test('returns null for unknown command', () => {
     expect(parseCommand('hello')).toBeNull();
   });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -165,14 +165,15 @@ setInterval(checkDonations, 10000);
 client.connect();
 
 function parseCommand(message) {
-  const trimmed = message.trim();
-  const prefix = trimmed.startsWith('!игра')
+  const original = message.trim();
+  const lowered = original.toLowerCase();
+  const prefix = lowered.startsWith('!игра')
     ? '!игра'
-    : trimmed.startsWith('!game')
+    : lowered.startsWith('!game')
     ? '!game'
     : null;
   if (!prefix) return null;
-  const gameName = trimmed.slice(prefix.length).trim();
+  const gameName = original.slice(prefix.length).trim();
   return { prefix, gameName };
 }
 


### PR DESCRIPTION
## Summary
- Make bot command parsing case-insensitive by lowercasing messages before prefix checks and preserving the original game name.
- Expand tests to cover mixed-case `!game` and `!игра` prefixes.

## Testing
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_6895308651ec83209d890002a751545a