### PR TITLE
Add intimacy and kiss stats endpoints

### DIFF
--- a/backend/__tests__/stats.test.js
+++ b/backend/__tests__/stats.test.js
@@ -14,8 +14,21 @@ const games = [
 ];
 const pollGames = [{ game_id: 1 }, { game_id: 1 }, { game_id: 2 }];
 const users = [
-  { id: 1, username: 'Alice' },
-  { id: 2, username: 'Bob' },
+  {
+    id: 1,
+    username: 'Alice',
+    intim_no_tag_0: 2,
+    intim_with_tag_69: 1,
+    poceluy_no_tag_0: 3,
+    poceluy_with_tag_69: 2,
+  },
+  {
+    id: 2,
+    username: 'Bob',
+    intim_no_tag_0: 5,
+    poceluy_no_tag_0: 4,
+    poceluy_with_tag_69: 0,
+  },
 ];
 
 const build = (data) => {
@@ -108,6 +121,30 @@ describe('stats endpoints', () => {
     expect(res.body.users).toEqual([
       { id: 1, username: 'Alice', roulettes: 2 },
       { id: 2, username: 'Bob', roulettes: 1 },
+    ]);
+  });
+
+  it('returns top intim stats', async () => {
+    const res = await request(app).get('/api/stats/intim');
+    expect(res.status).toBe(200);
+    expect(res.body.stats.intim_no_tag_0).toEqual([
+      { id: 2, username: 'Bob', value: 5 },
+      { id: 1, username: 'Alice', value: 2 },
+    ]);
+    expect(res.body.stats.intim_with_tag_69).toEqual([
+      { id: 1, username: 'Alice', value: 1 },
+    ]);
+  });
+
+  it('returns top poceluy stats', async () => {
+    const res = await request(app).get('/api/stats/poceluy');
+    expect(res.status).toBe(200);
+    expect(res.body.stats.poceluy_no_tag_0).toEqual([
+      { id: 2, username: 'Bob', value: 4 },
+      { id: 1, username: 'Alice', value: 3 },
+    ]);
+    expect(res.body.stats.poceluy_with_tag_69).toEqual([
+      { id: 1, username: 'Alice', value: 2 },
     ]);
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,6 +31,56 @@ if (!SUPABASE_URL || !SUPABASE_KEY) {
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
+const INTIM_COLUMNS = [
+  'intim_no_tag_0',
+  'intim_no_tag_69',
+  'intim_no_tag_100',
+  'intim_with_tag_0',
+  'intim_with_tag_69',
+  'intim_with_tag_100',
+  'intim_self_no_tag',
+  'intim_self_no_tag_0',
+  'intim_self_no_tag_69',
+  'intim_self_no_tag_100',
+  'intim_self_with_tag',
+  'intim_self_with_tag_0',
+  'intim_self_with_tag_69',
+  'intim_self_with_tag_100',
+  'intim_tagged_equals_partner',
+  'intim_tagged_equals_partner_0',
+  'intim_tagged_equals_partner_69',
+  'intim_tagged_equals_partner_100',
+  'intim_tag_match_success',
+  'intim_tag_match_success_0',
+  'intim_tag_match_success_69',
+  'intim_tag_match_success_100',
+];
+
+const POCELUY_COLUMNS = [
+  'poceluy_no_tag_0',
+  'poceluy_no_tag_69',
+  'poceluy_no_tag_100',
+  'poceluy_with_tag_0',
+  'poceluy_with_tag_69',
+  'poceluy_with_tag_100',
+  'poceluy_self_no_tag',
+  'poceluy_self_no_tag_0',
+  'poceluy_self_no_tag_69',
+  'poceluy_self_no_tag_100',
+  'poceluy_self_with_tag',
+  'poceluy_self_with_tag_0',
+  'poceluy_self_with_tag_69',
+  'poceluy_self_with_tag_100',
+  'poceluy_tagged_equals_partner',
+  'poceluy_tagged_equals_partner_0',
+  'poceluy_tagged_equals_partner_69',
+  'poceluy_tagged_equals_partner_100',
+  'poceluy_tag_match_success',
+  'poceluy_tag_match_success_0',
+  'poceluy_tag_match_success_69',
+  'poceluy_tag_match_success_100',
+];
+
 // Exchange Twitch OAuth code for an access token
 app.post('/auth/twitch-token', async (req, res) => {
   const { code } = req.body;
@@ -1941,6 +1991,42 @@ app.get('/api/logs', async (req, res) => {
   res.json({ logs: data });
 });
 
+app.get('/api/stats/intim', async (_req, res) => {
+  const { data, error } = await supabase
+    .from('users')
+    .select(['id', 'username', ...INTIM_COLUMNS].join(', '));
+  if (error) return res.status(500).json({ error: error.message });
+
+  const stats = {};
+  const rows = data || [];
+  for (const col of INTIM_COLUMNS) {
+    stats[col] = rows
+      .map((u) => ({ id: u.id, username: u.username, value: u[col] || 0 }))
+      .filter((u) => u.value > 0)
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 5);
+  }
+  res.json({ stats });
+});
+
+app.get('/api/stats/poceluy', async (_req, res) => {
+  const { data, error } = await supabase
+    .from('users')
+    .select(['id', 'username', ...POCELUY_COLUMNS].join(', '));
+  if (error) return res.status(500).json({ error: error.message });
+
+  const stats = {};
+  const rows = data || [];
+  for (const col of POCELUY_COLUMNS) {
+    stats[col] = rows
+      .map((u) => ({ id: u.id, username: u.username, value: u[col] || 0 }))
+      .filter((u) => u.value > 0)
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 5);
+  }
+  res.json({ stats });
+});
+
 // Aggregate vote counts by game
 app.get('/api/stats/popular-games', async (_req, res) => {
   const { data: votes, error: votesErr } = await supabase
@@ -2050,5 +2136,6 @@ if (require.main === module) {
     console.log(`Server listening on port ${port}`);
   });
 }
-
+app.INTIM_COLUMNS = INTIM_COLUMNS;
+app.POCELUY_COLUMNS = POCELUY_COLUMNS;
 module.exports = app;


### PR DESCRIPTION
## Summary
- track intimacy and kiss statistics via enumerated column lists
- provide `/api/stats/intim` and `/api/stats/poceluy` endpoints returning top users per stat
- expose column arrays for potential frontend use

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896ff259f808320a7cc0daa7f6af21d