### PR TITLE
feat(bot): add intim command

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -190,3 +190,9 @@ create table if not exists playlist_games (
   unique(tag)
 );
 
+create table if not exists intim_variants (
+  id serial primary key,
+  variant_one text not null,
+  variant_two text not null
+);
+


### PR DESCRIPTION
## Summary
- add `!интим` command with random phrases and participants
- create `intim_variants` table for phrase templates
- test new command

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895fdfe020c8320bf74fe0170019ab5