### PR TITLE
fix: improve mobile menu overlay

### DIFF
--- a/frontend/components/MobileMenu.tsx
+++ b/frontend/components/MobileMenu.tsx
@@ -40,7 +40,7 @@ export default function MobileMenu() {
         </svg>
       </button>
       {open && (
-        <div className="absolute left-0 top-full z-50 w-full bg-muted text-foreground flex flex-col space-y-2 p-4 animate-in fade-in slide-in-from-top-2">
+        <div className="absolute -left-4 top-full z-50 w-screen bg-background text-foreground flex flex-col space-y-2 p-4 animate-in fade-in slide-in-from-top-2">
           <Link href="/" onClick={close}>
             Home
           </Link>


### PR DESCRIPTION
## Summary
- make mobile menu dropdown use an opaque background and span full screen width

## Testing
- `npm test`
- `npm run lint` *(fails: interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689ccb195a1c8320b4ff545423a3cbf5