### PR TITLE
Add mobile activity panel with lazy-loaded widgets

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -11,6 +11,7 @@ import Eruda from "@/components/Eruda";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import ThemeToggle from "@/components/ThemeToggle";
 import { SocialLink } from "@/components/SocialLink";
+import ActivitySheet from "@/components/ActivitySheet";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -113,12 +114,8 @@ export default async function RootLayout({
                 <TwitchVideos />
                 <TwitchClips />
               </div>
-              <div className="order-last md:order-none md:hidden col-span-12 space-y-4 bg-muted rounded-lg p-4 h-full">
-                <EventLog />
-                <TwitchVideos />
-                <TwitchClips />
-              </div>
             </div>
+            <ActivitySheet />
           </main>
         </ThemeProvider>
       </body>

--- a/frontend/components/ActivityContent.tsx
+++ b/frontend/components/ActivityContent.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import EventLog from './EventLog';
+import TwitchVideos from './TwitchVideos';
+import TwitchClips from './TwitchClips';
+
+export default function ActivityContent() {
+  return (
+    <>
+      <EventLog />
+      <TwitchVideos />
+      <TwitchClips />
+    </>
+  );
+}

--- a/frontend/components/ActivitySheet.tsx
+++ b/frontend/components/ActivitySheet.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import { Button } from './ui/button';
+
+const ActivityContent = dynamic(() => import('./ActivityContent'), {
+  ssr: false,
+});
+
+export default function ActivitySheet() {
+  const [open, setOpen] = useState(false);
+
+  const close = () => setOpen(false);
+
+  return (
+    <div className="md:hidden">
+      <Button
+        className="fixed bottom-4 right-4 z-30"
+        onClick={() => setOpen(true)}
+      >
+        Activity
+      </Button>
+      {open && (
+        <div
+          className="fixed inset-0 z-40 flex flex-col justify-end bg-black/50"
+          onClick={close}
+        >
+          <div
+            className="bg-muted rounded-t-lg p-4 space-y-4 max-h-[80vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ActivityContent />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace duplicated mobile widgets with ActivitySheet bottom panel
- lazy-load activity widgets and only mount them when the sheet opens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d986cc5888320aca8f7b0f97ffad3