### PR TITLE
Add healthcheck wrapper server for bot and configure Fly.io

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -11,5 +11,8 @@ RUN npm ci --omit=dev
 # Copy source code
 COPY . .
 
+# Expose healthcheck port
+EXPOSE 3000
+
 # Run the bot
 CMD ["npm", "start"]

--- a/bot/__tests__/healthcheck.test.js
+++ b/bot/__tests__/healthcheck.test.js
@@ -1,0 +1,28 @@
+const http = require('http');
+
+jest.mock('../bot', () => {});
+
+let server;
+
+beforeAll(async () => {
+  server = require('../server');
+  if (!server.listening) {
+    await new Promise((resolve) => server.once('listening', resolve));
+  }
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+test('responds with 200 on /health', (done) => {
+  http.get('http://localhost:3000/health', (res) => {
+    expect(res.statusCode).toBe(200);
+    let body = '';
+    res.on('data', (chunk) => { body += chunk; });
+    res.on('end', () => {
+      expect(body).toBe('ok');
+      done();
+    });
+  }).on('error', done);
+});

--- a/bot/package.json
+++ b/bot/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "bot.js",
   "scripts": {
-    "start": "node bot.js",
+    "start": "node server.js",
     "test": "jest"
   },
   "dependencies": {

--- a/bot/server.js
+++ b/bot/server.js
@@ -1,0 +1,12 @@
+const http = require('http');
+const port = process.env.PORT || 3000;
+require('./bot');                    // starts the bot
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/health') { res.writeHead(200); res.end('ok'); }
+  else { res.writeHead(404); res.end(); }
+});
+
+server.listen(port, () => console.log(`Healthcheck listening on ${port}`));
+
+module.exports = server;

--- a/fly.toml
+++ b/fly.toml
@@ -9,3 +9,12 @@ primary_region = "ams"
 
 [env]
   NODE_ENV = "production"
+
+[http_service]
+  internal_port = 3000
+
+  [[http_service.checks]]
+    path = "/health"
+    interval = "15s"
+    timeout = "2s"
+    method = "get"


### PR DESCRIPTION
## Summary
- wrap bot with `server.js` exposing `/health` endpoint
- run server via updated npm start and Dockerfile exposing port 3000
- add Fly.io http_service config and healthcheck test

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a1fb9a16083209903a4b3726b66ba