### PR TITLE
feat: add responsive mobile navigation

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
 import AuthStatus from "@/components/AuthStatus";
 import SettingsLink from "@/components/SettingsLink";
+import MobileMenu from "@/components/MobileMenu";
 import TwitchVideos from "@/components/TwitchVideos";
 import TwitchClips from "@/components/TwitchClips";
 import EventLog from "@/components/EventLog";
@@ -46,15 +47,18 @@ export default function RootLayout({
       >
         <Eruda />
         <header className="bg-muted text-foreground border-b p-4">
-          <nav className="flex justify-between items-center">
-            <div className="flex space-x-4">
-              <Link href="/">Home</Link>
-              <Link href="/archive">Archive</Link>
-              <Link href="/games">Games</Link>
-              <Link href="/users">Users</Link>
-              <Link href="/stats">Stats</Link>
-              <Link href="/playlists">Playlists</Link>
-              <SettingsLink />
+          <nav className="flex justify-between items-center relative">
+            <div className="flex items-center">
+              <MobileMenu />
+              <div className="hidden md:flex space-x-4">
+                <Link href="/">Home</Link>
+                <Link href="/archive">Archive</Link>
+                <Link href="/games">Games</Link>
+                <Link href="/users">Users</Link>
+                <Link href="/stats">Stats</Link>
+                <Link href="/playlists">Playlists</Link>
+                <SettingsLink />
+              </div>
             </div>
             <div className="flex items-center space-x-4">
               <a

--- a/frontend/components/MobileMenu.tsx
+++ b/frontend/components/MobileMenu.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import SettingsLink from "@/components/SettingsLink";
+
+export default function MobileMenu() {
+  const [open, setOpen] = useState(false);
+
+  const toggle = () => setOpen((prev) => !prev);
+  const close = () => setOpen(false);
+
+  return (
+    <div className="md:hidden">
+      <button
+        onClick={toggle}
+        className="p-2 focus:outline-none"
+        aria-label="Toggle menu"
+      >
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          strokeWidth="2"
+        >
+          {open ? (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          ) : (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4 6h16M4 12h16M4 18h16"
+            />
+          )}
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full w-full bg-muted text-foreground flex flex-col space-y-2 p-4 animate-in fade-in slide-in-from-top-2">
+          <Link href="/" onClick={close}>
+            Home
+          </Link>
+          <Link href="/archive" onClick={close}>
+            Archive
+          </Link>
+          <Link href="/games" onClick={close}>
+            Games
+          </Link>
+          <Link href="/users" onClick={close}>
+            Users
+          </Link>
+          <Link href="/stats" onClick={close}>
+            Stats
+          </Link>
+          <Link href="/playlists" onClick={close}>
+            Playlists
+          </Link>
+          <div onClick={close}>
+            <SettingsLink />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- hide desktop nav links on small screens and add a mobile menu toggle
- create animated MobileMenu component with vertical link list

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6898b93b95508320bbd808552457a765