### PR TITLE
Expose game vote and roulette counts

### DIFF
--- a/backend/__tests__/game.test.js
+++ b/backend/__tests__/game.test.js
@@ -95,6 +95,8 @@ describe('GET /api/games/:id', () => {
     expect(res.status).toBe(200);
     expect(res.body.game.name).toBe('Game1');
     expect(res.body.game.initiators).toEqual([{ id: 1, username: 'Alice' }]);
+    expect(res.body.game.votes).toBe(3);
+    expect(res.body.game.roulettes).toBe(2);
     expect(res.body.polls.length).toBe(2);
     const poll = res.body.polls.find((p) => p.id === 10);
     expect(poll.winnerId).toBe(2);

--- a/backend/server.js
+++ b/backend/server.js
@@ -1532,7 +1532,12 @@ app.get('/api/games/:id', async (req, res) => {
   }
 
   res.json({
-    game: { ...game, initiators },
+    game: {
+      ...game,
+      initiators,
+      votes: votes.length,
+      roulettes: pollGames.length,
+    },
     polls: pollInfo,
     playlist,
   });

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -31,6 +31,8 @@ interface GameInfo {
   released_year: number | null;
   genres: string[] | null;
   initiators: UserRef[];
+  votes: number;
+  roulettes: number;
 }
 
 interface PlaylistData {
@@ -122,6 +124,8 @@ export default function GamePage({
           {game.selection_method && <p>Selection: {game.selection_method}</p>}
           {game.released_year && <p>Released: {game.released_year}</p>}
           {game.genres?.length ? <p>Genres: {game.genres.join(", ")}</p> : null}
+          <p>Votes: {game.votes}</p>
+          <p>Roulettes: {game.roulettes}</p>
           {game.initiators.length > 0 && (
             <p>
               Initiators:{" "}


### PR DESCRIPTION
## Summary
- return vote and roulette counts in `/api/games/:id`
- display counts in game detail page
- extend backend tests for new fields

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895bdf6012c83208623e0072d9b7bff