### PR TITLE
feat: use theme tokens for modals

### DIFF
--- a/frontend/components/AddCatalogGameModal.tsx
+++ b/frontend/components/AddCatalogGameModal.tsx
@@ -66,11 +66,11 @@ export default function AddCatalogGameModal({ session, onClose, onAdded }: Props
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 p-4 rounded space-y-4 shadow-lg w-96">
+      <div className="bg-background text-foreground p-4 rounded space-y-4 shadow-lg w-96">
         <h2 className="text-xl font-semibold">Add Game</h2>
         <div className="flex space-x-2">
           <input
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
@@ -81,7 +81,7 @@ export default function AddCatalogGameModal({ session, onClose, onAdded }: Props
         <div className="flex items-center space-x-2">
           <label className="text-sm">Status:</label>
           <select
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={status}
             onChange={(e) => setStatus(e.target.value)}
           >
@@ -93,7 +93,7 @@ export default function AddCatalogGameModal({ session, onClose, onAdded }: Props
         <div className="flex items-center space-x-2">
           <label className="text-sm">Method:</label>
           <select
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={method}
             onChange={(e) => setMethod(e.target.value)}
           >
@@ -108,7 +108,7 @@ export default function AddCatalogGameModal({ session, onClose, onAdded }: Props
             <label className="text-sm">Rating:</label>
             <input
               type="number"
-              className="border p-1 w-24 text-black"
+              className="border p-1 w-24 text-foreground"
               value={rating}
               onChange={(e) => setRating(e.target.value)}
             />
@@ -117,7 +117,7 @@ export default function AddCatalogGameModal({ session, onClose, onAdded }: Props
         <div className="flex items-center space-x-2">
           <label className="text-sm">Initiators:</label>
           <input
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={initiators}
             onChange={(e) => setInitiators(e.target.value)}
             placeholder="comma separated"
@@ -145,7 +145,7 @@ export default function AddCatalogGameModal({ session, onClose, onAdded }: Props
           ))}
         </div>
         <div className="flex justify-end">
-          <button className="px-2 py-1 bg-gray-300 rounded" onClick={onClose}>
+          <button className="px-2 py-1 bg-muted rounded" onClick={onClose}>
             Close
           </button>
         </div>

--- a/frontend/components/AddGameModal.tsx
+++ b/frontend/components/AddGameModal.tsx
@@ -63,11 +63,11 @@ export default function AddGameModal({ pollId, session, onClose, onAdded, onSele
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 p-4 rounded space-y-4 shadow-lg w-96">
+      <div className="bg-background text-foreground p-4 rounded space-y-4 shadow-lg w-96">
         <h2 className="text-xl font-semibold">Add Game</h2>
         <div className="flex space-x-2">
           <input
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
@@ -97,7 +97,7 @@ export default function AddGameModal({ pollId, session, onClose, onAdded, onSele
           ))}
         </div>
         <div className="flex justify-end">
-          <button className="px-2 py-1 bg-gray-300 rounded" onClick={onClose}>
+          <button className="px-2 py-1 bg-muted rounded" onClick={onClose}>
             Close
           </button>
         </div>

--- a/frontend/components/EditCatalogGameModal.tsx
+++ b/frontend/components/EditCatalogGameModal.tsx
@@ -100,11 +100,11 @@ export default function EditCatalogGameModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 p-4 rounded space-y-4 shadow-lg w-96">
+      <div className="bg-background text-foreground p-4 rounded space-y-4 shadow-lg w-96">
         <h2 className="text-xl font-semibold">Edit Game</h2>
         <div className="flex space-x-2">
           <input
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
@@ -116,14 +116,14 @@ export default function EditCatalogGameModal({
           <img src={background} alt={name} className="w-full h-32 object-cover" />
         )}
         <input
-          className="border p-1 w-full text-black"
+          className="border p-1 w-full text-foreground"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <div className="flex items-center space-x-2">
           <label className="text-sm">Status:</label>
           <select
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={status}
             onChange={(e) => setStatus(e.target.value)}
           >
@@ -135,7 +135,7 @@ export default function EditCatalogGameModal({
         <div className="flex items-center space-x-2">
           <label className="text-sm">Method:</label>
           <select
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={method}
             onChange={(e) => setMethod(e.target.value)}
           >
@@ -150,7 +150,7 @@ export default function EditCatalogGameModal({
             <label className="text-sm">Rating:</label>
             <input
               type="number"
-              className="border p-1 w-24 text-black"
+              className="border p-1 w-24 text-foreground"
               value={rating}
               onChange={(e) => setRating(e.target.value)}
             />
@@ -159,7 +159,7 @@ export default function EditCatalogGameModal({
         <div className="flex items-center space-x-2">
           <label className="text-sm">Initiators:</label>
           <input
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={initiators}
             onChange={(e) => setInitiators(e.target.value)}
             placeholder="comma separated"
@@ -187,7 +187,7 @@ export default function EditCatalogGameModal({
           ))}
         </div>
         <div className="flex justify-end space-x-2">
-          <button className="px-2 py-1 bg-gray-300 rounded" onClick={onClose}>
+          <button className="px-2 py-1 bg-muted rounded" onClick={onClose}>
             Cancel
           </button>
           <button className="px-2 py-1 bg-purple-600 text-white rounded" onClick={saveGame}>

--- a/frontend/components/EditPlaylistGameModal.tsx
+++ b/frontend/components/EditPlaylistGameModal.tsx
@@ -111,11 +111,11 @@ export default function EditPlaylistGameModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 p-4 rounded space-y-4 shadow-lg w-96">
+      <div className="bg-background text-foreground p-4 rounded space-y-4 shadow-lg w-96">
         <h2 className="text-xl font-semibold">Select Game for #{tag}</h2>
         <div className="flex space-x-2">
           <input
-            className="border p-1 flex-grow text-black"
+            className="border p-1 flex-grow text-foreground"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
@@ -152,7 +152,7 @@ export default function EditPlaylistGameModal({
           ))}
         </div>
         <div className="flex justify-between">
-          <button className="px-2 py-1 bg-gray-300 rounded" onClick={onClose}>
+          <button className="px-2 py-1 bg-muted rounded" onClick={onClose}>
             Cancel
           </button>
           <button

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -42,7 +42,7 @@ export default function SettingsModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 p-4 rounded space-y-4 shadow-lg">
+      <div className="bg-background text-foreground p-4 rounded space-y-4 shadow-lg">
         <h2 className="text-xl font-semibold">Settings</h2>
         <div className="flex items-center space-x-2">
           <label className="text-sm">Voice coefficient:</label>
@@ -50,7 +50,7 @@ export default function SettingsModal({
             type="number"
             value={value}
             onChange={(e) => setValue(parseFloat(e.target.value))}
-            className="border p-1 w-24 text-black"
+            className="border p-1 w-24 text-foreground"
           />
         </div>
         <div className="flex items-center space-x-2">
@@ -59,7 +59,7 @@ export default function SettingsModal({
             type="number"
             value={zero}
             onChange={(e) => setZero(parseFloat(e.target.value))}
-            className="border p-1 w-24 text-black"
+            className="border p-1 w-24 text-foreground"
           />
         </div>
         <div className="flex items-center space-x-2">
@@ -79,7 +79,7 @@ export default function SettingsModal({
           />
         </div>
         <div className="flex justify-end space-x-2">
-          <button className="px-2 py-1 bg-gray-300 rounded" onClick={onClose}>
+          <button className="px-2 py-1 bg-muted rounded" onClick={onClose}>
             Cancel
           </button>
           <button

--- a/frontend/components/SpinResultModal.tsx
+++ b/frontend/components/SpinResultModal.tsx
@@ -10,7 +10,7 @@ interface SpinResultModalProps {
 export default function SpinResultModal({ eliminated, winner, onClose }: SpinResultModalProps) {
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 p-4 rounded space-y-4 shadow-lg">
+      <div className="bg-background text-foreground p-4 rounded space-y-4 shadow-lg">
         <h2 className="text-xl font-semibold">Dropped game: {eliminated.name}</h2>
         {winner && (
           <p className="text-lg">Winning game: {winner.name}</p>


### PR DESCRIPTION
## Summary
- replace hardcoded modal colors with theme variables
- remove dark: classes in modal components

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c622a677c8320a8beffec85e7e516