### PR TITLE
fix: hide sub badges for unsubscribed users

### DIFF
--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -105,6 +105,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   if (!backendUrl) return <div className="p-4">Backend URL not configured.</div>;
   if (loading) return <div className="p-4">Loading...</div>;
   if (!user) return <div className="p-4">User not found.</div>;
+  const subBadge = getSubBadge(user.total_months_subbed);
 
   return (
     <main className="col-span-12 md:col-span-9 p-4 space-y-4">
@@ -117,14 +118,16 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
           roles.length > 0 &&
           roles.map((r) =>
             r === "Sub"
-              ? (
-                  <img
-                    key={r}
-                    src={getSubBadge(user.total_months_subbed)}
-                    alt={r}
-                    className="w-6 h-6"
-                  />
-                )
+              ? subBadge
+                ? (
+                    <img
+                      key={r}
+                      src={subBadge}
+                      alt={r}
+                      className="w-6 h-6"
+                    />
+                  )
+                : null
               : ROLE_ICONS[r]
               ? (
                   <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-6 h-6" />

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -36,19 +36,22 @@ function UserRowBase({
   user: UserInfo;
   roles: string[];
 }) {
+  const badge = getSubBadge(user.total_months_subbed);
   return (
     <li className="flex items-center space-x-2 border p-2 rounded-lg bg-muted text-sm whitespace-nowrap">
       <span className="flex items-center space-x-1">
         {roles.map((r) =>
           r === "Sub"
-            ? (
-                <img
-                  key={r}
-                  src={getSubBadge(user.total_months_subbed)}
-                  alt={r}
-                  className="w-4 h-4"
-                />
-              )
+            ? badge
+              ? (
+                  <img
+                    key={r}
+                    src={badge}
+                    alt={r}
+                    className="w-4 h-4"
+                  />
+                )
+              : null
             : ROLE_ICONS[r]
             ? (
                 <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -390,6 +390,8 @@ export default function AuthStatus() {
     session?.user.user_metadata.nickname ||
     session?.user.email;
 
+  const subBadge = getSubBadge(subMonths);
+
   return session ? (
     <>
       <DropdownMenu>
@@ -400,14 +402,16 @@ export default function AuthStatus() {
                 roles.length > 0 &&
                 roles.map((r) =>
                   r === "Sub"
-                    ? (
-                        <img
-                          key={r}
-                          src={getSubBadge(subMonths)}
-                          alt={r}
-                          className="w-4 h-4"
-                        />
-                      )
+                    ? subBadge
+                      ? (
+                          <img
+                            key={r}
+                            src={subBadge}
+                            alt={r}
+                            className="w-4 h-4"
+                          />
+                        )
+                      : null
                     : ROLE_ICONS[r]
                     ? (
                         <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />

--- a/frontend/components/__tests__/AuthStatus.test.tsx
+++ b/frontend/components/__tests__/AuthStatus.test.tsx
@@ -335,5 +335,79 @@ describe('AuthStatus sub badges', () => {
     const img = await screen.findByAltText('Sub');
     expect(img).toHaveAttribute('src', `/icons/subs/${badge}.svg`);
   });
+
+  it('does not render badge for 0 months', async () => {
+    fromReturn.maybeSingle.mockResolvedValue({
+      data: { id: 42, total_months_subbed: 0 },
+    });
+    const userId = 'user1';
+    const fetchMock = jest.fn(async (url: RequestInfo) => {
+      if (url === `${backendUrl}/api/get-stream?endpoint=users`) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [{ id: userId, profile_image_url: 'p.png' }] }),
+        } as Response;
+      }
+      if (url === `${backendUrl}/api/streamer-token`) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ token: 'st123' }),
+        } as Response;
+      }
+      if (url === 'https://id.twitch.tv/oauth2/validate') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            scopes: [
+              'moderation:read',
+              'channel:read:vips',
+              'channel:read:subscriptions',
+            ],
+          }),
+        } as Response;
+      }
+      if (
+        url ===
+        `${backendUrl}/api/get-stream?endpoint=moderation/moderators&broadcaster_id=${channelId}&user_id=${userId}`
+      ) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response;
+      }
+      if (
+        url ===
+        `${backendUrl}/api/get-stream?endpoint=channels/vips&broadcaster_id=${channelId}&user_id=${userId}`
+      ) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response;
+      }
+      if (
+        url ===
+        `${backendUrl}/api/get-stream?endpoint=subscriptions&broadcaster_id=${channelId}&user_id=${userId}`
+      ) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response;
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    global.fetch = fetchMock as any;
+
+    render(<AuthStatus />);
+
+    await waitFor(() => {
+      expect(screen.queryByAltText('Sub')).toBeNull();
+    });
+  });
 });
 

