### PR TITLE
feat: show spinner during home page loading

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -10,6 +10,7 @@ import SpinResultModal from "@/components/SpinResultModal";
 import type { Session } from "@supabase/supabase-js";
 import type { Game, Poll, Voter } from "@/types";
 import { proxiedImage, cn } from "@/lib/utils";
+import { Spinner } from "@/components/ui/spinner";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 if (!backendUrl) {
@@ -446,8 +447,13 @@ export default function Home() {
     setOfficialMode(true);
   };
 
-
-  if (loading) return <div className="p-4">Loading...</div>;
+  if (loading) {
+    return (
+      <div className="p-4 flex items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
   if (!poll) return <div className="p-4">No poll available.</div>;
 
   return (

--- a/frontend/components/ui/spinner.tsx
+++ b/frontend/components/ui/spinner.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/lib/utils";
+
+interface SpinnerProps {
+  className?: string;
+}
+
+export function Spinner({ className }: SpinnerProps) {
+  return (
+    <div
+      className={cn(
+        "h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-transparent",
+        className
+      )}
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable Spinner component
- display spinner while home page loads poll data

## Testing
- `npm test` (frontend)
- `npm test` (backend)
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689da72071a0832081a4a10f33bb6f40