### PR TITLE
Add tests for custom user stats

### DIFF
--- a/backend/__tests__/users.test.js
+++ b/backend/__tests__/users.test.js
@@ -17,6 +17,8 @@ const users = [
     total_commands_run: 0,
     total_months_subbed: 0,
     intim_no_tag_0: 1,
+    intim_with_tag_69: 3,
+    poceluy_no_tag_0: 4,
     poceluy_with_tag_69: 2,
   },
   {
@@ -31,6 +33,8 @@ const users = [
     total_times_tagged: 0,
     total_commands_run: 0,
     total_months_subbed: 0,
+    intim_no_tag_0: 0,
+    poceluy_with_tag_69: 0,
   },
   {
     id: 3,
@@ -44,6 +48,8 @@ const users = [
     total_times_tagged: 0,
     total_commands_run: 0,
     total_months_subbed: 0,
+    intim_no_tag_0: 0,
+    poceluy_with_tag_69: 0,
   },
 ];
 
@@ -137,6 +143,8 @@ describe('GET /api/users', () => {
     const res = await request(app).get('/api/users');
     expect(res.status).toBe(200);
     expect(res.body.users.length).toBe(3);
+    expect(res.body.users[0].intim_no_tag_0).toBe(1);
+    expect(res.body.users[0].poceluy_with_tag_69).toBe(2);
   });
 
   it('filters by username', async () => {
@@ -156,6 +164,10 @@ describe('GET /api/users', () => {
         total_commands_run: 0,
         total_months_subbed: 0,
         logged_in: false,
+        intim_no_tag_0: 1,
+        intim_with_tag_69: 3,
+        poceluy_no_tag_0: 4,
+        poceluy_with_tag_69: 2,
       },
     ]);
   });
@@ -168,6 +180,8 @@ describe('GET /api/users/:id', () => {
     expect(res.body.user.votes).toBe(3);
     expect(res.body.user.roulettes).toBe(2);
     expect(res.body.user.intim_no_tag_0).toBe(1);
+    expect(res.body.user.intim_with_tag_69).toBe(3);
+    expect(res.body.user.poceluy_no_tag_0).toBe(4);
     expect(res.body.user.poceluy_with_tag_69).toBe(2);
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -1020,31 +1020,35 @@ app.post('/api/log_reward_ids', requireModerator, async (req, res) => {
 // List all users
 app.get('/api/users', async (req, res) => {
   const search = req.query.search || req.query.q;
-  let builder = supabase
-    .from('users')
-    .select(
-      'id, username, auth_id, twitch_login, total_streams_watched, total_subs_gifted, total_subs_received, total_chat_messages_sent, total_times_tagged, total_commands_run, total_months_subbed'
-    );
+  let builder = supabase.from('users').select('*');
   if (search) {
     builder = builder.ilike('username', `%${search}%`);
   }
   builder = builder.order('username', { ascending: true });
   const { data, error } = await builder;
   if (error) return res.status(500).json({ error: error.message });
-  const users = (data || []).map((u) => ({
-    id: u.id,
-    username: u.username,
-    auth_id: u.auth_id,
-    twitch_login: u.twitch_login,
-    total_streams_watched: u.total_streams_watched,
-    total_subs_gifted: u.total_subs_gifted,
-    total_subs_received: u.total_subs_received,
-    total_chat_messages_sent: u.total_chat_messages_sent,
-    total_times_tagged: u.total_times_tagged,
-    total_commands_run: u.total_commands_run,
-    total_months_subbed: u.total_months_subbed,
-    logged_in: !!u.auth_id,
-  }));
+  const users = (data || []).map((u) => {
+    const base = {
+      id: u.id,
+      username: u.username,
+      auth_id: u.auth_id,
+      twitch_login: u.twitch_login,
+      total_streams_watched: u.total_streams_watched,
+      total_subs_gifted: u.total_subs_gifted,
+      total_subs_received: u.total_subs_received,
+      total_chat_messages_sent: u.total_chat_messages_sent,
+      total_times_tagged: u.total_times_tagged,
+      total_commands_run: u.total_commands_run,
+      total_months_subbed: u.total_months_subbed,
+      logged_in: !!u.auth_id,
+    };
+    for (const [key, value] of Object.entries(u)) {
+      if (key.startsWith('intim_') || key.startsWith('poceluy_')) {
+        base[key] = value;
+      }
+    }
+    return base;
+  });
   res.json({ users });
 });
 

--- a/frontend/components/__tests__/UserPage.test.tsx
+++ b/frontend/components/__tests__/UserPage.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, act, fireEvent } from "@testing-library/react";
+
+process.env.NEXT_PUBLIC_BACKEND_URL = "http://backend";
+
+const UserPage = require("@/app/users/[id]/page").default;
+
+jest.mock("@/lib/useTwitchUserInfo", () => ({
+  useTwitchUserInfo: () => ({ profileUrl: null, roles: [], error: null }),
+}));
+
+describe("UserPage", () => {
+  it("shows stats when categories expand", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          user: {
+            id: 1,
+            username: "Alice",
+            auth_id: null,
+            twitch_login: null,
+            logged_in: false,
+            total_streams_watched: 0,
+            total_subs_gifted: 0,
+            total_subs_received: 0,
+            total_chat_messages_sent: 0,
+            total_times_tagged: 0,
+            total_commands_run: 0,
+            total_months_subbed: 0,
+            votes: 3,
+            roulettes: 2,
+            intim_no_tag_0: 1,
+            poceluy_with_tag_69: 2,
+          },
+          history: [],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ games: [] }),
+      });
+
+    (global as any).fetch = fetchMock;
+
+    await act(async () => {
+      render(<UserPage params={Promise.resolve({ id: "1" })} />);
+    });
+
+    await screen.findByText("Votes: 3");
+
+    const intimSummary = screen.getByText("Интимы");
+    fireEvent.click(intimSummary);
+    expect(intimSummary.closest("details")).toHaveAttribute("open");
+    expect(screen.getByText("intim_no_tag_0: 1")).toBeInTheDocument();
+
+    const poceluySummary = screen.getByText("Поцелуи");
+    fireEvent.click(poceluySummary);
+    expect(poceluySummary.closest("details")).toHaveAttribute("open");
+    expect(screen.getByText("poceluy_with_tag_69: 2")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- include dynamic intim_* and poceluy_* fields in user list endpoint
- extend users tests for custom stats
- add user page test ensuring stats categories expand

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689676deaa708320b61979498f06e7b7