### PR TITLE
Clear stream chatters table when stream status changes

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -215,8 +215,10 @@ async function checkStreamStatus() {
     const online = Array.isArray(data.data) && data.data.length > 0;
     if (streamOnline && !online) {
       joinedThisStream.clear();
+      await supabase.from('stream_chatters').delete().neq('user_id', 0);
     } else if (!streamOnline && online) {
       joinedThisStream.clear();
+      await supabase.from('stream_chatters').delete().neq('user_id', 0);
     }
     streamOnline = online;
   } catch (err) {


### PR DESCRIPTION
## Summary
- Clear `stream_chatters` table when stream toggles online/offline

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895f04544308320bccf20382a372e31