### PR TITLE
feat: add twitch icon login button

### DIFF
--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -452,7 +452,19 @@ export default function AuthStatus() {
     </>
   ) : (
     <>
-      <Button onClick={handleLogin}>Login with Twitch</Button>
+      <Button
+        onClick={handleLogin}
+        size="icon"
+        aria-label="Login with Twitch"
+        className="sm:w-auto sm:px-4"
+      >
+        <img
+          src="/icons/socials/twitch.svg"
+          alt="Twitch"
+          className="w-6 h-6"
+        />
+        <span className="hidden sm:inline ml-2">Login with Twitch</span>
+      </Button>
       {rolesEnabled && scopeWarning && (
         <p className="text-xs text-red-500 mt-2">
           {scopeWarning}{" "}

--- a/frontend/components/__tests__/AuthStatus.test.tsx
+++ b/frontend/components/__tests__/AuthStatus.test.tsx
@@ -67,7 +67,7 @@ describe('AuthStatus login/logout', () => {
     jest.useFakeTimers();
     render(<AuthStatus />);
 
-    const btn = await screen.findByText('Login with Twitch');
+    const btn = await screen.findByRole('button', { name: 'Login with Twitch' });
     fireEvent.click(btn);
     act(() => {
       jest.runAllTimers();


### PR DESCRIPTION
## Summary
- use Twitch icon in login button and hide label on small screens
- adjust AuthStatus login test to query by accessible name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8a3bc24c8320ba74268ca3e4eed3