### PR TITLE
Group stats tables by percent categories

### DIFF
--- a/frontend/lib/statLabels.ts
+++ b/frontend/lib/statLabels.ts
@@ -47,3 +47,19 @@ export const POCELUY_LABELS: Record<string, string> = {
   poceluy_tag_match_success_69: "Заставил кого-то поцеловаться с самим собой с 69%",
   poceluy_tag_match_success_100: "Заставил кого-то поцеловаться с самим собой 100%",
 };
+
+export type StatCategory = "none" | "0" | "69" | "100";
+
+export function getIntimCategory(key: string): StatCategory {
+  if (key.endsWith("_0")) return "0";
+  if (key.endsWith("_69")) return "69";
+  if (key.endsWith("_100")) return "100";
+  return "none";
+}
+
+export function getPoceluyCategory(key: string): StatCategory {
+  if (key.endsWith("_0")) return "0";
+  if (key.endsWith("_69")) return "69";
+  if (key.endsWith("_100")) return "100";
+  return "none";
+}


### PR DESCRIPTION
## Summary
- add `getIntimCategory` and `getPoceluyCategory` helpers for suffix-based categories
- refactor stats page to group tables using new category helpers

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689755a8cd8c8320856a5ef7b851744d