### PR TITLE
Wrap intimate and kiss stats tables in collapsible lists

### DIFF
--- a/frontend/app/__tests__/StatsPage.intim-poceluy.test.tsx
+++ b/frontend/app/__tests__/StatsPage.intim-poceluy.test.tsx
@@ -46,12 +46,25 @@ describe("StatsPage intim & poceluy", () => {
 
     render(<StatsPage />);
 
-    expect(await screen.findByText("Интим: Без процентов")).toBeInTheDocument();
-    expect(screen.getByText("Интим: 69%" )).toBeInTheDocument();
-    expect(screen.getByText("Поцелуй: Без процентов" )).toBeInTheDocument();
-    expect(screen.getByText("Поцелуй: 0%" )).toBeInTheDocument();
+    const intimGroupSummary = await screen.findByText("Интимы");
+    fireEvent.click(intimGroupSummary);
+    const intimGroupDetails = intimGroupSummary.closest("details")!;
+    expect(within(intimGroupDetails).getByText("Интим: Без процентов"))
+      .toBeInTheDocument();
+    expect(within(intimGroupDetails).getByText("Интим: 69%"))
+      .toBeInTheDocument();
 
-    const intimNoneSummary = screen.getByText("Интим: Без процентов");
+    const poceluyGroupSummary = screen.getByText("Поцелуи");
+    fireEvent.click(poceluyGroupSummary);
+    const poceluyGroupDetails = poceluyGroupSummary.closest("details")!;
+    expect(within(poceluyGroupDetails).getByText("Поцелуй: Без процентов"))
+      .toBeInTheDocument();
+    expect(within(poceluyGroupDetails).getByText("Поцелуй: 0%"))
+      .toBeInTheDocument();
+
+    const intimNoneSummary = within(intimGroupDetails).getByText(
+      "Интим: Без процентов"
+    );
     fireEvent.click(intimNoneSummary);
     const intimNoneDetails = intimNoneSummary.closest("details")!;
     const intimGrid = intimNoneDetails.querySelector("div.grid")!;
@@ -68,7 +81,9 @@ describe("StatsPage intim & poceluy", () => {
     expect(intimTableContainer).toBeInTheDocument();
     expect(within(intimTableContainer).getByText("Alice")).toBeInTheDocument();
 
-    const poceluy0Summary = screen.getByText("Поцелуй: 0%");
+    const poceluy0Summary = within(poceluyGroupDetails).getByText(
+      "Поцелуй: 0%"
+    );
     fireEvent.click(poceluy0Summary);
     const poceluy0Details = poceluy0Summary.closest("details")!;
     const poceluyGrid = poceluy0Details.querySelector("div.grid")!;

--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -238,44 +238,54 @@ export default function StatsPage() {
         </section>
       </div>
       <div className="space-y-6">
-        {Object.entries(intimCategories).map(([category, stats]) => (
-          <details key={`intim-${category}`}>
-            <summary className="cursor-pointer font-semibold">
-              Интим: {CATEGORY_LABELS[category as Category]}
-            </summary>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
-              {Object.entries(stats).map(([key, users]) => {
-                const list = Array.isArray(users) ? users : [];
-                return (
-                  <StatsTable
-                    key={`intim-${key}`}
-                    title={INTIM_LABELS[key] ?? key}
-                    rows={list}
-                  />
-                );
-              })}
-            </div>
-          </details>
-        ))}
-        {Object.entries(poceluyCategories).map(([category, stats]) => (
-          <details key={`poceluy-${category}`}>
-            <summary className="cursor-pointer font-semibold">
-              Поцелуй: {CATEGORY_LABELS[category as Category]}
-            </summary>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
-              {Object.entries(stats).map(([key, users]) => {
-                const list = Array.isArray(users) ? users : [];
-                return (
-                  <StatsTable
-                    key={`poceluy-${key}`}
-                    title={POCELUY_LABELS[key] ?? key}
-                    rows={list}
-                  />
-                );
-              })}
-            </div>
-          </details>
-        ))}
+        <details>
+          <summary className="cursor-pointer text-xl font-semibold">Интимы</summary>
+          <div className="space-y-2 mt-2">
+            {Object.entries(intimCategories).map(([category, stats]) => (
+              <details key={`intim-${category}`}>
+                <summary className="cursor-pointer font-semibold">
+                  Интим: {CATEGORY_LABELS[category as Category]}
+                </summary>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
+                  {Object.entries(stats).map(([key, users]) => {
+                    const list = Array.isArray(users) ? users : [];
+                    return (
+                      <StatsTable
+                        key={`intim-${key}`}
+                        title={INTIM_LABELS[key] ?? key}
+                        rows={list}
+                      />
+                    );
+                  })}
+                </div>
+              </details>
+            ))}
+          </div>
+        </details>
+        <details>
+          <summary className="cursor-pointer text-xl font-semibold">Поцелуи</summary>
+          <div className="space-y-2 mt-2">
+            {Object.entries(poceluyCategories).map(([category, stats]) => (
+              <details key={`poceluy-${category}`}>
+                <summary className="cursor-pointer font-semibold">
+                  Поцелуй: {CATEGORY_LABELS[category as Category]}
+                </summary>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
+                  {Object.entries(stats).map(([key, users]) => {
+                    const list = Array.isArray(users) ? users : [];
+                    return (
+                      <StatsTable
+                        key={`poceluy-${key}`}
+                        title={POCELUY_LABELS[key] ?? key}
+                        rows={list}
+                      />
+                    );
+                  })}
+                </div>
+              </details>
+            ))}
+          </div>
+        </details>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- nest intimate and kiss statistics tables inside collapsible sections
- adjust tests for new collapsible structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a4a3eb1f483209c7cfc387b12c0e8