### PR TITLE
Add playlist hashtag search

### DIFF
--- a/frontend/app/playlists/page.tsx
+++ b/frontend/app/playlists/page.tsx
@@ -19,6 +19,7 @@ export default function PlaylistsPage() {
   const [session, setSession] = useState<Session | null>(null);
   const [isModerator, setIsModerator] = useState(false);
   const [editingTag, setEditingTag] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
 
   const fetchData = async () => {
     if (!backendUrl) return;
@@ -63,12 +64,27 @@ export default function PlaylistsPage() {
   if (!backendUrl) return <div className="p-4">Backend URL not configured.</div>;
   if (loading) return <div className="p-4">Loading...</div>;
 
-  const tags = Object.keys(data).sort();
+  const tags = Object.keys(data)
+    .sort()
+    .filter((tag) => tag.toLowerCase().includes(query.toLowerCase()));
 
   return (
     <>
       <main className="col-span-12 md:col-span-9 p-4 space-y-6">
         <h1 className="text-2xl font-semibold">Playlists</h1>
+        <div>
+          <label htmlFor="playlist-search" className="sr-only">
+            Search hashtags
+          </label>
+          <input
+            id="playlist-search"
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search hashtags"
+            className="border p-1 rounded w-full text-black"
+          />
+        </div>
         {tags.map((tag) => (
           <PlaylistRow
             key={tag}

--- a/frontend/components/__tests__/Playlists.test.tsx
+++ b/frontend/components/__tests__/Playlists.test.tsx
@@ -44,6 +44,28 @@ describe('PlaylistsPage', () => {
     expect(screen.queryByText(/#rpg/)).not.toBeInTheDocument();
   });
 
+  it('filters playlists based on search query', async () => {
+    mockSupabase.auth.getSession.mockResolvedValue({ data: { session: null } });
+    (global as any).fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        rpg: { videos: [], game: null },
+        fps: { videos: [], game: null },
+      }),
+    });
+
+    render(<PlaylistsPage />);
+
+    await screen.findByText('#rpg');
+    expect(screen.getByText('#fps')).toBeInTheDocument();
+
+    const input = screen.getByLabelText('Search hashtags');
+    fireEvent.change(input, { target: { value: 'rpg' } });
+
+    expect(screen.getByText('#rpg')).toBeInTheDocument();
+    expect(screen.queryByText('#fps')).not.toBeInTheDocument();
+  });
+
   it('opens modal and sends request as moderator', async () => {
     const fetchMock = jest
       .fn()
@@ -97,7 +119,7 @@ describe('PlaylistsPage', () => {
 
     await screen.findByText('Select Game for #rpg');
 
-    const searchBox = screen.getByRole('textbox');
+    const searchBox = screen.getAllByRole('textbox')[1];
     fireEvent.change(searchBox, { target: { value: 'Game2' } });
     fireEvent.click(screen.getByText('Search'));
 


### PR DESCRIPTION
## Summary
- add search input to filter playlist hashtags
- cover playlist search with unit test and update existing test

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b32f09ebc8320889142f33300bbd8