### PR TITLE
feat(frontend): add theme provider using next-themes

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -8,6 +8,7 @@ import TwitchVideos from "@/components/TwitchVideos";
 import TwitchClips from "@/components/TwitchClips";
 import EventLog from "@/components/EventLog";
 import Eruda from "@/components/Eruda";
+import { ThemeProvider } from "@/components/ThemeProvider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -45,81 +46,83 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background font-sans antialiased flex flex-col`}
       >
-        <Eruda />
-        <header className="bg-muted text-foreground border-b p-4">
-          <nav className="flex justify-between items-center relative">
-            <div className="flex items-center">
-              <MobileMenu />
-              <div className="hidden md:flex space-x-4">
-                <Link href="/">Home</Link>
-                <Link href="/archive">Archive</Link>
-                <Link href="/games">Games</Link>
-                <Link href="/users">Users</Link>
-                <Link href="/stats">Stats</Link>
-                <Link href="/playlists">Playlists</Link>
-                <SettingsLink />
+        <ThemeProvider>
+          <Eruda />
+          <header className="bg-muted text-foreground border-b p-4">
+            <nav className="flex justify-between items-center relative">
+              <div className="flex items-center">
+                <MobileMenu />
+                <div className="hidden md:flex space-x-4">
+                  <Link href="/">Home</Link>
+                  <Link href="/archive">Archive</Link>
+                  <Link href="/games">Games</Link>
+                  <Link href="/users">Users</Link>
+                  <Link href="/stats">Stats</Link>
+                  <Link href="/playlists">Playlists</Link>
+                  <SettingsLink />
+                </div>
+              </div>
+              <div className="flex items-center space-x-4">
+                <a
+                  href="https://www.donationalerts.com/r/terrenkur"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
+                >
+                  <img
+                    src="/icons/socials/DA.svg"
+                    alt="Donations Alerts"
+                    className="w-6 h-6"
+                  />
+                </a>
+                <a
+                  href="https://t.me/terenkur"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
+                >
+                  <img
+                    src="/icons/socials/telegram.svg"
+                    alt="Telegram"
+                    className="w-6 h-6"
+                  />
+                </a>
+                <a
+                  href="https://discord.gg/eWwk2wAYBf"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
+                >
+                  <img
+                    src="/icons/socials/discord.svg"
+                    alt="Discord"
+                    className="w-6 h-6"
+                  />
+                </a>
+                <AuthStatus />
+              </div>
+            </nav>
+          </header>
+          <main className="mt-4 flex-grow">
+            <div
+              className="container mx-auto px-0 grid grid-cols-1 md:grid-cols-12 gap-x-2 gap-y-4 items-start min-h-[calc(100vh-64px)]"
+            >
+              <div className="col-span-12 md:col-span-9 bg-muted rounded-lg p-4 h-full">
+                {children}
+              </div>
+              <div className="hidden md:block col-span-12 md:col-span-3 md:col-start-10 space-y-4 bg-muted rounded-lg p-4 h-full">
+                <EventLog />
+                <TwitchVideos />
+                <TwitchClips />
+              </div>
+              <div className="order-last md:order-none md:hidden col-span-12 space-y-4 bg-muted rounded-lg p-4 h-full">
+                <EventLog />
+                <TwitchVideos />
+                <TwitchClips />
               </div>
             </div>
-            <div className="flex items-center space-x-4">
-              <a
-                href="https://www.donationalerts.com/r/terrenkur"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
-              >
-                <img
-                  src="/icons/socials/DA.svg"
-                  alt="Donations Alerts"
-                  className="w-6 h-6"
-                />
-              </a>
-              <a
-                href="https://t.me/terenkur"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
-              >
-                <img
-                  src="/icons/socials/telegram.svg"
-                  alt="Telegram"
-                  className="w-6 h-6"
-                />
-              </a>
-              <a
-                href="https://discord.gg/eWwk2wAYBf"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
-              >
-                <img
-                  src="/icons/socials/discord.svg"
-                  alt="Discord"
-                  className="w-6 h-6"
-                />
-              </a>
-              <AuthStatus />
-            </div>
-          </nav>
-        </header>
-        <main className="mt-4 flex-grow">
-          <div
-            className="container mx-auto px-0 grid grid-cols-1 md:grid-cols-12 gap-x-2 gap-y-4 items-start min-h-[calc(100vh-64px)]"
-          >
-            <div className="col-span-12 md:col-span-9 bg-muted rounded-lg p-4 h-full">
-              {children}
-            </div>
-            <div className="hidden md:block col-span-12 md:col-span-3 md:col-start-10 space-y-4 bg-muted rounded-lg p-4 h-full">
-              <EventLog />
-              <TwitchVideos />
-              <TwitchClips />
-            </div>
-            <div className="order-last md:order-none md:hidden col-span-12 space-y-4 bg-muted rounded-lg p-4 h-full">
-              <EventLog />
-              <TwitchVideos />
-              <TwitchClips />
-            </div>
-          </div>
-        </main>
+          </main>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/components/ThemeProvider.tsx
+++ b/frontend/components/ThemeProvider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" {...props}>
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "next": "15.4.1",
+        "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "tailwind-merge": "^2.2.2",
@@ -6199,6 +6200,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,28 +10,29 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.1",
+    "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@supabase/supabase-js": "^2.43.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "next": "15.4.1",
+    "next-themes": "^0.4.6",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "tailwind-merge": "^2.2.2",
-    "tailwindcss-animate": "^1.0.7",
-    "@radix-ui/react-dropdown-menu": "^2.1.15"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "tailwindcss": "^3.4.17",
     "autoprefixer": "^10",
     "jest": "^29.7.0",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/jest-dom": "^6.4.2",
+    "jest-environment-jsdom": "^29.7.0",
+    "tailwindcss": "^3.4.17",
     "ts-jest": "^29.1.1",
-    "jest-environment-jsdom": "^29.7.0"
+    "typescript": "^5"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- install next-themes and expose ThemeProvider wrapper
- wrap app layout with ThemeProvider for system-based dark mode

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689c57050fc08320989fc42ebb6c2df2