### PR TITLE
Add total statistics section to user page

### DIFF
--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { ROLE_ICONS, getSubBadge } from "@/lib/roleIcons";
 import { useTwitchUserInfo } from "@/lib/useTwitchUserInfo";
 import { proxiedImage, cn } from "@/lib/utils";
-import { INTIM_LABELS, POCELUY_LABELS } from "@/lib/statLabels";
+import { INTIM_LABELS, POCELUY_LABELS, TOTAL_LABELS } from "@/lib/statLabels";
 
 interface PollHistory {
   id: number;
@@ -98,6 +98,9 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   const poceluyStats = user
     ? Object.entries(user).filter(([k]) => k.startsWith("poceluy_"))
     : [];
+  const totalStats = user
+    ? Object.entries(user).filter(([k]) => k.startsWith("total_"))
+    : [];
 
   if (!backendUrl) return <div className="p-4">Backend URL not configured.</div>;
   if (loading) return <div className="p-4">Loading...</div>;
@@ -177,6 +180,16 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
           {poceluyStats.map(([key, value]) => (
             <li key={key}>
               {POCELUY_LABELS[key] ?? key}: {value}
+            </li>
+          ))}
+        </ul>
+      </details>
+      <details>
+        <summary>Статистика</summary>
+        <ul className="pl-4 list-disc">
+          {totalStats.map(([key, value]) => (
+            <li key={key}>
+              {TOTAL_LABELS[key] ?? key}: {value}
             </li>
           ))}
         </ul>

--- a/frontend/components/__tests__/UserPage.test.tsx
+++ b/frontend/components/__tests__/UserPage.test.tsx
@@ -58,6 +58,11 @@ describe("UserPage", () => {
     fireEvent.click(poceluySummary);
     expect(poceluySummary.closest("details")).toHaveAttribute("open");
     expect(screen.getByText("Заставил кого-то поцеловаться с 69%: 2")).toBeInTheDocument();
+
+    const totalSummary = screen.getByText("Статистика");
+    fireEvent.click(totalSummary);
+    expect(totalSummary.closest("details")).toHaveAttribute("open");
+    expect(screen.getByText("Просмотрено стримов: 0")).toBeInTheDocument();
   });
 });
 

--- a/frontend/lib/statLabels.ts
+++ b/frontend/lib/statLabels.ts
@@ -48,6 +48,16 @@ export const POCELUY_LABELS: Record<string, string> = {
   poceluy_tag_match_success_100: "Заставил кого-то поцеловаться с самим собой 100%",
 };
 
+export const TOTAL_LABELS: Record<string, string> = {
+  total_streams_watched: "Просмотрено стримов",
+  total_subs_gifted: "Подарено подписок",
+  total_subs_received: "Получено подписок",
+  total_chat_messages_sent: "Отправлено сообщений в чате",
+  total_times_tagged: "Сколько раз тегали",
+  total_commands_run: "Использовано команд",
+  total_months_subbed: "Месяцев в подписке",
+};
+
 export type StatCategory = "none" | "0" | "69" | "100";
 
 export function getIntimCategory(key: string): StatCategory {


### PR DESCRIPTION
## Summary
- map human-readable labels for total_* stats
- show aggregated total stats section on user page
- test total stats rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b4d571a008320a7a537a85db6ddf6