### PR TITLE
feat(frontend): adjust sidebar for responsive layout

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -108,7 +108,12 @@ export default function RootLayout({
             <div className="col-span-12 md:col-span-9 bg-muted rounded-lg p-4 h-full">
               {children}
             </div>
-            <div className="col-span-12 md:col-span-3 md:col-start-10 space-y-4 bg-muted rounded-lg p-4 h-full">
+            <div className="hidden md:block col-span-12 md:col-span-3 md:col-start-10 space-y-4 bg-muted rounded-lg p-4 h-full">
+              <EventLog />
+              <TwitchVideos />
+              <TwitchClips />
+            </div>
+            <div className="order-last md:order-none md:hidden col-span-12 space-y-4 bg-muted rounded-lg p-4 h-full">
               <EventLog />
               <TwitchVideos />
               <TwitchClips />


### PR DESCRIPTION
## Summary
- hide sidebar on small screens
- render sidebar content below main content on mobile

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c5e67cf08320a68a95e6fa1914db