### PR TITLE
fix: await cookies in root layout

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -41,7 +41,8 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   let defaultTheme = "system";
-  const token = cookies().get("sb-access-token")?.value;
+  const cookieStore = await cookies();
+  const token = cookieStore.get("sb-access-token")?.value;
   const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
   if (token && backendUrl) {
     try {


### PR DESCRIPTION
## Summary
- await cookies before reading token to match Next.js 15 API

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c7afc829483209ed68f461150b170