### PR TITLE
Adjust layout grid for responsive columns

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -102,11 +102,13 @@ export default function RootLayout({
           </nav>
         </header>
         <main className="mt-4 flex-grow">
-          <div className="container mx-auto px-0 grid grid-cols-12 gap-x-2 gap-y-4 items-start min-h-[calc(100vh-64px)]">
-            <div className="col-span-9 bg-muted rounded-lg p-4 h-full">
+          <div
+            className="container mx-auto px-0 grid grid-cols-1 md:grid-cols-12 gap-x-2 gap-y-4 items-start min-h-[calc(100vh-64px)]"
+          >
+            <div className="col-span-12 md:col-span-9 bg-muted rounded-lg p-4 h-full">
               {children}
             </div>
-            <div className="col-span-3 col-start-10 space-y-4 bg-muted rounded-lg p-4 h-full">
+            <div className="col-span-12 md:col-span-3 md:col-start-10 space-y-4 bg-muted rounded-lg p-4 h-full">
               <EventLog />
               <TwitchVideos />
               <TwitchClips />


### PR DESCRIPTION
## Summary
- refine top-level layout grid to switch from single to 12 columns on medium screens
- expand main content to full width on small screens and 9 columns on medium+
- update sidebar to stack on small screens and occupy 3 columns starting at 10th on larger screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898bcb0e32883208018015a85030c37