### PR TITLE
Check tmi client readyState before disconnecting

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -290,7 +290,9 @@ setInterval(async () => {
     try {
       if (typeof client.disconnect === 'function') {
         try {
-          await client.disconnect();
+          if (typeof client.readyState === 'function' && client.readyState() === 'OPEN') {
+            await client.disconnect();
+          }
         } catch {}
       }
       await connectClient();


### PR DESCRIPTION
## Summary
- only disconnect Twitch bot client when the WebSocket is open to avoid spurious logs

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ad8d79f8c832090cc0571aa20c8c9