### PR TITLE
feat: add horizontal scroll to stats table

### DIFF
--- a/frontend/components/StatsTable.tsx
+++ b/frontend/components/StatsTable.tsx
@@ -23,29 +23,31 @@ export default function StatsTable({ title, rows }: Props) {
         <p>No data.</p>
       ) : (
         <div className="max-h-60 overflow-y-auto">
-          <table className="min-w-full border">
-            <thead>
-              <tr className="bg-muted">
-                <th className="p-2 text-left">User</th>
-                <th className="p-2 text-right">{title}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((u) => (
-                <tr key={u.id} className="border-t">
-                  <td className="p-2">
-                    <Link
-                      href={`/users/${u.id}`}
-                      className="text-purple-600 underline"
-                    >
-                      {u.username}
-                    </Link>
-                  </td>
-                  <td className="p-2 text-right">{u.value}</td>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-max border">
+              <thead>
+                <tr className="bg-muted">
+                  <th className="p-2 text-left">User</th>
+                  <th className="p-2 text-right">{title}</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {rows.map((u) => (
+                  <tr key={u.id} className="border-t">
+                    <td className="p-2">
+                      <Link
+                        href={`/users/${u.id}`}
+                        className="text-purple-600 underline"
+                      >
+                        {u.username}
+                      </Link>
+                    </td>
+                    <td className="p-2 text-right">{u.value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </details>


### PR DESCRIPTION
## Summary
- wrap stats table with horizontally scrollable container
- prevent stats table cells from shrinking

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6898c3be83408320b99473563640d170