### PR TITLE
Use streamer token for subscription data

### DIFF
--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useEffect, useState } from "react";
 import Link from "next/link";
-import { ROLE_ICONS } from "@/lib/roleIcons";
+import { ROLE_ICONS, getSubBadge } from "@/lib/roleIcons";
 import { useTwitchUserInfo } from "@/lib/useTwitchUserInfo";
 import { proxiedImage, cn } from "@/lib/utils";
 import { INTIM_LABELS, POCELUY_LABELS } from "@/lib/statLabels";
@@ -113,9 +113,20 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         {enableTwitchRoles &&
           roles.length > 0 &&
           roles.map((r) =>
-            ROLE_ICONS[r] ? (
-              <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-6 h-6" />
-            ) : null
+            r === "Sub"
+              ? (
+                  <img
+                    key={r}
+                    src={getSubBadge(user.total_months_subbed)}
+                    alt={r}
+                    className="w-6 h-6"
+                  />
+                )
+              : ROLE_ICONS[r]
+              ? (
+                  <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-6 h-6" />
+                )
+              : null
           )}
         {enableTwitchRoles && profileUrl && (
           <img

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ROLE_ICONS } from "@/lib/roleIcons";
+import { ROLE_ICONS, getSubBadge } from "@/lib/roleIcons";
 import { useTwitchUserInfo } from "@/lib/useTwitchUserInfo";
 import {
   DropdownMenu,
@@ -40,9 +40,20 @@ function UserRowBase({
     <li className="flex items-center space-x-2 border p-2 rounded-lg bg-muted text-sm whitespace-nowrap">
       <span className="flex items-center space-x-1">
         {roles.map((r) =>
-          ROLE_ICONS[r] ? (
-            <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
-          ) : null
+          r === "Sub"
+            ? (
+                <img
+                  key={r}
+                  src={getSubBadge(user.total_months_subbed)}
+                  alt={r}
+                  className="w-4 h-4"
+                />
+              )
+            : ROLE_ICONS[r]
+            ? (
+                <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
+              )
+            : null
         )}
         <Link href={`/users/${user.id}`} className="text-purple-600 underline">
           {user.username}

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -8,7 +8,7 @@ import {
   refreshProviderToken,
 } from "@/lib/twitch";
 import { Button } from "@/components/ui/button";
-import { ROLE_ICONS } from "@/lib/roleIcons";
+import { ROLE_ICONS, getSubBadge } from "@/lib/roleIcons";
 import Link from "next/link";
 import {
   DropdownMenu,
@@ -24,6 +24,7 @@ export default function AuthStatus() {
   const [profileUrl, setProfileUrl] = useState<string | null>(null);
   const [roles, setRoles] = useState<string[]>([]);
   const [userId, setUserId] = useState<number | null>(null);
+  const [subMonths, setSubMonths] = useState<number>(0);
   const [scopeWarning, setScopeWarning] = useState<string | null>(null);
   const [streamerTokenMissing, setStreamerTokenMissing] = useState(false);
   const [skipRoleChecks, setSkipRoleChecks] = useState(false);
@@ -51,10 +52,11 @@ export default function AuthStatus() {
       }
       const { data } = await supabase
         .from('users')
-        .select('id')
+        .select('id, total_months_subbed')
         .eq('auth_id', session.user.id)
         .maybeSingle();
       setUserId(data?.id ?? null);
+      setSubMonths(data?.total_months_subbed ?? 0);
     };
     fetchId();
   }, [session]);
@@ -397,9 +399,20 @@ export default function AuthStatus() {
               {rolesEnabled &&
                 roles.length > 0 &&
                 roles.map((r) =>
-                  ROLE_ICONS[r] ? (
-                    <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
-                  ) : null
+                  r === "Sub"
+                    ? (
+                        <img
+                          key={r}
+                          src={getSubBadge(subMonths)}
+                          alt={r}
+                          className="w-4 h-4"
+                        />
+                      )
+                    : ROLE_ICONS[r]
+                    ? (
+                        <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
+                      )
+                    : null
                 )}
               {username}
             </span>

--- a/frontend/lib/__tests__/twitch.test.ts
+++ b/frontend/lib/__tests__/twitch.test.ts
@@ -1,89 +1,37 @@
-// Mock Supabase client with failing refresh behavior
-const signOut = jest.fn();
-const getSession = jest
-  .fn()
-  .mockResolvedValue({ data: { session: { refresh_token: 'rt' } }, error: null });
-const refreshSession = jest
-  .fn()
-  .mockResolvedValue({ data: {}, error: new Error('fail') });
-
-jest.mock('../supabase', () => ({
-  supabase: {
-    auth: { signOut, getSession, refreshSession },
-  },
-}));
-
-// Provide a mock alert implementation for environments like JSDOM
-(global as any).alert = jest.fn();
+jest.mock('../supabase', () => ({ supabase: { auth: {} } }));
+import { fetchSubscriptionRole } from '../twitch';
 
 describe('fetchSubscriptionRole', () => {
   const backendUrl = 'http://backend';
   const query = 'q';
 
-  beforeEach(() => {
-    jest.resetModules();
-    jest.clearAllMocks();
-    (global as any).fetch = jest
-      .fn()
-      .mockResolvedValue({ status: 401, ok: false } as Response);
-    refreshSession.mockReset();
-    refreshSession.mockResolvedValue({ data: {}, error: new Error('fail') });
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('returns error without signing out on first refresh failure', async () => {
-    const twitch = await import('../twitch');
-    const result = await twitch.fetchSubscriptionRole(
-      backendUrl,
-      query,
-      {},
-      []
-    );
-    const { supabase } = await import('../supabase');
-    expect(result).toBe('error');
-    expect(supabase.auth.signOut).not.toHaveBeenCalled();
-  });
-
-  test('signs out after consecutive refresh failures', async () => {
-    const twitch = await import('../twitch');
-    const { supabase } = await import('../supabase');
-
-    const res1 = await twitch.fetchSubscriptionRole(
-      backendUrl,
-      query,
-      {},
-      []
-    );
-    expect(res1).toBe('error');
-    expect(supabase.auth.signOut).not.toHaveBeenCalled();
-
-    const res2 = await twitch.fetchSubscriptionRole(
-      backendUrl,
-      query,
-      {},
-      []
-    );
-    expect(res2).toBe('unauthorized');
-    expect(supabase.auth.signOut).toHaveBeenCalledTimes(1);
-  });
-
-  test('returns unauthorized without signing out when scope missing', async () => {
-    refreshSession.mockResolvedValueOnce({
-      data: { session: { provider_token: 'new' } },
-      error: null,
-    });
+  test('adds Sub role when subscription exists', async () => {
     (global as any).fetch = jest
       .fn()
-      .mockResolvedValueOnce({ status: 401, ok: false } as Response)
-      .mockResolvedValueOnce({ status: 401, ok: false } as Response);
-    const twitch = await import('../twitch');
-    const { supabase } = await import('../supabase');
-    const res = await twitch.fetchSubscriptionRole(backendUrl, query, {}, []);
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'st' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [{}] }) });
+    const roles: string[] = [];
+    const res = await fetchSubscriptionRole(backendUrl, query, roles);
+    expect(res).toBe('ok');
+    expect(roles).toContain('Sub');
+  });
+
+  test('returns unauthorized on 401', async () => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'st' }) })
+      .mockResolvedValueOnce({ ok: false, status: 401 });
+    const res = await fetchSubscriptionRole(backendUrl, query, []);
     expect(res).toBe('unauthorized');
-    expect(supabase.auth.signOut).not.toHaveBeenCalled();
+  });
+
+  test('returns error when token fetch fails', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 });
+    const res = await fetchSubscriptionRole(backendUrl, query, []);
+    expect(res).toBe('error');
   });
 });
