### PR TITLE
Limit stats tables height with scroll

### DIFF
--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -64,26 +64,28 @@ export default function StatsPage() {
           {games.length === 0 ? (
             <p>No data.</p>
           ) : (
-            <table className="min-w-full border">
-              <thead>
-                <tr className="bg-muted">
-                  <th className="p-2 text-left">Game</th>
-                  <th className="p-2 text-right">Votes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {games.map((g) => (
-                  <tr key={g.id} className="border-t">
-                    <td className="p-2">
-                      <Link href={`/games/${g.id}`} className="text-purple-600 underline">
-                        {g.name}
-                      </Link>
-                    </td>
-                    <td className="p-2 text-right">{g.votes}</td>
+            <div className="max-h-60 overflow-y-auto">
+              <table className="min-w-full border">
+                <thead>
+                  <tr className="bg-muted">
+                    <th className="p-2 text-left">Game</th>
+                    <th className="p-2 text-right">Votes</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {games.map((g) => (
+                    <tr key={g.id} className="border-t">
+                      <td className="p-2">
+                        <Link href={`/games/${g.id}`} className="text-purple-600 underline">
+                          {g.name}
+                        </Link>
+                      </td>
+                      <td className="p-2 text-right">{g.votes}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </section>
         <section className="space-y-2">
@@ -91,26 +93,28 @@ export default function StatsPage() {
           {roulettes.length === 0 ? (
             <p>No data.</p>
           ) : (
-            <table className="min-w-full border">
-              <thead>
-                <tr className="bg-muted">
-                  <th className="p-2 text-left">Game</th>
-                  <th className="p-2 text-right">Roulettes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {roulettes.map((g) => (
-                  <tr key={g.id} className="border-t">
-                    <td className="p-2">
-                      <Link href={`/games/${g.id}`} className="text-purple-600 underline">
-                        {g.name}
-                      </Link>
-                    </td>
-                    <td className="p-2 text-right">{g.roulettes}</td>
+            <div className="max-h-60 overflow-y-auto">
+              <table className="min-w-full border">
+                <thead>
+                  <tr className="bg-muted">
+                    <th className="p-2 text-left">Game</th>
+                    <th className="p-2 text-right">Roulettes</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {roulettes.map((g) => (
+                    <tr key={g.id} className="border-t">
+                      <td className="p-2">
+                        <Link href={`/games/${g.id}`} className="text-purple-600 underline">
+                          {g.name}
+                        </Link>
+                      </td>
+                      <td className="p-2 text-right">{g.roulettes}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </section>
         <section className="space-y-2">
@@ -118,26 +122,28 @@ export default function StatsPage() {
           {voters.length === 0 ? (
             <p>No data.</p>
           ) : (
-            <table className="min-w-full border">
-              <thead>
-                <tr className="bg-muted">
-                  <th className="p-2 text-left">User</th>
-                  <th className="p-2 text-right">Votes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {voters.map((v) => (
-                  <tr key={v.id} className="border-t">
-                    <td className="p-2">
-                      <Link href={`/users/${v.id}`} className="text-purple-600 underline">
-                        {v.username}
-                      </Link>
-                    </td>
-                    <td className="p-2 text-right">{v.votes}</td>
+            <div className="max-h-60 overflow-y-auto">
+              <table className="min-w-full border">
+                <thead>
+                  <tr className="bg-muted">
+                    <th className="p-2 text-left">User</th>
+                    <th className="p-2 text-right">Votes</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {voters.map((v) => (
+                    <tr key={v.id} className="border-t">
+                      <td className="p-2">
+                        <Link href={`/users/${v.id}`} className="text-purple-600 underline">
+                          {v.username}
+                        </Link>
+                      </td>
+                      <td className="p-2 text-right">{v.votes}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </section>
       </div>


### PR DESCRIPTION
## Summary
- make stats tables scrollable by capping their height

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6895b16fbbdc8320804b9c0edbe66270