--- a/frontend/components/__tests__/UserPage.test.tsx
+++ b/frontend/components/__tests__/UserPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, fireEvent } from "@testing-library/react";
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
 
 process.env.NEXT_PUBLIC_BACKEND_URL = "http://backend";
 process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES = "true";
@@ -134,6 +134,47 @@ describe("UserPage sub badges", () => {
 
     const img = await screen.findByAltText("Sub");
     expect(img).toHaveAttribute("src", `/icons/subs/${badge}.svg`);
+  });
+
+  it("does not render badge for 0 months", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          user: {
+            id: 1,
+            username: "Alice",
+            auth_id: null,
+            twitch_login: null,
+            logged_in: false,
+            total_streams_watched: 0,
+            total_subs_gifted: 0,
+            total_subs_received: 0,
+            total_chat_messages_sent: 0,
+            total_times_tagged: 0,
+            total_commands_run: 0,
+            total_months_subbed: 0,
+            votes: 0,
+            roulettes: 0,
+          },
+          history: [],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ games: [] }),
+      });
+
+    (global as any).fetch = fetchMock;
+
+    await act(async () => {
+      render(<UserPage params={Promise.resolve({ id: "1" })} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByAltText("Sub")).toBeNull();
+    });
   });
 });
 

--- a/frontend/components/__tests__/UsersPage.test.tsx
+++ b/frontend/components/__tests__/UsersPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 
 process.env.NEXT_PUBLIC_BACKEND_URL = "http://backend";
 process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES = "true";
@@ -33,7 +33,7 @@ describe("UsersPage sub badges", () => {
   });
 
   it("shows proper badges for users", async () => {
-    const months = [1, 2, 4, 7, 10, 15, 20, 30];
+    const months = [0, 1, 2, 4, 7, 10, 15, 20, 30];
     const users = months.map((m, i) => ({
       id: i + 1,
       username: `U${i}`,
@@ -57,12 +57,15 @@ describe("UsersPage sub badges", () => {
     render(<UsersPage />);
 
     await waitFor(() =>
-      expect(screen.getAllByAltText("Sub")).toHaveLength(months.length)
+      expect(screen.getAllByAltText("Sub")).toHaveLength(months.length - 1)
     );
     const imgs = screen.getAllByAltText("Sub");
     const expected = ["1", "2", "3", "6", "9", "12", "18", "24"];
     imgs.forEach((img, idx) => {
       expect(img).toHaveAttribute("src", `/icons/subs/${expected[idx]}.svg`);
     });
+
+    const firstRow = screen.getByText("U0").closest("li");
+    expect(within(firstRow as HTMLElement).queryByAltText("Sub")).toBeNull();
   });
 });

--- a/frontend/lib/__tests__/roleIcons.test.ts
+++ b/frontend/lib/__tests__/roleIcons.test.ts
@@ -1,6 +1,10 @@
 import { getSubBadge } from "../roleIcons";
 
 describe("getSubBadge", () => {
+  test("returns undefined for 0 months", () => {
+    expect(getSubBadge(0)).toBeUndefined();
+  });
+
   test.each([
     [1, "1"],
     [2, "2"],

--- a/frontend/lib/roleIcons.ts
+++ b/frontend/lib/roleIcons.ts
@@ -4,8 +4,9 @@ export const ROLE_ICONS: Record<string, string> = {
   VIP: "/icons/roles/vip.svg",
 };
 
-export function getSubBadge(months: number): string {
+export function getSubBadge(months: number): string | undefined {
   const m = Math.floor(months);
+  if (m < 1) return undefined;
 
   const badge =
     m >= 24 ? 24 :


### PR DESCRIPTION
## Summary
- hide subscription badges when subbed months are 0
- show sub badges only for users with at least 1 month
- add tests for zero-month subscribers

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb16723e083208bd6d17f597a372e