### PR TITLE
feat: load Eruda console on Android

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -6,6 +6,7 @@ import SettingsLink from "@/components/SettingsLink";
 import TwitchVideos from "@/components/TwitchVideos";
 import TwitchClips from "@/components/TwitchClips";
 import EventLog from "@/components/EventLog";
+import Eruda from "@/components/Eruda";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -43,6 +44,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background font-sans antialiased flex flex-col`}
       >
+        <Eruda />
         <header className="bg-muted text-foreground border-b p-4">
           <nav className="flex justify-between items-center">
             <div className="flex space-x-4">

--- a/frontend/components/Eruda.tsx
+++ b/frontend/components/Eruda.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Eruda() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!/Android/i.test(navigator.userAgent)) return;
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/eruda';
+    document.body.appendChild(script);
+    script.onload = () => {
+      // @ts-ignore
+      eruda.init();
+      // Display toggle button instead of opening console
+      // @ts-ignore
+      eruda.hide();
+    };
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## Summary
- load Eruda only on Android devices to enable debugging console
- initialize mobile console in root layout
- hide console after init so toggle button appears

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68970812a84083208db61531dd79b2ab