### PR TITLE
Add achievements and user medals tables to Supabase schema

### DIFF
--- a/supabase/migrations/20250808180445_create_achievements.sql
+++ b/supabase/migrations/20250808180445_create_achievements.sql
@@ -1,0 +1,22 @@
+create table if not exists achievements (
+  id serial primary key,
+  stat_key text,
+  title text,
+  description text,
+  threshold integer
+);
+
+create table if not exists user_achievements (
+  user_id integer references users(id),
+  achievement_id integer references achievements(id),
+  earned_at timestamp,
+  primary key (user_id, achievement_id)
+);
+
+create table if not exists user_medals (
+  user_id integer references users(id),
+  stat_key text,
+  medal_type text,
+  awarded_at timestamp,
+  primary key (user_id, stat_key, medal_type)
+);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -302,3 +302,26 @@ create table if not exists poceluy_contexts (
   variant_three text not null
 );
 
+create table if not exists achievements (
+  id serial primary key,
+  stat_key text,
+  title text,
+  description text,
+  threshold integer
+);
+
+create table if not exists user_achievements (
+  user_id integer references users(id),
+  achievement_id integer references achievements(id),
+  earned_at timestamp,
+  primary key (user_id, achievement_id)
+);
+
+create table if not exists user_medals (
+  user_id integer references users(id),
+  stat_key text,
+  medal_type text,
+  awarded_at timestamp,
+  primary key (user_id, stat_key, medal_type)
+);
+


### PR DESCRIPTION
## Summary
- add achievements, user_achievements, and user_medals tables to Supabase schema
- include matching migration for new tables

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bbe95b4948320850ba0605fa6b51f