### PR TITLE
feat: add skeleton placeholders for twitch and log data

### DIFF
--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface LogEntry {
   id: number;
@@ -19,6 +21,7 @@ export default function EventLog() {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [session, setSession] = useState<Session | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
   const listRef = useRef<HTMLUListElement | null>(null);
   const headerRef = useRef<HTMLHeadingElement | null>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -67,27 +70,35 @@ export default function EventLog() {
     return () => list.removeEventListener("scroll", update);
   }, [logs]);
 
-  useEffect(() => {
+  const fetchLogs = async () => {
     if (!backendUrl) return;
-
-    const fetchLogs = async () => {
-      const token = session?.access_token;
-      try {
-        const res = await fetch(`${backendUrl}/api/logs?limit=10`, {
-          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        });
-        if (!res.ok) {
-          setError("Failed to fetch logs");
-          return;
-        }
-        const data = await res.json();
-        setError(null);
-        setLogs((data.logs || []) as LogEntry[]);
-      } catch {
-        setError("Failed to fetch logs");
+    const token = session?.access_token;
+    setLoading(true);
+    try {
+      const res = await fetch(`${backendUrl}/api/logs?limit=10`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      });
+      if (!res.ok) {
+        throw new Error();
       }
-    };
+      const data = await res.json();
+      const items = (data.logs || []) as LogEntry[];
+      if (items.length === 0) {
+        setError("No events found");
+        setLogs([]);
+      } else {
+        setError(null);
+        setLogs(items);
+      }
+    } catch {
+      setError("Failed to fetch logs");
+      setLogs([]);
+    } finally {
+      setLoading(false);
+    }
+  };
 
+  useEffect(() => {
     fetchLogs();
     const id = setInterval(fetchLogs, 5000);
     return () => clearInterval(id);
@@ -95,49 +106,99 @@ export default function EventLog() {
 
   if (!backendUrl) return null;
 
+  const LIST_HEIGHT = 960;
+
   return (
     <Card className="space-y-2 relative">
       <h2 ref={headerRef} className="text-lg font-semibold">Recent Events</h2>
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      <ul
-        ref={listRef}
-        className="space-y-2 text-sm overflow-y-auto scroll-smooth pr-1"
-        style={{ maxHeight: itemHeight ? itemHeight * 4.8 : 960 }}
-      >
-        {logs.map((l) => (
-          <li
-            key={l.id}
-            className="bg-muted rounded border p-2"
+      {loading ? (
+        <ul
+          className="space-y-2 text-sm pr-1"
+          style={{ height: LIST_HEIGHT }}
+        >
+          {Array.from({ length: 4 }).map((_, i) => (
+            <li key={i} className="bg-muted rounded border p-2">
+              <Skeleton className="h-4 w-3/4" />
+            </li>
+          ))}
+        </ul>
+      ) : logs.length === 0 || error ? (
+        <div
+          className="flex items-center justify-center"
+          style={{ height: LIST_HEIGHT }}
+        >
+          <div className="space-y-2 text-center">
+            <p className="text-sm">{error || "No events found"}</p>
+            <Button onClick={fetchLogs}>Reload</Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <ul
+            ref={listRef}
+            className="space-y-2 text-sm overflow-y-auto scroll-smooth pr-1"
+            style={{ height: LIST_HEIGHT }}
           >
-            {new Date(l.created_at).toLocaleTimeString()} - {l.message}
-            {l.preview_url && l.media_url && (
-              <a href={l.media_url} target="_blank" rel="noopener noreferrer">
-                <img
-                  src={l.preview_url}
-                  alt={l.message}
-                  className="mt-2 max-w-full"
-                />
-              </a>
-            )}
-          </li>
-        ))}
-      </ul>
-      <button
-        className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
-        style={{ top: headerHeight + 8, left: "calc(50% - 8px)" }}
-        onClick={() => listRef.current?.scrollBy({ top: -itemHeight, behavior: 'smooth' })}
-        disabled={!canUp}
-      >
-        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 15l-6-6-6 6" /></svg>
-      </button>
-      <button
-        className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
-        style={{ bottom: 8, left: "calc(50% - 8px)" }}
-        onClick={() => listRef.current?.scrollBy({ top: itemHeight, behavior: 'smooth' })}
-        disabled={!canDown}
-      >
-        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
-      </button>
+            {logs.map((l) => (
+              <li
+                key={l.id}
+                className="bg-muted rounded border p-2"
+              >
+                {new Date(l.created_at).toLocaleTimeString()} - {l.message}
+                {l.preview_url && l.media_url && (
+                  <a href={l.media_url} target="_blank" rel="noopener noreferrer">
+                    <img
+                      src={l.preview_url}
+                      alt={l.message}
+                      className="mt-2 max-w-full"
+                    />
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+          <button
+            className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+            style={{ top: headerHeight + 8, left: "calc(50% - 8px)" }}
+            onClick={() =>
+              listRef.current?.scrollBy({ top: -itemHeight, behavior: "smooth" })
+            }
+            disabled={!canUp}
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 15l-6-6-6 6" />
+            </svg>
+          </button>
+          <button
+            className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+            style={{ bottom: 8, left: "calc(50% - 8px)" }}
+            onClick={() =>
+              listRef.current?.scrollBy({ top: itemHeight, behavior: "smooth" })
+            }
+            disabled={!canDown}
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+        </>
+      )}
     </Card>
   );
 }

--- a/frontend/components/TwitchClips.tsx
+++ b/frontend/components/TwitchClips.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { proxiedImage } from "@/lib/utils";
 
 interface Clip {
@@ -15,6 +17,8 @@ const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 export default function TwitchClips() {
   const [clips, setClips] = useState<Clip[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const listRef = useRef<HTMLUListElement | null>(null);
   const headerRef = useRef<HTMLHeadingElement | null>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -51,18 +55,35 @@ export default function TwitchClips() {
     return () => list.removeEventListener('scroll', update);
   }, [clips]);
 
-  useEffect(() => {
+  const fetchClips = async () => {
     if (!backendUrl) return;
-    fetch(`${backendUrl}/api/twitch_clips`).then(async (res) => {
-      if (!res.ok) return;
-      const data = await res.json();
-      if (Array.isArray(data.clips)) {
-        setClips(data.clips);
+    setLoading(true);
+    try {
+      const res = await fetch(`${backendUrl}/api/twitch_clips`);
+      if (!res.ok) {
+        throw new Error("Failed to fetch clips");
       }
-    });
+      const data = await res.json();
+      const items = Array.isArray(data.clips) ? data.clips : [];
+      if (items.length === 0) {
+        setError("No clips found");
+      } else {
+        setError(null);
+      }
+      setClips(items);
+    } catch (e) {
+      setError((e as Error).message);
+      setClips([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchClips();
   }, []);
 
-  if (!backendUrl || clips.length === 0) return null;
+  if (!backendUrl) return null;
 
   const up = () => {
     if (!listRef.current) return;
@@ -74,50 +95,92 @@ export default function TwitchClips() {
     listRef.current.scrollBy({ top: itemHeight, behavior: "smooth" });
   };
 
+  const LIST_HEIGHT = 2400;
+
   return (
     <Card className="space-y-2 relative">
       <h2 ref={headerRef} className="text-lg font-semibold">Twitch Clips</h2>
-      <ul
-        ref={listRef}
-        className="space-y-2 overflow-y-auto scroll-smooth pr-1"
-        style={{ maxHeight: itemHeight ? itemHeight * 12 : 2400 }}
-      >
-        {clips.map((clip) => {
-          const thumb = clip.thumbnail_url
-            .replace("%{width}", "320")
-            .replace("%{height}", "180");
-          const src = proxiedImage(thumb) ?? thumb;
-          return (
-            <li key={clip.id} className="space-y-1">
-              <a
-                href={clip.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block"
-              >
-                <img src={src} alt={clip.title} className="w-full rounded" />
-                <p className="text-sm">{clip.title}</p>
-              </a>
+      {loading ? (
+        <ul className="space-y-2 pr-1" style={{ height: LIST_HEIGHT }}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <li key={i} className="space-y-1">
+              <Skeleton className="w-full rounded aspect-video" />
+              <Skeleton className="h-4 w-3/4" />
             </li>
-          );
-        })}
-      </ul>
-      <button
-        className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
-        style={{ top: headerHeight + 8, left: "calc(50% - 8px)" }}
-        onClick={up}
-        disabled={!canUp}
-      >
-        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 15l-6-6-6 6" /></svg>
-      </button>
-      <button
-        className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
-        style={{ bottom: 8, left: "calc(50% - 8px)" }}
-        onClick={down}
-        disabled={!canDown}
-      >
-        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
-      </button>
+          ))}
+        </ul>
+      ) : clips.length === 0 || error ? (
+        <div className="flex items-center justify-center" style={{ height: LIST_HEIGHT }}>
+          <div className="space-y-2 text-center">
+            <p className="text-sm">{error || "No clips found"}</p>
+            <Button onClick={fetchClips}>Reload</Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <ul
+            ref={listRef}
+            className="space-y-2 overflow-y-auto scroll-smooth pr-1"
+            style={{ height: LIST_HEIGHT }}
+          >
+            {clips.map((clip) => {
+              const thumb = clip.thumbnail_url
+                .replace("%{width}", "320")
+                .replace("%{height}", "180");
+              const src = proxiedImage(thumb) ?? thumb;
+              return (
+                <li key={clip.id} className="space-y-1">
+                  <a
+                    href={clip.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block"
+                  >
+                    <img src={src} alt={clip.title} className="w-full rounded" />
+                    <p className="text-sm">{clip.title}</p>
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+          <button
+            className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+            style={{ top: headerHeight + 8, left: "calc(50% - 8px)" }}
+            onClick={up}
+            disabled={!canUp}
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 15l-6-6-6 6" />
+            </svg>
+          </button>
+          <button
+            className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+            style={{ bottom: 8, left: "calc(50% - 8px)" }}
+            onClick={down}
+            disabled={!canDown}
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+        </>
+      )}
     </Card>
   );
 }

--- a/frontend/components/TwitchVideos.tsx
+++ b/frontend/components/TwitchVideos.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface TwitchVideo {
   id: string;
@@ -13,6 +15,8 @@ const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 export default function TwitchVideos() {
   const [videos, setVideos] = useState<TwitchVideo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const listRef = useRef<HTMLUListElement | null>(null);
   const headerRef = useRef<HTMLHeadingElement | null>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -33,15 +37,32 @@ export default function TwitchVideos() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  useEffect(() => {
+  const fetchVideos = async () => {
     if (!backendUrl) return;
-    fetch(`${backendUrl}/api/twitch_videos`).then(async (res) => {
-      if (!res.ok) return;
-      const data = await res.json();
-      if (Array.isArray(data.videos)) {
-        setVideos(data.videos);
+    setLoading(true);
+    try {
+      const res = await fetch(`${backendUrl}/api/twitch_videos`);
+      if (!res.ok) {
+        throw new Error("Failed to fetch videos");
       }
-    });
+      const data = await res.json();
+      const items = Array.isArray(data.videos) ? data.videos : [];
+      if (items.length === 0) {
+        setError("No videos found");
+      } else {
+        setError(null);
+      }
+      setVideos(items);
+    } catch (e) {
+      setError((e as Error).message);
+      setVideos([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchVideos();
   }, []);
 
   useEffect(() => {
@@ -60,7 +81,7 @@ export default function TwitchVideos() {
     return () => list.removeEventListener('scroll', update);
   }, [videos]);
 
-  if (!backendUrl || videos.length === 0) return null;
+  if (!backendUrl) return null;
 
   const up = () => {
     if (!listRef.current) return;
@@ -72,53 +93,95 @@ export default function TwitchVideos() {
     listRef.current.scrollBy({ top: itemHeight, behavior: "smooth" });
   };
 
+  const LIST_HEIGHT = 2400;
+
   return (
     <Card className="space-y-2 relative">
       <h2 ref={headerRef} className="text-lg font-semibold">Stream VODs</h2>
-      <ul
-        ref={listRef}
-        className="space-y-2 overflow-y-auto scroll-smooth pr-1"
-        style={{ maxHeight: itemHeight ? itemHeight * 12 : 2400 }}
-      >
-        {videos.map((v) => {
-          const thumb = v.thumbnail_url
-            .replace("%{width}", "320")
-            .replace("%{height}", "180");
-          const src =
-            thumb.startsWith("http") && backendUrl
-              ? `${backendUrl}/api/proxy?url=${encodeURIComponent(thumb)}`
-              : thumb;
-          return (
-            <li key={v.id} className="space-y-1">
-              <a
-                href={`https://www.twitch.tv/videos/${v.id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block"
-              >
-                <img src={src} alt={v.title} className="w-full rounded" />
-                <p className="text-sm">{v.title}</p>
-              </a>
+      {loading ? (
+        <ul className="space-y-2 pr-1" style={{ height: LIST_HEIGHT }}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <li key={i} className="space-y-1">
+              <Skeleton className="w-full rounded aspect-video" />
+              <Skeleton className="h-4 w-3/4" />
             </li>
-          );
-        })}
-      </ul>
-      <button
-        className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
-        style={{ top: headerHeight + 8, left: "calc(50% - 8px)" }}
-        onClick={up}
-        disabled={!canUp}
-      >
-        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 15l-6-6-6 6" /></svg>
-      </button>
-      <button
-        className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
-        style={{ bottom: 8, left: "calc(50% - 8px)" }}
-        onClick={down}
-        disabled={!canDown}
-      >
-        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
-      </button>
+          ))}
+        </ul>
+      ) : videos.length === 0 || error ? (
+        <div className="flex items-center justify-center" style={{ height: LIST_HEIGHT }}>
+          <div className="space-y-2 text-center">
+            <p className="text-sm">{error || "No videos found"}</p>
+            <Button onClick={fetchVideos}>Reload</Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <ul
+            ref={listRef}
+            className="space-y-2 overflow-y-auto scroll-smooth pr-1"
+            style={{ height: LIST_HEIGHT }}
+          >
+            {videos.map((v) => {
+              const thumb = v.thumbnail_url
+                .replace("%{width}", "320")
+                .replace("%{height}", "180");
+              const src =
+                thumb.startsWith("http") && backendUrl
+                  ? `${backendUrl}/api/proxy?url=${encodeURIComponent(thumb)}`
+                  : thumb;
+              return (
+                <li key={v.id} className="space-y-1">
+                  <a
+                    href={`https://www.twitch.tv/videos/${v.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block"
+                  >
+                    <img src={src} alt={v.title} className="w-full rounded" />
+                    <p className="text-sm">{v.title}</p>
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+          <button
+            className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+            style={{ top: headerHeight + 8, left: "calc(50% - 8px)" }}
+            onClick={up}
+            disabled={!canUp}
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 15l-6-6-6 6" />
+            </svg>
+          </button>
+          <button
+            className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+            style={{ bottom: 8, left: "calc(50% - 8px)" }}
+            onClick={down}
+            disabled={!canDown}
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+        </>
+      )}
     </Card>
   );
 }

--- a/frontend/components/ui/skeleton.tsx
+++ b/frontend/components/ui/skeleton.tsx
@@ -1,0 +1,9 @@
+import { cn } from "@/lib/utils";
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return <div className={cn("animate-pulse rounded-md bg-muted", className)} />;
+}


### PR DESCRIPTION
## Summary
- add reusable Skeleton component
- show skeletons and reload messaging in EventLog, TwitchVideos and TwitchClips
- fix component heights to prevent layout shift

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d8c36d0e88320b884a96750e7318a