### PR TITLE
feat: support extended sub badge ranges

### DIFF
--- a/frontend/lib/__tests__/roleIcons.test.ts
+++ b/frontend/lib/__tests__/roleIcons.test.ts
@@ -1,0 +1,22 @@
+import { getSubBadge } from "../roleIcons";
+
+describe("getSubBadge", () => {
+  test.each([
+    [1, "1"],
+    [2, "2"],
+    [3, "3"],
+    [5, "3"],
+    [6, "6"],
+    [8, "6"],
+    [9, "9"],
+    [11, "9"],
+    [12, "12"],
+    [17, "12"],
+    [18, "18"],
+    [23, "18"],
+    [24, "24"],
+  ])("returns %s.svg for %i months", (months, badge) => {
+    expect(getSubBadge(months)).toBe(`/icons/subs/${badge}.svg`);
+  });
+});
+

--- a/frontend/lib/roleIcons.ts
+++ b/frontend/lib/roleIcons.ts
@@ -5,6 +5,17 @@ export const ROLE_ICONS: Record<string, string> = {
 };
 
 export function getSubBadge(months: number): string {
-  const badge = Math.min(Math.max(Math.floor(months) || 1, 1), 8);
-  return `/icons/roles/${badge}.svg`;
+  const m = Math.floor(months);
+
+  const badge =
+    m >= 24 ? 24 :
+    m >= 18 ? 18 :
+    m >= 12 ? 12 :
+    m >= 9 ? 9 :
+    m >= 6 ? 6 :
+    m >= 3 ? 3 :
+    m >= 2 ? 2 :
+    1;
+
+  return `/icons/subs/${badge}.svg`;
 }


### PR DESCRIPTION
## Summary
- map subscription months to new sub badge ranges
- test sub badge boundary values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b7bab7e348320908d964ec2c3570c