### PR TITLE
Add stream_chatters table

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -28,6 +28,10 @@ alter table users
   add column if not exists total_commands_run integer default 0,
   add column if not exists total_months_subbed integer default 0;
 
+create table if not exists stream_chatters (
+  user_id integer primary key references users(id)
+);
+
 create table if not exists games (
   id serial primary key,
   name text,


### PR DESCRIPTION
## Summary
- add `stream_chatters` table mapping users to stream participation

## Testing
- `npx supabase db push` *(fails: Cannot find project ref. Have you run supabase link?)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6895ee5b34288320bca2adb6a8622864