### PR TITLE
fix mobile menu stacking

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -69,7 +69,7 @@ export default async function RootLayout({
       >
         <ThemeProvider defaultTheme={defaultTheme}>
           <Eruda />
-          <header className="bg-muted text-foreground border-b p-4">
+          <header className="bg-muted text-foreground border-b p-4 relative z-20">
             <nav className="flex justify-between items-center relative">
               <div className="flex items-center">
                 <MobileMenu />

--- a/frontend/components/MobileMenu.tsx
+++ b/frontend/components/MobileMenu.tsx
@@ -11,7 +11,7 @@ export default function MobileMenu() {
   const close = () => setOpen(false);
 
   return (
-    <div className="md:hidden">
+    <div className="relative md:hidden">
       <button
         onClick={toggle}
         className="p-2 focus:outline-none"
@@ -40,7 +40,7 @@ export default function MobileMenu() {
         </svg>
       </button>
       {open && (
-        <div className="absolute left-0 top-full w-full bg-muted text-foreground flex flex-col space-y-2 p-4 animate-in fade-in slide-in-from-top-2">
+        <div className="absolute left-0 top-full z-50 w-full bg-muted text-foreground flex flex-col space-y-2 p-4 animate-in fade-in slide-in-from-top-2">
           <Link href="/" onClick={close}>
             Home
           </Link>


### PR DESCRIPTION
## Summary
- ensure mobile navigation menu overlays page content
- raise header stacking context

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689ca1171840832095349ed5a4a3b61f