### PR TITLE
feat: handle self-selection in !интим

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -221,9 +221,7 @@ const createSupabaseIntim = ({
       if (table === 'stream_chatters') {
         return {
           upsert: jest.fn(() => Promise.resolve({ error: null })),
-          select: jest.fn(() => ({
-            neq: jest.fn(() => Promise.resolve({ data: chatters, error: null })),
-          })),
+          select: jest.fn(() => Promise.resolve({ data: chatters, error: null })),
         };
       }
       if (table === 'intim_contexts') {
@@ -659,6 +657,52 @@ describe('!интим', () => {
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
       '50% шанс того, что @author тайно интимиться с @partner в кустах'
+    );
+    Math.random.mockRestore();
+  });
+
+  test('при выборе автора без тега сообщение корректно', async () => {
+    const on = jest.fn();
+    const say = jest.fn();
+    const supabase = createSupabaseIntim({
+      chatters: [{ user_id: 1, users: { username: 'author' } }],
+    });
+    loadBotWithOn(supabase, on, say);
+    await new Promise(setImmediate);
+    const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    await handler(
+      'channel',
+      { username: 'author', 'display-name': 'Author' },
+      '!интим',
+      false
+    );
+    expect(say).toHaveBeenCalledTimes(1);
+    expect(say.mock.calls[0][1]).toBe(
+      '50% шанс того, что у @author в кустах будет интим с самим собой'
+    );
+    Math.random.mockRestore();
+  });
+
+  test('при выборе автора с тегом сообщение корректно', async () => {
+    const on = jest.fn();
+    const say = jest.fn();
+    const supabase = createSupabaseIntim({
+      chatters: [{ user_id: 1, users: { username: 'author' } }],
+    });
+    loadBotWithOn(supabase, on, say);
+    await new Promise(setImmediate);
+    const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    await handler(
+      'channel',
+      { username: 'author', 'display-name': 'Author' },
+      '!интим @target',
+      false
+    );
+    expect(say).toHaveBeenCalledTimes(1);
+    expect(say.mock.calls[0][1]).toBe(
+      '50% шанс того, что @author тайно интимиться с самим собой в кустах'
     );
     Math.random.mockRestore();
   });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -425,8 +425,7 @@ client.on('message', async (channel, tags, message, self) => {
     try {
       const { data: chatters, error } = await supabase
         .from('stream_chatters')
-        .select('user_id, users ( username )')
-        .neq('user_id', user.id);
+        .select('user_id, users ( username )');
       if (error) throw error;
       if (!chatters || chatters.length === 0) {
         client.say(channel, `@${tags.username}, сейчас нет других участников.`);
@@ -450,7 +449,8 @@ client.on('message', async (channel, tags, message, self) => {
       const variantTwo = context.variant_two || '';
       const percent = Math.floor(Math.random() * 101);
       const authorName = `@${tags.username}`;
-      const partnerName = `@${partnerUser.username}`;
+      const isSelf = partnerUser.id === user.id;
+      const partnerName = isSelf ? 'самим собой' : `@${partnerUser.username}`;
       const text = tagArg
         ? `${percent}% шанс того, что ${authorName} ${variantTwo} интимиться с ${partnerName} ${variantOne}`
         : `${percent}% шанс того, что у ${authorName} ${variantOne} будет интим с ${partnerName}`;


### PR DESCRIPTION
## Summary
- allow !интим to include author in random pool
- handle self-selection with appropriate message
- test self-selection scenarios

## Testing
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_6896117572288320ab17f4f5a464ee61