### PR TITLE
Log YouTube titles for music rewards

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -641,6 +641,7 @@ describe('reward logging', () => {
       message: `Reward ${rewardId} redeemed by User: Hello`,
       media_url: null,
       preview_url: null,
+      title: null,
     });
   });
 
@@ -662,6 +663,10 @@ describe('reward logging', () => {
     await new Promise(setImmediate);
     const messageHandler = on.mock.calls.find((c) => c[0] === 'message')[1];
     const link = 'https://youtu.be/abc123';
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ title: 'Song' }),
+    });
     await messageHandler(
       'channel',
       {
@@ -676,7 +681,9 @@ describe('reward logging', () => {
       message: `Reward 545cc880-f6c1-4302-8731-29075a8a1f17 redeemed by User: ${link}`,
       media_url: link,
       preview_url: 'https://img.youtube.com/vi/abc123/hqdefault.jpg',
+      title: 'Song',
     });
+    global.fetch.mockRestore();
   });
 
   test('warns and skips music reward with invalid link', async () => {
@@ -777,16 +784,19 @@ describe('donation logging', () => {
       message: 'Donation from Alice: 10 USD',
       media_url: null,
       preview_url: null,
+      title: null,
     });
     expect(insertMock).toHaveBeenNthCalledWith(2, {
       message: 'Donation from Bob: 5 USD',
       media_url: 'http://clip',
       preview_url: null,
+      title: null,
     });
     expect(insertMock).toHaveBeenNthCalledWith(3, {
       message: 'Donation from Carol: 7 USD',
       media_url: 'https://youtu.be/abc123',
       preview_url: expect.stringContaining('img.youtube.com'),
+      title: null,
     });
 
     global.fetch.mockRestore();

--- a/supabase/migrations/20250808180447_add_title_to_event_logs.sql
+++ b/supabase/migrations/20250808180447_add_title_to_event_logs.sql
@@ -1,0 +1,1 @@
+alter table event_logs add column if not exists title text;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -218,6 +218,7 @@ create table if not exists event_logs (
   message text not null,
   media_url text,
   preview_url text,
+  title text,
   created_at timestamp default now()
 );
 


### PR DESCRIPTION
## Summary
- fetch YouTube titles via oEmbed and attach them to logged events
- store optional `title` in `event_logs` schema
- test music reward logging with mocked title fetch

## Testing
- `cd bot && npm test`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cffa7e1148320b78bc3d44f3ca87d