### PR TITLE
Use Button component for settings and scroll controls

### DIFF
--- a/frontend/components/ScrollableList.tsx
+++ b/frontend/components/ScrollableList.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 
 interface ScrollableListProps<T> {
   title: string;
@@ -72,8 +73,10 @@ export default function ScrollableList<T>({
       >
         {items.map((item) => renderItem(item))}
       </ul>
-      <button
-        className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+      <Button
+        variant="icon"
+        size="icon"
+        className="absolute p-1 rounded-full h-6 w-6"
         style={{ top: headerHeight + 8, left: "calc(50% - 8px)" }}
         onClick={up}
         disabled={!canUp}
@@ -91,9 +94,11 @@ export default function ScrollableList<T>({
         >
           <path d="M18 15l-6-6-6 6" />
         </svg>
-      </button>
-      <button
-        className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+      </Button>
+      <Button
+        variant="icon"
+        size="icon"
+        className="absolute p-1 rounded-full h-6 w-6"
         style={{ bottom: 8, left: "calc(50% - 8px)" }}
         onClick={down}
         disabled={!canDown}
@@ -111,7 +116,7 @@ export default function ScrollableList<T>({
         >
           <path d="M6 9l6 6 6-6" />
         </svg>
-      </button>
+      </Button>
     </Card>
   );
 }

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
 
 interface SettingsModalProps {
   coeff: number;
@@ -79,15 +80,12 @@ export default function SettingsModal({
           />
         </div>
         <div className="flex justify-end space-x-2">
-          <button className="px-2 py-1 bg-muted rounded" onClick={onClose}>
+          <Button variant="secondary" onClick={onClose}>
             Cancel
-          </button>
-          <button
-            className="px-2 py-1 bg-purple-600 text-white rounded"
-            onClick={handleSave}
-          >
+          </Button>
+          <Button variant="default" onClick={handleSave}>
             Save
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/components/TwitchClips.tsx
+++ b/frontend/components/TwitchClips.tsx
@@ -143,8 +143,10 @@ export default function TwitchClips() {
               );
             })}
           </ul>
-          <button
-            className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+          <Button
+            variant="icon"
+            size="icon"
+            className="absolute p-1 rounded-full h-6 w-6"
             style={{ top: headerHeight + 8, left: "calc(50% - 8px)" }}
             onClick={up}
             disabled={!canUp}
@@ -160,9 +162,11 @@ export default function TwitchClips() {
             >
               <path d="M18 15l-6-6-6 6" />
             </svg>
-          </button>
-          <button
-            className="absolute bg-gray-300 rounded-full p-1 disabled:opacity-50"
+          </Button>
+          <Button
+            variant="icon"
+            size="icon"
+            className="absolute p-1 rounded-full h-6 w-6"
             style={{ bottom: 8, left: "calc(50% - 8px)" }}
             onClick={down}
             disabled={!canDown}
@@ -178,7 +182,7 @@ export default function TwitchClips() {
             >
               <path d="M6 9l6 6 6-6" />
             </svg>
-          </button>
+          </Button>
         </>
       )}
     </Card>

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -16,6 +16,8 @@ const buttonVariants = cva(
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "underline-offset-4 hover:underline text-primary",
+        icon: "bg-muted text-muted-foreground hover:bg-muted/80",
+        "icon-rounded": "bg-muted text-muted-foreground hover:bg-muted/80 rounded-full",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
## Summary
- replace SettingsModal buttons with shared Button variants
- add icon and icon-rounded variants to Button and use for scroll controls
- swap raw scroll buttons in lists and clips for themed Button

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da9a8258c8320b2b7089de8e348f2