### PR TITLE
feat(bot): add intim command tests with contexts

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -197,11 +197,11 @@ const createSupabaseMessage = (
 };
 
 const createSupabaseIntim = ({
-  chatters = [{ user_id: 2, users: { username: 'Partner' } }],
-  variants = [{ variant_one: 'целуется с', variant_two: 'обнимает' }],
+  chatters = [{ user_id: 2, users: { username: 'target' } }],
+  contexts = [{ phrase: 'интим в кустах' }],
   users = [
-    { id: 1, username: 'user', twitch_login: 'user', vote_limit: 1 },
-    { id: 2, username: 'partner', twitch_login: 'partner' },
+    { id: 1, username: 'author', twitch_login: 'author', vote_limit: 1 },
+    { id: 2, username: 'target', twitch_login: 'target' },
   ],
 } = {}) => {
   const usersTable = {
@@ -226,9 +226,9 @@ const createSupabaseIntim = ({
           })),
         };
       }
-      if (table === 'intim_variants') {
+      if (table === 'intim_contexts') {
         return {
-          select: jest.fn(() => Promise.resolve({ data: variants, error: null })),
+          select: jest.fn(() => Promise.resolve({ data: contexts, error: null })),
         };
       }
       if (table === 'log_rewards') {
@@ -623,8 +623,8 @@ describe('donation logging', () => {
   });
 });
 
-describe('intim command', () => {
-  test('uses random chatter when no tag provided', async () => {
+describe('!интим', () => {
+  test('без тега выводит шанс для автора', async () => {
     const on = jest.fn();
     const say = jest.fn();
     const supabase = createSupabaseIntim();
@@ -632,13 +632,15 @@ describe('intim command', () => {
     await new Promise(setImmediate);
     const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
     jest.spyOn(Math, 'random').mockReturnValue(0.5);
-    await handler('channel', { username: 'user', 'display-name': 'User' }, '!интим', false);
+    await handler('channel', { username: 'author', 'display-name': 'Author' }, '!интим', false);
     expect(say).toHaveBeenCalledTimes(1);
-    expect(say.mock.calls[0][1]).toMatch(/% шанс того, что/);
+    expect(say.mock.calls[0][1]).toBe(
+      '50% шанс того, что у @author интим в кустах'
+    );
     Math.random.mockRestore();
   });
 
-  test('uses tagged user when provided', async () => {
+  test('с тегом выводит шанс для пары', async () => {
     const on = jest.fn();
     const say = jest.fn();
     const supabase = createSupabaseIntim();
@@ -646,11 +648,11 @@ describe('intim command', () => {
     await new Promise(setImmediate);
     const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
     jest.spyOn(Math, 'random').mockReturnValue(0.5);
-    await handler('channel', { username: 'user', 'display-name': 'User' }, '!интим @partner', false);
+    await handler('channel', { username: 'author', 'display-name': 'Author' }, '!интим @target', false);
     expect(say).toHaveBeenCalledTimes(1);
-    const text = say.mock.calls[0][1];
-    expect(text).toMatch(/@partner/);
-    expect(text).toMatch(/% шанс того, что/);
+    expect(say.mock.calls[0][1]).toBe(
+      '50% шанс того, что @author интимиться с @target интим в кустах'
+    );
     Math.random.mockRestore();
   });
 });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -454,22 +454,19 @@ client.on('message', async (channel, tags, message, self) => {
     }
 
     try {
-      const { data: variants, error: varErr } = await supabase
-        .from('intim_variants')
-        .select('variant_one, variant_two');
-      if (varErr || !variants || variants.length === 0) throw varErr;
-      const variantOneList = variants.map((v) => v.variant_one).filter(Boolean);
-      const variantTwoList = variants.map((v) => v.variant_two).filter(Boolean);
-      const variantOne =
-        variantOneList[Math.floor(Math.random() * variantOneList.length)] || '';
-      const variantTwo =
-        variantTwoList[Math.floor(Math.random() * variantTwoList.length)] || '';
+      const { data: contexts, error: ctxErr } = await supabase
+        .from('intim_contexts')
+        .select('phrase');
+      if (ctxErr || !contexts || contexts.length === 0) throw ctxErr;
+      const phraseList = contexts.map((c) => c.phrase).filter(Boolean);
+      const phrase =
+        phraseList[Math.floor(Math.random() * phraseList.length)] || '';
       const percent = Math.floor(Math.random() * 101);
       const authorName = `@${tags.username}`;
       const partnerName = `@${partnerUser.username}`;
       const text = tagArg
-        ? `${percent}% шанс того, что ${authorName} ${variantTwo} ${partnerName} ${variantOne}`
-        : `${percent}% шанс того, что ${authorName} ${variantOne} ${partnerName}`;
+        ? `${percent}% шанс того, что ${authorName} интимиться с ${partnerName} ${phrase}`
+        : `${percent}% шанс того, что у ${authorName} ${phrase}`;
       client.say(channel, text);
     } catch (err) {
       console.error('intim command failed', err);


### PR DESCRIPTION
## Summary
- fetch phrases from `intim_contexts` and format `!интим` replies
- cover `!интим` command with Supabase mocks for contexts and chatters

## Testing
- `cd bot && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68960062dec88320bb90f6b6ec782a8c