### PR TITLE
feat: track user engagement metrics

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -8,11 +8,25 @@ create table if not exists users (
   username text,
   auth_id uuid references auth.users(id) unique,
   vote_limit integer default 1,
-  is_moderator boolean default false
+  is_moderator boolean default false,
+  total_streams_watched integer default 0,
+  total_subs_gifted integer default 0,
+  total_subs_received integer default 0,
+  total_chat_messages_sent integer default 0,
+  total_times_tagged integer default 0,
+  total_commands_run integer default 0,
+  total_months_subbed integer default 0
 );
 
 alter table users
-  add column if not exists twitch_login text;
+  add column if not exists twitch_login text,
+  add column if not exists total_streams_watched integer default 0,
+  add column if not exists total_subs_gifted integer default 0,
+  add column if not exists total_subs_received integer default 0,
+  add column if not exists total_chat_messages_sent integer default 0,
+  add column if not exists total_times_tagged integer default 0,
+  add column if not exists total_commands_run integer default 0,
+  add column if not exists total_months_subbed integer default 0;
 
 create table if not exists games (
   id serial primary key,


### PR DESCRIPTION
## Summary
- track user engagement stats on the users table
- ensure new metrics exist on existing deployments

## Testing
- `npm --prefix backend test`
- `npm --prefix bot test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6895e3c99750832084424509562d759d