### PR TITLE
Validate YouTube links for music reward

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -476,19 +476,25 @@ describe('reward logging', () => {
       }),
     };
     const on = jest.fn();
+    const say = jest.fn();
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    loadBotWithOn(supabase, on);
+    loadBotWithOn(supabase, on, say);
     await new Promise(setImmediate);
     const messageHandler = on.mock.calls.find((c) => c[0] === 'message')[1];
     const link = 'https://example.com/video';
     await messageHandler(
       'channel',
-      { 'custom-reward-id': '545cc880-f6c1-4302-8731-29075a8a1f17', 'display-name': 'User' },
+      {
+        'custom-reward-id': '545cc880-f6c1-4302-8731-29075a8a1f17',
+        'display-name': 'User',
+        username: 'user',
+      },
       link,
       false
     );
     expect(insertMock).not.toHaveBeenCalled();
-    expect(consoleSpy).toHaveBeenCalledWith(`Music reward invalid link: ${link}`);
+    expect(consoleSpy).toHaveBeenCalledWith('Invalid YouTube URL', link);
+    expect(say).toHaveBeenCalledWith('channel', '@user, invalid YouTube link.');
     consoleSpy.mockRestore();
   });
 });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -124,6 +124,15 @@ function getYoutubeThumbnail(url) {
   }
 }
 
+function isYoutubeUrl(url) {
+  try {
+    const u = new URL(url);
+    return u.hostname === 'youtu.be' || u.hostname.endsWith('youtube.com');
+  } catch {
+    return false;
+  }
+}
+
 async function checkNewFollower() {
   if (!TWITCH_CHANNEL_ID || !TWITCH_CLIENT_ID || !TWITCH_SECRET) return;
   try {
@@ -312,8 +321,9 @@ client.on('message', async (channel, tags, message, self) => {
       );
       return;
     }
-    if (!text.includes('youtube.com') && !text.includes('youtu.be')) {
-      console.error(`Music reward invalid link: ${text}`);
+    if (!isYoutubeUrl(text)) {
+      console.error('Invalid YouTube URL', text);
+      client.say(channel, `@${tags.username}, invalid YouTube link.`);
       return;
     }
     const preview = getYoutubeThumbnail(text);


### PR DESCRIPTION
## Summary
- Add helper to check if a URL belongs to YouTube
- Notify chat and log when music reward contains non-YouTube link
- Update unit test for invalid link

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895d981e20c8320980903ba87da7a72