### PR TITLE
feat(bot): mention tagged user in intim command

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -656,7 +656,7 @@ describe('!интим', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что @author тайно интимиться с @partner в кустах'
+      '50% шанс того, что @author тайно @target интимиться с @partner в кустах'
     );
     Math.random.mockRestore();
   });
@@ -702,7 +702,7 @@ describe('!интим', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что @author тайно интимиться с самим собой в кустах'
+      '50% шанс того, что @author тайно @target интимиться с самим собой в кустах'
     );
     Math.random.mockRestore();
   });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -452,7 +452,7 @@ client.on('message', async (channel, tags, message, self) => {
       const isSelf = partnerUser.id === user.id;
       const partnerName = isSelf ? 'самим собой' : `@${partnerUser.username}`;
       const text = tagArg
-        ? `${percent}% шанс того, что ${authorName} ${variantTwo} интимиться с ${partnerName} ${variantOne}`
+        ? `${percent}% шанс того, что ${authorName} ${variantTwo} ${tagArg} интимиться с ${partnerName} ${variantOne}`
         : `${percent}% шанс того, что у ${authorName} ${variantOne} будет интим с ${partnerName}`;
       client.say(channel, text);
     } catch (err) {


### PR DESCRIPTION
## Summary
- include tagged user in `!интим` command responses
- adjust tests for new `!интим` formatting

## Testing
- `cd bot && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896151e3778832095921b2ed92f2bdd