### PR TITLE
feat(bot): dockerize bot for Fly.io deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,24 @@ roulette via chat commands:
    npm start
    ```
 
+### Deploying the bot to Fly.io
+
+The repository includes a `Dockerfile` and `fly.toml` for deploying the bot on
+[Fly.io](https://fly.io) using Docker:
+
+1. Initialize the Fly application (creates `fly.toml` if it doesn't exist):
+   ```bash
+   fly launch --no-deploy
+   ```
+2. Configure the required secrets for your environment:
+   ```bash
+   fly secrets set SUPABASE_URL=... SUPABASE_KEY=... BOT_USERNAME=... TWITCH_CHANNEL=...
+   ```
+3. Deploy the bot:
+   ```bash
+   fly deploy
+   ```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/bot/.dockerignore
+++ b/bot/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+__tests__
+.env
+

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,0 +1,15 @@
+# Use Node.js 18 LTS on Alpine
+FROM node:18-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy source code
+COPY . .
+
+# Run the bot
+CMD ["npm", "start"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,11 @@
+app = "terrenkur-bot"
+primary_region = "ams"
+
+[build]
+  dockerfile = "bot/Dockerfile"
+
+[processes]
+  app = "npm start"
+
+[env]
+  NODE_ENV = "production"


### PR DESCRIPTION
## Summary
- add Dockerfile and .dockerignore for bot
- add Fly.io configuration
- document Fly.io deployment steps in README

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ff668b488320ad0f811465a44e2a