### PR TITLE
Filter zero user stats and add tests

### DIFF
--- a/frontend/app/__tests__/UserPage.statsZero.test.tsx
+++ b/frontend/app/__tests__/UserPage.statsZero.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent, within, act } from "@testing-library/react";
+
+process.env.NEXT_PUBLIC_BACKEND_URL = "http://backend";
+process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES = "false";
+
+jest.mock("@/lib/useTwitchUserInfo", () => ({
+  useTwitchUserInfo: () => ({ profileUrl: null, roles: [], error: null }),
+}));
+
+const UserPage = require("@/app/users/[id]/page").default;
+
+describe("UserPage stats filtering", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("hides zero values and empty sections", async () => {
+    const user: any = {
+      id: 1,
+      username: "User",
+      auth_id: null,
+      twitch_login: null,
+      logged_in: false,
+      votes: 0,
+      roulettes: 0,
+      total_streams_watched: 5,
+      total_subs_gifted: 0,
+      total_subs_received: 0,
+      total_chat_messages_sent: 0,
+      total_times_tagged: 0,
+      total_commands_run: 0,
+      total_months_subbed: 0,
+      intim_no_tag_0: 0,
+      intim_no_tag_69: 2,
+      poceluy_no_tag_0: 0,
+    };
+
+    (global as any).fetch = jest.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: async () => {
+          if (url.includes("/api/users/1")) return { user, history: [] };
+          if (url.includes("/api/games")) return { games: [] };
+          if (url.includes("/api/achievements/1")) return { achievements: [] };
+          if (url.includes("/api/medals/1")) return { medals: {} };
+          return {};
+        },
+      })
+    );
+
+    await act(async () => {
+      render(<UserPage params={Promise.resolve({ id: "1" })} />);
+    });
+
+    const intimSummary = await screen.findByText("Интимы");
+    fireEvent.click(intimSummary);
+    const intimDetails = intimSummary.closest("details")!;
+    expect(
+      within(intimDetails).getByText("Интим с 69%: 2")
+    ).toBeInTheDocument();
+    expect(
+      within(intimDetails).queryByText("Интим с 0%")
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText("Поцелуи")).not.toBeInTheDocument();
+
+    const totalSummary = screen.getByText("Статистика");
+    fireEvent.click(totalSummary);
+    const totalDetails = totalSummary.closest("details")!;
+    expect(
+      within(totalDetails).getByText("Просмотрено стримов: 5")
+    ).toBeInTheDocument();
+    expect(
+      within(totalDetails).queryByText("Получено подписок")
+    ).not.toBeInTheDocument();
+  });
+});
+

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -132,13 +132,19 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   }, [id]);
 
   const intimStats = user
-    ? Object.entries(user).filter(([k]) => k.startsWith("intim_"))
+    ? Object.entries(user).filter(
+        ([k, v]) => k.startsWith("intim_") && Number(v) !== 0
+      )
     : [];
   const poceluyStats = user
-    ? Object.entries(user).filter(([k]) => k.startsWith("poceluy_"))
+    ? Object.entries(user).filter(
+        ([k, v]) => k.startsWith("poceluy_") && Number(v) !== 0
+      )
     : [];
   const totalStats = user
-    ? Object.entries(user).filter(([k]) => k.startsWith("total_"))
+    ? Object.entries(user).filter(
+        ([k, v]) => k.startsWith("total_") && Number(v) !== 0
+      )
     : [];
   const earnedMedals = Object.entries(medals).filter(
     ([, type]) => type !== null
@@ -232,36 +238,42 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
           </ul>
         </details>
       )}
-      <details>
-        <summary>Интимы</summary>
-        <ul className="pl-4 list-disc">
-          {intimStats.map(([key, value]) => (
-            <li key={key}>
-              {INTIM_LABELS[key] ?? key}: {value}
-            </li>
-          ))}
-        </ul>
-      </details>
-      <details>
-        <summary>Поцелуи</summary>
-        <ul className="pl-4 list-disc">
-          {poceluyStats.map(([key, value]) => (
-            <li key={key}>
-              {POCELUY_LABELS[key] ?? key}: {value}
-            </li>
-          ))}
-        </ul>
-      </details>
-      <details>
-        <summary>Статистика</summary>
-        <ul className="pl-4 list-disc">
-          {totalStats.map(([key, value]) => (
-            <li key={key}>
-              {TOTAL_LABELS[key] ?? key}: {value}
-            </li>
-          ))}
-        </ul>
-      </details>
+      {intimStats.length > 0 && (
+        <details>
+          <summary>Интимы</summary>
+          <ul className="pl-4 list-disc">
+            {intimStats.map(([key, value]) => (
+              <li key={key}>
+                {INTIM_LABELS[key] ?? key}: {value}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+      {poceluyStats.length > 0 && (
+        <details>
+          <summary>Поцелуи</summary>
+          <ul className="pl-4 list-disc">
+            {poceluyStats.map(([key, value]) => (
+              <li key={key}>
+                {POCELUY_LABELS[key] ?? key}: {value}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+      {totalStats.length > 0 && (
+        <details>
+          <summary>Статистика</summary>
+          <ul className="pl-4 list-disc">
+            {totalStats.map(([key, value]) => (
+              <li key={key}>
+                {TOTAL_LABELS[key] ?? key}: {value}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
       {history.length === 0 ? (
         <p>No votes yet.</p>
       ) : (

--- a/frontend/components/__tests__/UserPage.test.tsx
+++ b/frontend/components/__tests__/UserPage.test.tsx
@@ -38,7 +38,7 @@ describe("UserPage", () => {
             auth_id: null,
             twitch_login: null,
             logged_in: false,
-            total_streams_watched: 0,
+            total_streams_watched: 1,
             total_subs_gifted: 0,
             total_subs_received: 0,
             total_chat_messages_sent: 0,
@@ -89,7 +89,7 @@ describe("UserPage", () => {
     const totalSummary = screen.getByText("Статистика");
     fireEvent.click(totalSummary);
     expect(totalSummary.closest("details")).toHaveAttribute("open");
-    expect(screen.getByText("Просмотрено стримов: 0")).toBeInTheDocument();
+    expect(screen.getByText("Просмотрено стримов: 1")).toBeInTheDocument();
   });
 
   it("displays achievements and medals from API", async () => {


### PR DESCRIPTION
## Summary
- ignore zero-valued user stats when building intimacy, kiss, and total stat lists
- hide empty stat sections on the user page
- add tests ensuring zero stats are omitted and sections without stats are hidden

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c52379bd88320b8ce37822bb06977