### PR TITLE
feat: add media and preview URLs to event logs

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -109,6 +109,8 @@ create table if not exists log_rewards (
 create table if not exists event_logs (
   id serial primary key,
   message text not null,
+  media_url text,
+  preview_url text,
   created_at timestamp default now()
 );
 


### PR DESCRIPTION
## Summary
- allow event logs to reference related media and preview assets

## Testing
- `psql "$SUPABASE_URL" -f supabase/schema.sql` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6895a7a5cb88832093e28a69956ec31a