### PR TITLE
Expose extra user intimacy fields

### DIFF
--- a/backend/__tests__/users.test.js
+++ b/backend/__tests__/users.test.js
@@ -16,6 +16,8 @@ const users = [
     total_times_tagged: 0,
     total_commands_run: 0,
     total_months_subbed: 0,
+    intim_no_tag_0: 1,
+    poceluy_with_tag_69: 2,
   },
   {
     id: 2,
@@ -160,10 +162,12 @@ describe('GET /api/users', () => {
 });
 
 describe('GET /api/users/:id', () => {
-  it('includes vote and roulette counts', async () => {
+  it('includes vote and roulette counts and custom fields', async () => {
     const res = await request(app).get('/api/users/1');
     expect(res.status).toBe(200);
     expect(res.body.user.votes).toBe(3);
     expect(res.body.user.roulettes).toBe(2);
+    expect(res.body.user.intim_no_tag_0).toBe(1);
+    expect(res.body.user.poceluy_with_tag_69).toBe(2);
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -1055,15 +1055,35 @@ app.get('/api/users/:id', async (req, res) => {
     return res.status(400).json({ error: 'Invalid user id' });
   }
 
-  const { data: user, error: userError } = await supabase
+  const { data: row, error: userError } = await supabase
     .from('users')
-    .select(
-      'id, username, auth_id, twitch_login, total_streams_watched, total_subs_gifted, total_subs_received, total_chat_messages_sent, total_times_tagged, total_commands_run, total_months_subbed'
-    )
+    .select('*')
     .eq('id', userId)
     .maybeSingle();
   if (userError) return res.status(500).json({ error: userError.message });
-  if (!user) return res.status(404).json({ error: 'User not found' });
+  if (!row) return res.status(404).json({ error: 'User not found' });
+
+  const baseUser = {
+    id: row.id,
+    username: row.username,
+    auth_id: row.auth_id,
+    twitch_login: row.twitch_login,
+    total_streams_watched: row.total_streams_watched,
+    total_subs_gifted: row.total_subs_gifted,
+    total_subs_received: row.total_subs_received,
+    total_chat_messages_sent: row.total_chat_messages_sent,
+    total_times_tagged: row.total_times_tagged,
+    total_commands_run: row.total_commands_run,
+    total_months_subbed: row.total_months_subbed,
+  };
+
+  for (const [key, value] of Object.entries(row)) {
+    if (key.startsWith('intim_') || key.startsWith('poceluy_')) {
+      baseUser[key] = value;
+    }
+  }
+
+  const user = baseUser;
 
   const { data: votes, error: votesError } = await supabase
     .from('votes')


### PR DESCRIPTION
## Summary
- include columns beginning with `intim_` and `poceluy_` in `/api/users/:id` response
- add mock data and tests for new user fields

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68967377b3f08320ad2bf8bb48e9e8ec