### PR TITLE
feat: show media preview in event log

### DIFF
--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -9,6 +9,8 @@ interface LogEntry {
   id: number;
   message: string;
   created_at: string;
+  media_url?: string;
+  preview_url?: string;
 }
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
@@ -108,6 +110,15 @@ export default function EventLog() {
             className="bg-muted rounded border p-2"
           >
             {new Date(l.created_at).toLocaleTimeString()} - {l.message}
+            {l.preview_url && l.media_url && (
+              <a href={l.media_url} target="_blank" rel="noopener noreferrer">
+                <img
+                  src={l.preview_url}
+                  alt={l.message}
+                  className="mt-2 max-w-full"
+                />
+              </a>
+            )}
           </li>
         ))}
       </ul>

--- a/frontend/components/__tests__/EventLog.test.tsx
+++ b/frontend/components/__tests__/EventLog.test.tsx
@@ -24,4 +24,27 @@ describe('EventLog', () => {
       expect(screen.getByText('Failed to fetch logs')).toBeInTheDocument()
     );
   });
+
+  it('renders media preview when available', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        logs: [
+          {
+            id: 1,
+            message: 'test',
+            created_at: '2024-01-01T00:00:00Z',
+            media_url: 'http://media',
+            preview_url: 'http://preview',
+          },
+        ],
+      }),
+    });
+
+    render(<EventLog />);
+
+    const img = await screen.findByAltText('test');
+    expect(img).toHaveAttribute('src', 'http://preview');
+    expect(img.closest('a')).toHaveAttribute('href', 'http://media');
+  });
 });


### PR DESCRIPTION
## Summary
- display media preview images for event log entries with media URLs
- test event log preview rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cfe875d4883209d49fc86c3105334