### PR TITLE
Rename StatUser count to value

### DIFF
--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -31,7 +31,7 @@ interface TopParticipant {
 interface StatUser {
   id: number;
   username: string;
-  count: number;
+  value: number;
 }
 
 interface StatsResponse {
@@ -240,7 +240,7 @@ export default function StatsPage() {
                               {u.username}
                             </Link>
                           </td>
-                          <td className="p-2 text-right">{u.count}</td>
+                          <td className="p-2 text-right">{u.value}</td>
                         </tr>
                       ))}
                     </tbody>
@@ -281,7 +281,7 @@ export default function StatsPage() {
                               {u.username}
                             </Link>
                           </td>
-                          <td className="p-2 text-right">{u.count}</td>
+                          <td className="p-2 text-right">{u.value}</td>
                         </tr>
                       ))}
                     </tbody>


### PR DESCRIPTION
## Summary
- update StatUser interface to use `value` instead of `count`
- adjust stats tables to read `u.value`

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_6897257911cc83208baba8934d6584e0