### PR TITLE
fix closing div in archive page

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -249,6 +249,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
           ))}
         </ul>
         </div>
+        </div>
         <div className="col-span-12 md:col-span-6 px-2 py-4 flex flex-col items-center justify-start">
         {rouletteGames.length > 0 && !winner && (
           <>


### PR DESCRIPTION
## Summary
- fix container structure in archived poll page by closing missing div

## Testing
- `npm run build` (fails: Supabase credentials are missing. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY)


------
https://chatgpt.com/codex/tasks/task_e_6898cbf7b7f483208e756f21cb28bd36