### PR TITLE
Always use random partner for !интим command

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -640,18 +640,25 @@ describe('!интим', () => {
     Math.random.mockRestore();
   });
 
-  test('с тегом выводит шанс для пары', async () => {
+  test('с тегом выводит шанс для пары с случайным партнером', async () => {
     const on = jest.fn();
     const say = jest.fn();
-    const supabase = createSupabaseIntim();
+    const supabase = createSupabaseIntim({
+      chatters: [{ user_id: 2, users: { username: 'partner' } }],
+    });
     loadBotWithOn(supabase, on, say);
     await new Promise(setImmediate);
     const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
     jest.spyOn(Math, 'random').mockReturnValue(0.5);
-    await handler('channel', { username: 'author', 'display-name': 'Author' }, '!интим @target', false);
+    await handler(
+      'channel',
+      { username: 'author', 'display-name': 'Author' },
+      '!интим @target',
+      false
+    );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что @author интимиться с @target интим в кустах'
+      '50% шанс того, что @author интимиться с @partner интим в кустах'
     );
     Math.random.mockRestore();
   });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -422,35 +422,21 @@ client.on('message', async (channel, tags, message, self) => {
     const tagArg = args.find((a) => a.startsWith('@'));
     let partnerUser = null;
 
-    if (tagArg) {
-      try {
-        const login = tagArg.slice(1).toLowerCase();
-        partnerUser = await findOrCreateUser({ username: login });
-        if (partnerUser.id === user.id) {
-          partnerUser = null;
-        }
-      } catch (err) {
-        console.error('find tagged user failed', err);
-      }
-    }
-
-    if (!partnerUser) {
-      try {
-        const { data: chatters, error } = await supabase
-          .from('stream_chatters')
-          .select('user_id, users ( username )')
-          .neq('user_id', user.id);
-        if (error) throw error;
-        if (!chatters || chatters.length === 0) {
-          client.say(channel, `@${tags.username}, сейчас нет других участников.`);
-          return;
-        }
-        const random = chatters[Math.floor(Math.random() * chatters.length)];
-        partnerUser = { id: random.user_id, username: random.users.username };
-      } catch (err) {
-        console.error('select random chatter failed', err);
+    try {
+      const { data: chatters, error } = await supabase
+        .from('stream_chatters')
+        .select('user_id, users ( username )')
+        .neq('user_id', user.id);
+      if (error) throw error;
+      if (!chatters || chatters.length === 0) {
+        client.say(channel, `@${tags.username}, сейчас нет других участников.`);
         return;
       }
+      const random = chatters[Math.floor(Math.random() * chatters.length)];
+      partnerUser = { id: random.user_id, username: random.users.username };
+    } catch (err) {
+      console.error('select random chatter failed', err);
+      return;
     }
 
     try {


### PR DESCRIPTION
## Summary
- ignore tagged usernames when handling `!интим`
- always pick random chatter as the partner
- test that tags only toggle text variant

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896067285108320845597001c39b0f8