### PR TITLE
feat: use intim context variants

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -198,7 +198,7 @@ const createSupabaseMessage = (
 
 const createSupabaseIntim = ({
   chatters = [{ user_id: 2, users: { username: 'target' } }],
-  contexts = [{ phrase: 'интим в кустах' }],
+  contexts = [{ variant_one: 'в кустах', variant_two: 'тайно' }],
   users = [
     { id: 1, username: 'author', twitch_login: 'author', vote_limit: 1 },
     { id: 2, username: 'target', twitch_login: 'target' },
@@ -635,7 +635,7 @@ describe('!интим', () => {
     await handler('channel', { username: 'author', 'display-name': 'Author' }, '!интим', false);
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что у @author интим в кустах'
+      '50% шанс того, что у @author в кустах будет интим с @target'
     );
     Math.random.mockRestore();
   });
@@ -658,7 +658,7 @@ describe('!интим', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что @author интимиться с @partner интим в кустах'
+      '50% шанс того, что @author тайно интимиться с @partner в кустах'
     );
     Math.random.mockRestore();
   });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -442,17 +442,18 @@ client.on('message', async (channel, tags, message, self) => {
     try {
       const { data: contexts, error: ctxErr } = await supabase
         .from('intim_contexts')
-        .select('phrase');
+        .select('variant_one, variant_two');
       if (ctxErr || !contexts || contexts.length === 0) throw ctxErr;
-      const phraseList = contexts.map((c) => c.phrase).filter(Boolean);
-      const phrase =
-        phraseList[Math.floor(Math.random() * phraseList.length)] || '';
+      const context =
+        contexts[Math.floor(Math.random() * contexts.length)] || {};
+      const variantOne = context.variant_one || '';
+      const variantTwo = context.variant_two || '';
       const percent = Math.floor(Math.random() * 101);
       const authorName = `@${tags.username}`;
       const partnerName = `@${partnerUser.username}`;
       const text = tagArg
-        ? `${percent}% шанс того, что ${authorName} интимиться с ${partnerName} ${phrase}`
-        : `${percent}% шанс того, что у ${authorName} ${phrase}`;
+        ? `${percent}% шанс того, что ${authorName} ${variantTwo} интимиться с ${partnerName} ${variantOne}`
+        : `${percent}% шанс того, что у ${authorName} ${variantOne} будет интим с ${partnerName}`;
       client.say(channel, text);
     } catch (err) {
       console.error('intim command failed', err);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -190,7 +190,7 @@ create table if not exists playlist_games (
   unique(tag)
 );
 
-create table if not exists intim_variants (
+create table if not exists intim_contexts (
   id serial primary key,
   variant_one text not null,
   variant_two text not null


### PR DESCRIPTION
## Summary
- build intim command messages from `intim_contexts` variants
- align bot tests with new message patterns
- define `intim_contexts` table schema with variant fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896088e1ea883208df61f25b9e070e0