### PR TITLE
refactor: add SocialLink component using next/image

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -10,6 +10,7 @@ import EventLog from "@/components/EventLog";
 import Eruda from "@/components/Eruda";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import ThemeToggle from "@/components/ThemeToggle";
+import { SocialLink } from "@/components/SocialLink";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -77,42 +78,24 @@ export default async function RootLayout({
                 </div>
               </div>
               <div className="flex items-center space-x-2 sm:space-x-4">
-                <a
+                <SocialLink
                   href="https://www.donationalerts.com/r/terrenkur"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hidden sm:flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
-                >
-                  <img
-                    src="/icons/socials/DA.svg"
-                    alt="Donations Alerts"
-                    className="w-6 h-6"
-                  />
-                </a>
-                <a
+                  src="/icons/socials/DA.svg"
+                  alt="Donations Alerts"
+                  ariaLabel="Donationalerts"
+                />
+                <SocialLink
                   href="https://t.me/terenkur"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hidden sm:flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
-                >
-                  <img
-                    src="/icons/socials/telegram.svg"
-                    alt="Telegram"
-                    className="w-6 h-6"
-                  />
-                </a>
-                <a
+                  src="/icons/socials/telegram.svg"
+                  alt="Telegram"
+                  ariaLabel="Telegram"
+                />
+                <SocialLink
                   href="https://discord.gg/eWwk2wAYBf"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hidden sm:flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
-                >
-                  <img
-                    src="/icons/socials/discord.svg"
-                    alt="Discord"
-                    className="w-6 h-6"
-                  />
-                </a>
+                  src="/icons/socials/discord.svg"
+                  alt="Discord"
+                  ariaLabel="Discord"
+                />
                 <ThemeToggle />
                 <AuthStatus />
               </div>

--- a/frontend/components/SocialLink.tsx
+++ b/frontend/components/SocialLink.tsx
@@ -1,0 +1,22 @@
+import Image from "next/image";
+
+interface SocialLinkProps {
+  href: string;
+  src: string;
+  alt: string;
+  ariaLabel: string;
+}
+
+export function SocialLink({ href, src, alt, ariaLabel }: SocialLinkProps) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={ariaLabel}
+      className="hidden sm:flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent"
+    >
+      <Image src={src} alt={alt} width={24} height={24} />
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- replace header social icons with new SocialLink component
- use Next.js Image with explicit size for social icons
- add aria labels to social links for accessibility

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint setup)*


------
https://chatgpt.com/codex/tasks/task_e_689d8ff0c84c8320a42a004f7b101ca6