-

--- a/frontend/lib/roleIcons.ts
+++ b/frontend/lib/roleIcons.ts
@@ -1,6 +1,10 @@
 export const ROLE_ICONS: Record<string, string> = {
-  Sub: "/icons/roles/1.svg",
   Streamer: "/icons/roles/broadcaster.svg",
   Mod: "/icons/roles/moderator.svg",
   VIP: "/icons/roles/vip.svg",
 };
+
+export function getSubBadge(months: number): string {
+  const badge = Math.min(Math.max(Math.floor(months) || 1, 1), 8);
+  return `/icons/roles/${badge}.svg`;
+}

--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -261,7 +261,7 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
             await checkRole("channels/vips", "VIP");
           }
           if (!unauthorized && hasScope("channel:read:subscriptions")) {
-            const res = await fetchSubscriptionRole(backendUrl, query, headers, r);
+            const res = await fetchSubscriptionRole(backendUrl, query, r);
             if (res === "unauthorized") {
               unauthorized = true;
               await fetchStreamerInfo();


### PR DESCRIPTION
## Summary
- fetch subscription months in bot via Twitch API using streamer token
- always use streamer token for subscription role checks in frontend
- show subscription badges based on months with new getSubBadge

## Testing
- `cd bot && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b2c4374508320996db8fe9daa1a96