### PR TITLE
Expose new user statistics fields

### DIFF
--- a/backend/__tests__/users.test.js
+++ b/backend/__tests__/users.test.js
@@ -4,9 +4,45 @@ process.env.SUPABASE_URL = 'http://localhost';
 process.env.SUPABASE_KEY = 'test';
 
 const users = [
-  { id: 1, username: 'Alice', auth_id: null, twitch_login: null },
-  { id: 2, username: 'Bob', auth_id: 'x', twitch_login: 'bob' },
-  { id: 3, username: 'Charlie', auth_id: null, twitch_login: null },
+  {
+    id: 1,
+    username: 'Alice',
+    auth_id: null,
+    twitch_login: null,
+    total_streams_watched: 0,
+    total_subs_gifted: 0,
+    total_subs_received: 0,
+    total_chat_messages_sent: 0,
+    total_times_tagged: 0,
+    total_commands_run: 0,
+    total_months_subbed: 0,
+  },
+  {
+    id: 2,
+    username: 'Bob',
+    auth_id: 'x',
+    twitch_login: 'bob',
+    total_streams_watched: 0,
+    total_subs_gifted: 0,
+    total_subs_received: 0,
+    total_chat_messages_sent: 0,
+    total_times_tagged: 0,
+    total_commands_run: 0,
+    total_months_subbed: 0,
+  },
+  {
+    id: 3,
+    username: 'Charlie',
+    auth_id: null,
+    twitch_login: null,
+    total_streams_watched: 0,
+    total_subs_gifted: 0,
+    total_subs_received: 0,
+    total_chat_messages_sent: 0,
+    total_times_tagged: 0,
+    total_commands_run: 0,
+    total_months_subbed: 0,
+  },
 ];
 
 const votes = [
@@ -110,6 +146,13 @@ describe('GET /api/users', () => {
         username: 'Alice',
         auth_id: null,
         twitch_login: null,
+        total_streams_watched: 0,
+        total_subs_gifted: 0,
+        total_subs_received: 0,
+        total_chat_messages_sent: 0,
+        total_times_tagged: 0,
+        total_commands_run: 0,
+        total_months_subbed: 0,
         logged_in: false,
       },
     ]);

--- a/backend/server.js
+++ b/backend/server.js
@@ -1022,7 +1022,9 @@ app.get('/api/users', async (req, res) => {
   const search = req.query.search || req.query.q;
   let builder = supabase
     .from('users')
-    .select('id, username, auth_id, twitch_login');
+    .select(
+      'id, username, auth_id, twitch_login, total_streams_watched, total_subs_gifted, total_subs_received, total_chat_messages_sent, total_times_tagged, total_commands_run, total_months_subbed'
+    );
   if (search) {
     builder = builder.ilike('username', `%${search}%`);
   }
@@ -1034,6 +1036,13 @@ app.get('/api/users', async (req, res) => {
     username: u.username,
     auth_id: u.auth_id,
     twitch_login: u.twitch_login,
+    total_streams_watched: u.total_streams_watched,
+    total_subs_gifted: u.total_subs_gifted,
+    total_subs_received: u.total_subs_received,
+    total_chat_messages_sent: u.total_chat_messages_sent,
+    total_times_tagged: u.total_times_tagged,
+    total_commands_run: u.total_commands_run,
+    total_months_subbed: u.total_months_subbed,
     logged_in: !!u.auth_id,
   }));
   res.json({ users });
@@ -1048,7 +1057,9 @@ app.get('/api/users/:id', async (req, res) => {
 
   const { data: user, error: userError } = await supabase
     .from('users')
-    .select('id, username, auth_id, twitch_login')
+    .select(
+      'id, username, auth_id, twitch_login, total_streams_watched, total_subs_gifted, total_subs_received, total_chat_messages_sent, total_times_tagged, total_commands_run, total_months_subbed'
+    )
     .eq('id', userId)
     .maybeSingle();
   if (userError) return res.status(500).json({ error: userError.message });

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -22,6 +22,13 @@ interface UserInfo {
   auth_id: string | null;
   twitch_login: string | null;
   logged_in: boolean;
+  total_streams_watched: number;
+  total_subs_gifted: number;
+  total_subs_received: number;
+  total_chat_messages_sent: number;
+  total_times_tagged: number;
+  total_commands_run: number;
+  total_months_subbed: number;
   votes: number;
   roulettes: number;
 }

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -19,6 +19,13 @@ interface UserInfo {
   username: string;
   auth_id: string | null;
   twitch_login: string | null;
+  total_streams_watched: number;
+  total_subs_gifted: number;
+  total_subs_received: number;
+  total_chat_messages_sent: number;
+  total_times_tagged: number;
+  total_commands_run: number;
+  total_months_subbed: number;
   logged_in: boolean;
 }
 


### PR DESCRIPTION
## Summary
- return new user statistic columns from `/api/users` and `/api/users/:id`
- update tests and frontend types to handle the expanded user object

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e787bf9c8320a5c7e6ca18f95e4d