### PR TITLE
Move theme column to users table

### DIFF
--- a/backend/__tests__/user_theme.test.js
+++ b/backend/__tests__/user_theme.test.js
@@ -18,7 +18,7 @@ const mockSupabase = {
       .mockResolvedValue({ data: { user: { id: 'user1' } }, error: null }),
   },
   from: jest.fn((table) => {
-    if (table === 'profiles') return { update: updateMock, select: selectMock };
+    if (table === 'users') return { update: updateMock, select: selectMock };
     return {};
   }),
 };
@@ -41,6 +41,7 @@ describe('user theme API', () => {
       .send({ theme: 'dark' });
     expect(res.status).toBe(200);
     expect(mockSupabase.auth.getUser).toHaveBeenCalledWith('token123');
+    expect(mockSupabase.from).toHaveBeenCalledWith('users');
     expect(updateMock).toHaveBeenCalledWith({ theme: 'dark' });
     expect(updateEqMock).toHaveBeenCalledWith('id', 'user1');
   });
@@ -51,6 +52,7 @@ describe('user theme API', () => {
       .set('Authorization', 'Bearer token123');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ theme: 'dark' });
+    expect(mockSupabase.from).toHaveBeenCalledWith('users');
     expect(selectMock).toHaveBeenCalledWith('theme');
     expect(selectEqMock).toHaveBeenCalledWith('id', 'user1');
   });

--- a/backend/server.js
+++ b/backend/server.js
@@ -766,7 +766,7 @@ app.post('/api/user/theme', async (req, res) => {
   }
 
   const { error: updateErr } = await supabase
-    .from('profiles')
+    .from('users')
     .update({ theme })
     .eq('id', user.id);
   if (updateErr) return res.status(500).json({ error: updateErr.message });
@@ -788,7 +788,7 @@ app.get('/api/user/theme', async (req, res) => {
   }
 
   const { data, error } = await supabase
-    .from('profiles')
+    .from('users')
     .select('theme')
     .eq('id', user.id)
     .maybeSingle();

--- a/supabase/migrations/20250808180446_add_theme_to_profiles.sql
+++ b/supabase/migrations/20250808180446_add_theme_to_profiles.sql
@@ -1,1 +1,0 @@
-ALTER TABLE profiles ADD COLUMN theme text DEFAULT 'system';

--- a/supabase/migrations/20250808180446_add_theme_to_users.sql
+++ b/supabase/migrations/20250808180446_add_theme_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN theme text DEFAULT 'system';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -9,6 +9,7 @@ create table if not exists users (
   auth_id uuid references auth.users(id) unique,
   vote_limit integer default 1,
   is_moderator boolean default false,
+  theme text default 'system',
   total_streams_watched integer default 0,
   total_subs_gifted integer default 0,
   total_subs_received integer default 0,
@@ -326,5 +327,5 @@ create table if not exists user_medals (
 );
 
 
-alter table profiles
+alter table users
   add column if not exists theme text default 'system';


### PR DESCRIPTION
## Summary
- move theme column to users table and default to system
- update API endpoints and tests to use users instead of profiles

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c73395058832091257207307c90e7