### PR TITLE
Add cascade delete FK for votes.game_id

### DIFF
--- a/supabase/migrations/20250808180445_add_votes_game_id_fkey.sql
+++ b/supabase/migrations/20250808180445_add_votes_game_id_fkey.sql
@@ -1,0 +1,4 @@
+alter table votes
+  add constraint votes_game_id_fkey
+  foreign key (game_id) references games(id)
+  on delete cascade;


### PR DESCRIPTION
## Summary
- add a migration to ensure `votes.game_id` references `games.id` with ON DELETE CASCADE

## Testing
- `npx supabase db push` *(fails: Cannot find project ref)*
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ade7d35b48320ac397d5f247a67cd