### PR TITLE
Fix Eruda initialization to show debug button

### DIFF
--- a/frontend/components/Eruda.tsx
+++ b/frontend/components/Eruda.tsx
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 export default function Eruda() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    if (!/Android/i.test(navigator.userAgent)) return;
     const script = document.createElement('script');
     script.src = 'https://cdn.jsdelivr.net/npm/eruda';
     document.body.appendChild(script);


### PR DESCRIPTION
## Summary
- remove Android user agent restriction so Eruda loads on any device

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68970e851d28832095c7e6721795fcdc