### PR TITLE
Track chatters for stream

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -186,6 +186,9 @@ const createSupabaseMessage = (
           }))
         };
       }
+      if (table === 'stream_chatters') {
+        return { upsert: jest.fn(() => Promise.resolve({ error: null })) };
+      }
       return { select: jest.fn(() => Promise.resolve({ data: [], error: null })), insert: jest.fn() };
     })
   };
@@ -399,7 +402,12 @@ describe('reward logging', () => {
     await new Promise(setImmediate);
 
     const messageHandler = on.mock.calls.find((c) => c[0] === 'message')[1];
-    await messageHandler('channel', { 'custom-reward-id': rewardId, 'display-name': 'User' }, 'Hello', false);
+    await messageHandler(
+      'channel',
+      { username: 'user', 'custom-reward-id': rewardId, 'display-name': 'User' },
+      'Hello',
+      false
+    );
 
     expect(insertMock).toHaveBeenCalledWith({
       message: `Reward ${rewardId} redeemed by User: Hello`,
@@ -428,7 +436,11 @@ describe('reward logging', () => {
     const link = 'https://youtu.be/abc123';
     await messageHandler(
       'channel',
-      { 'custom-reward-id': '545cc880-f6c1-4302-8731-29075a8a1f17', 'display-name': 'User' },
+      {
+        username: 'user',
+        'custom-reward-id': '545cc880-f6c1-4302-8731-29075a8a1f17',
+        'display-name': 'User',
+      },
       link,
       false
     );

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -389,6 +389,11 @@ client.on('message', async (channel, tags, message, self) => {
   let user;
   try {
     user = await findOrCreateUser(tags);
+    if (tags.username.toLowerCase() !== 'hornypaps') {
+      await supabase
+        .from('stream_chatters')
+        .upsert({ user_id: user.id }, { onConflict: 'user_id' });
+    }
     await incrementUserStat(user.id, 'total_chat_messages_sent');
     if (message.trim().startsWith('!')) {
       await incrementUserStat(user.id, 'total_commands_run');


### PR DESCRIPTION
## Summary
- Record users in `stream_chatters` on each message unless the user is `hornypaps`
- Extend bot tests to handle `stream_chatters` and provide `username` in reward scenarios

## Testing
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_6895f10757f0832099d53251ba0529ab