### PR TITLE
feat: add horizontal scroll for tables

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -194,6 +194,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
             )}
           </div>
         )}
+        <div className="overflow-x-auto">
         <ul className="space-y-2">
           {poll.games.map((game) => (
             <li
@@ -212,7 +213,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
                   />
                 </>
               )}
-              <div className="flex items-center space-x-2 relative z-10 text-white w-full">
+              <div className="flex items-center space-x-2 relative z-10 text-white w-full text-sm whitespace-nowrap">
                 <Link
                   href={`/games/${game.id}`}
                   className={cn(

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -190,9 +190,9 @@ export default function GamePage({
                     Winner is {p.winnerName}
                   </Link>
                 )}
-                <div className="pl-4">
+                <div className="pl-4 overflow-x-auto">
                   {p.voters.map((v) => (
-                    <div key={v.id} className="text-sm">
+                    <div key={v.id} className="text-sm whitespace-nowrap">
                       {v.count}{" "}
                       <Link
                         href={`/users/${v.id}`}

--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -165,7 +165,7 @@ export default function GamesPage() {
             />
         </>
       )}
-      <div className="flex items-center space-x-2 relative z-10 text-white">
+      <div className="flex items-center space-x-2 relative z-10 text-white text-sm whitespace-nowrap">
         <Link
           href={`/games/${g.id}`}
           className={cn(
@@ -360,7 +360,9 @@ export default function GamesPage() {
         {games.length === 0 ? (
           <p>No games.</p>
         ) : (
-          <ul className="space-y-2">{games.map(renderGame)}</ul>
+          <div className="overflow-x-auto">
+            <ul className="space-y-2">{games.map(renderGame)}</ul>
+          </div>
         )}
       </section>
     </main>

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -37,7 +37,7 @@ function UserRowBase({
   roles: string[];
 }) {
   return (
-    <li className="flex items-center space-x-2 border p-2 rounded-lg bg-muted">
+    <li className="flex items-center space-x-2 border p-2 rounded-lg bg-muted text-sm whitespace-nowrap">
       <span className="flex items-center space-x-1">
         {roles.map((r) =>
           ROLE_ICONS[r] ? (
@@ -130,19 +130,21 @@ export default function UsersPage() {
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
-      <ul className="space-y-2">
-        {users.map((u) =>
-          enableTwitchRoles ? (
-            <UserRow
-              key={u.id}
-              user={u}
-              requiredRoles={selectedRoles}
-            />
-          ) : (
-            <UserRowBase key={u.id} user={u} roles={[]} />
-          )
-        )}
-      </ul>
+      <div className="overflow-x-auto">
+        <ul className="space-y-2">
+          {users.map((u) =>
+            enableTwitchRoles ? (
+              <UserRow
+                key={u.id}
+                user={u}
+                requiredRoles={selectedRoles}
+              />
+            ) : (
+              <UserRowBase key={u.id} user={u} roles={[]} />
+            )
+          )}
+        </ul>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- wrap multi-column lists with `overflow-x-auto`
- ensure columns stay readable on small screens using `text-sm` and `whitespace-nowrap`

## Testing
- `npm test`
- `npm run lint` *(fails: interactive setup required)*

------
https://chatgpt.com/codex/tasks/task_e_6898c75894508320a657e6ed3ae5d488