### PR TITLE
Use existing intim_tagged_equals_partner stats for tag matches

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -479,12 +479,8 @@ client.on('message', async (channel, tags, message, self) => {
         if (isSelf) {
           columns.push(`intim_self_${tagType}_${suffix}`);
         }
-        if (hasTag) {
-          const matchType = partnerMatchesTag ? 'tag_match' : 'tag_mismatch';
-          columns.push(`intim_${matchType}_${suffix}`);
-          if (isSelf) {
-            columns.push(`intim_self_${matchType}_${suffix}`);
-          }
+        if (partnerMatchesTag) {
+          columns.push(`intim_tagged_equals_partner_${suffix}`);
         }
         await Promise.all(
           columns.map((col) => incrementUserStat(user.id, col))


### PR DESCRIPTION
## Summary
- Increment `intim_tagged_equals_partner_${suffix}` when tag matches partner during `!интим`
- Remove obsolete `tag_match`/`tag_mismatch` references

## Testing
- `cd bot && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68965c8c7cc48320bfcab7d9ee3311fd