### PR TITLE
feat: add responsive stats grid

### DIFF
--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -58,87 +58,89 @@ export default function StatsPage() {
   return (
     <main className="col-span-9 p-4 space-y-6">
       <h1 className="text-2xl font-semibold">Statistics</h1>
-      <section className="space-y-2">
-        <h2 className="text-xl font-semibold mb-2">Most Popular Games</h2>
-        {games.length === 0 ? (
-          <p>No data.</p>
-        ) : (
-          <table className="min-w-full border">
-            <thead>
-              <tr className="bg-muted">
-                <th className="p-2 text-left">Game</th>
-                <th className="p-2 text-right">Votes</th>
-              </tr>
-            </thead>
-            <tbody>
-              {games.map((g) => (
-                <tr key={g.id} className="border-t">
-                  <td className="p-2">
-                    <Link href={`/games/${g.id}`} className="text-purple-600 underline">
-                      {g.name}
-                    </Link>
-                  </td>
-                  <td className="p-2 text-right">{g.votes}</td>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold mb-2">Most Popular Games</h2>
+          {games.length === 0 ? (
+            <p>No data.</p>
+          ) : (
+            <table className="min-w-full border">
+              <thead>
+                <tr className="bg-muted">
+                  <th className="p-2 text-left">Game</th>
+                  <th className="p-2 text-right">Votes</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
-      <section className="space-y-2">
-        <h2 className="text-xl font-semibold mb-2">Games by Roulette Appearances</h2>
-        {roulettes.length === 0 ? (
-          <p>No data.</p>
-        ) : (
-          <table className="min-w-full border">
-            <thead>
-              <tr className="bg-muted">
-                <th className="p-2 text-left">Game</th>
-                <th className="p-2 text-right">Roulettes</th>
-              </tr>
-            </thead>
-            <tbody>
-              {roulettes.map((g) => (
-                <tr key={g.id} className="border-t">
-                  <td className="p-2">
-                    <Link href={`/games/${g.id}`} className="text-purple-600 underline">
-                      {g.name}
-                    </Link>
-                  </td>
-                  <td className="p-2 text-right">{g.roulettes}</td>
+              </thead>
+              <tbody>
+                {games.map((g) => (
+                  <tr key={g.id} className="border-t">
+                    <td className="p-2">
+                      <Link href={`/games/${g.id}`} className="text-purple-600 underline">
+                        {g.name}
+                      </Link>
+                    </td>
+                    <td className="p-2 text-right">{g.votes}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold mb-2">Games by Roulette Appearances</h2>
+          {roulettes.length === 0 ? (
+            <p>No data.</p>
+          ) : (
+            <table className="min-w-full border">
+              <thead>
+                <tr className="bg-muted">
+                  <th className="p-2 text-left">Game</th>
+                  <th className="p-2 text-right">Roulettes</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
-      <section className="space-y-2">
-        <h2 className="text-xl font-semibold mb-2">Top Voters</h2>
-        {voters.length === 0 ? (
-          <p>No data.</p>
-        ) : (
-          <table className="min-w-full border">
-            <thead>
-              <tr className="bg-muted">
-                <th className="p-2 text-left">User</th>
-                <th className="p-2 text-right">Votes</th>
-              </tr>
-            </thead>
-            <tbody>
-              {voters.map((v) => (
-                <tr key={v.id} className="border-t">
-                  <td className="p-2">
-                    <Link href={`/users/${v.id}`} className="text-purple-600 underline">
-                      {v.username}
-                    </Link>
-                  </td>
-                  <td className="p-2 text-right">{v.votes}</td>
+              </thead>
+              <tbody>
+                {roulettes.map((g) => (
+                  <tr key={g.id} className="border-t">
+                    <td className="p-2">
+                      <Link href={`/games/${g.id}`} className="text-purple-600 underline">
+                        {g.name}
+                      </Link>
+                    </td>
+                    <td className="p-2 text-right">{g.roulettes}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold mb-2">Top Voters</h2>
+          {voters.length === 0 ? (
+            <p>No data.</p>
+          ) : (
+            <table className="min-w-full border">
+              <thead>
+                <tr className="bg-muted">
+                  <th className="p-2 text-left">User</th>
+                  <th className="p-2 text-right">Votes</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
+              </thead>
+              <tbody>
+                {voters.map((v) => (
+                  <tr key={v.id} className="border-t">
+                    <td className="p-2">
+                      <Link href={`/users/${v.id}`} className="text-purple-600 underline">
+                        {v.username}
+                      </Link>
+                    </td>
+                    <td className="p-2 text-right">{v.votes}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- arrange stats page sections using a responsive two-column grid

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6895ae8ec46483209fdae8dd6dc91937