### PR TITLE
Configure music reward via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ roulette via chat commands:
    # Optional comma separated list of reward IDs to log
    # These will be merged with IDs stored in the `log_rewards` table
    LOG_REWARD_IDS=id1,id2
+   MUSIC_REWARD_ID=545cc880-f6c1-4302-8731-29075a8a1f17
    ```
 
    The bot also fetches reward IDs from the `log_rewards` table in Supabase at

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -8,4 +8,5 @@ TWITCH_SECRET=
 TWITCH_CHANNEL_ID=
 # Comma separated reward IDs to log, leave empty to log all
 LOG_REWARD_IDS=
+MUSIC_REWARD_ID=545cc880-f6c1-4302-8731-29075a8a1f17
 DONATIONALERTS_TOKEN=

--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -12,6 +12,7 @@ const loadBot = (mockSupabase) => {
   process.env.BOT_USERNAME = 'bot';
   process.env.BOT_OAUTH_TOKEN = 'token';
   process.env.TWITCH_CHANNEL = 'channel';
+  process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
   const bot = require('../bot');
   jest.useRealTimers();
   return bot;
@@ -31,6 +32,7 @@ const loadBotWithOn = (mockSupabase, onMock, sayMock = jest.fn()) => {
   process.env.BOT_USERNAME = 'bot';
   process.env.BOT_OAUTH_TOKEN = 'token';
   process.env.TWITCH_CHANNEL = 'channel';
+  process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
   delete process.env.LOG_REWARD_IDS;
   const bot = require('../bot');
   jest.useRealTimers();

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -12,6 +12,7 @@ const {
   TWITCH_SECRET,
   TWITCH_CHANNEL_ID,
   LOG_REWARD_IDS,
+  MUSIC_REWARD_ID,
 } = process.env;
 
 if (!SUPABASE_URL || !SUPABASE_KEY) {
@@ -34,7 +35,9 @@ let rewardIds = LOG_REWARD_IDS
   ? LOG_REWARD_IDS.split(',').map((s) => s.trim()).filter(Boolean)
   : [];
 
-const MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
+if (!MUSIC_REWARD_ID) {
+  console.warn('MUSIC_REWARD_ID not set');
+}
 
 async function loadRewardIds() {
   try {
@@ -299,7 +302,7 @@ client.on('message', async (channel, tags, message, self) => {
   if (self) return;
 
   const rewardId = tags['custom-reward-id'];
-  if (rewardId === MUSIC_REWARD_ID) {
+  if (MUSIC_REWARD_ID && rewardId === MUSIC_REWARD_ID) {
     const text = message.trim();
     if (!text) {
       console.warn(


### PR DESCRIPTION
## Summary
- document MUSIC_REWARD_ID in README and sample env file
- read MUSIC_REWARD_ID from env in bot and warn if missing
- adjust bot tests for MUSIC_REWARD_ID

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895d74a20348320838c9b72e43c4838