### PR TITLE
Invert Twitch login icon color

### DIFF
--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -461,7 +461,7 @@ export default function AuthStatus() {
         <img
           src="/icons/socials/twitch.svg"
           alt="Twitch"
-          className="w-6 h-6"
+          className="w-6 h-6 invert"
         />
         <span className="hidden sm:inline ml-2">Login with Twitch</span>
       </Button>


### PR DESCRIPTION
## Summary
- ensure Twitch login button displays white icon by applying color inversion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdc109e3483208d346d6e42ad75ce