### PR TITLE
feat: make grid layouts responsive

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -167,8 +167,8 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
 
   return (
     <>
-      <main className="col-span-9 grid grid-cols-9 gap-x-2 gap-y-4 max-w-5xl">
-        <div className="col-span-3 px-2 py-4 space-y-4 overflow-y-auto">
+      <main className="col-span-12 md:col-span-9 grid grid-cols-1 md:grid-cols-9 gap-x-2 gap-y-4 max-w-5xl">
+        <div className="col-span-12 md:col-span-3 px-2 py-4 space-y-4 overflow-y-auto">
           <Link href="/archive" className="text-purple-600 underline">
             Back to archive
           </Link>
@@ -248,7 +248,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
           ))}
         </ul>
         </div>
-        <div className="col-span-6 px-2 py-4 flex flex-col items-center justify-start">
+        <div className="col-span-12 md:col-span-6 px-2 py-4 flex flex-col items-center justify-start">
         {rouletteGames.length > 0 && !winner && (
           <>
             <RouletteWheel

--- a/frontend/app/archive/page.tsx
+++ b/frontend/app/archive/page.tsx
@@ -120,7 +120,7 @@ export default function ArchivePage() {
   }
 
   return (
-    <main className="col-span-9 p-4 space-y-4">
+    <main className="col-span-12 md:col-span-9 p-4 space-y-4">
       <h1 className="text-2xl font-semibold">Roulette Archive</h1>
       <ul className="space-y-2">
         <li className="border-2 border-purple-600 p-2 rounded-lg bg-purple-50">

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -92,7 +92,7 @@ export default function GamePage({
   );
 
   return (
-    <main className="col-span-9 p-4 space-y-4">
+    <main className="col-span-12 md:col-span-9 p-4 space-y-4">
       <Link href="/games" className="text-purple-600 underline">
         Back to games
       </Link>

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -219,7 +219,7 @@ export default function GamesPage() {
 
   return (
     <>
-    <main className="col-span-9 p-4 space-y-6">
+    <main className="col-span-12 md:col-span-9 p-4 space-y-6">
       <h1 className="text-2xl font-semibold">Games</h1>
       {isModerator && (
         <button

--- a/frontend/app/new-poll/page.tsx
+++ b/frontend/app/new-poll/page.tsx
@@ -122,7 +122,7 @@ function NewPollPageContent() {
 
   return (
     <>
-      <main className="col-span-9 p-4 space-y-4">
+      <main className="col-span-12 md:col-span-9 p-4 space-y-4">
       <h1 className="text-2xl font-semibold">New Roulette</h1>
       <div className="flex items-center space-x-2">
         <label className="text-sm">Add to archive only:</label>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -452,8 +452,8 @@ export default function Home() {
 
   return (
     <>
-      <main className="col-span-9 grid grid-cols-9 gap-x-2 gap-y-4 max-w-5xl">
-        <div className="col-span-3 px-2 py-4 space-y-4 overflow-y-auto">
+      <main className="col-span-12 md:col-span-9 grid grid-cols-1 md:grid-cols-9 gap-x-2 gap-y-4 max-w-5xl">
+        <div className="col-span-12 md:col-span-3 px-2 py-4 space-y-4 overflow-y-auto">
         <h1 className="text-2xl font-semibold">Current Poll</h1>
         {isModerator && (
           <div className="space-x-2">
@@ -567,7 +567,7 @@ export default function Home() {
         You have used {usedVotes} of {voteLimit} votes.
       </p>
         </div>
-        <div className="col-span-6 px-2 py-4 flex flex-col items-center justify-start">
+        <div className="col-span-12 md:col-span-6 px-2 py-4 flex flex-col items-center justify-start">
         {rouletteGames.length > 0 && !winner && (
           <>
             <RouletteWheel

--- a/frontend/app/playlists/page.tsx
+++ b/frontend/app/playlists/page.tsx
@@ -67,7 +67,7 @@ export default function PlaylistsPage() {
 
   return (
     <>
-      <main className="col-span-9 p-4 space-y-6">
+      <main className="col-span-12 md:col-span-9 p-4 space-y-6">
         <h1 className="text-2xl font-semibold">Playlists</h1>
         {tags.map((tag) => (
           <PlaylistRow

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -182,7 +182,7 @@ export default function SettingsPage() {
   if (!isModerator) return <div className="p-4">Access denied.</div>;
 
   return (
-    <main className="col-span-9 p-4 space-y-4">
+    <main className="col-span-12 md:col-span-9 p-4 space-y-4">
       <h1 className="text-2xl font-semibold">Settings</h1>
       {rewards.length === 0 ? (
         <p>No rewards found.</p>

--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -117,7 +117,7 @@ export default function StatsPage() {
   const poceluyCategories = categorizeBy(poceluy, getPoceluyCategory);
 
   return (
-    <main className="col-span-9 p-4 space-y-6">
+    <main className="col-span-12 md:col-span-9 p-4 space-y-6">
       <h1 className="text-2xl font-semibold">Statistics</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <section className="space-y-2">

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -104,7 +104,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   if (!user) return <div className="p-4">User not found.</div>;
 
   return (
-    <main className="col-span-9 p-4 space-y-4">
+    <main className="col-span-12 md:col-span-9 p-4 space-y-4">
       <Link href="/users" className="text-purple-600 underline">
         Back to users
       </Link>

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -93,7 +93,7 @@ export default function UsersPage() {
   }
 
   return (
-    <main className="col-span-9 p-4 space-y-4">
+    <main className="col-span-12 md:col-span-9 p-4 space-y-4">
       <h1 className="text-2xl font-semibold">Users</h1>
       <input
         type="text"


### PR DESCRIPTION
## Summary
- make `<main>` and auxiliary blocks span full width on small screens
- switch nested 9-column grids to single column layouts below `md`

## Testing
- `npm test`
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6898be2782ec8320a13ca27e2d510e0e