### PR TITLE
feat: add shadow variants for cards

### DIFF
--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -76,7 +76,7 @@ export default function EventLog() {
   const LIST_HEIGHT = 960;
   if (loading) {
     return (
-      <Card className="space-y-2 relative">
+      <Card variant="shadow" className="space-y-2 relative">
         <h2 className="text-lg font-semibold">Recent Events</h2>
         <ul className="space-y-2 text-sm pr-1" style={{ height: LIST_HEIGHT }}>
           {Array.from({ length: 4 }).map((_, i) => (
@@ -91,7 +91,7 @@ export default function EventLog() {
 
   if (logs.length === 0 || error) {
     return (
-      <Card className="space-y-2 relative">
+      <Card variant="shadow" className="space-y-2 relative">
         <h2 className="text-lg font-semibold">Recent Events</h2>
         <div
           className="flex items-center justify-center"

--- a/frontend/components/TwitchClips.tsx
+++ b/frontend/components/TwitchClips.tsx
@@ -98,7 +98,7 @@ export default function TwitchClips() {
   const LIST_HEIGHT = 2400;
 
   return (
-    <Card className="space-y-2 relative">
+    <Card variant="shadow" className="space-y-2 relative">
       <h2 ref={headerRef} className="text-lg font-semibold">Twitch Clips</h2>
       {loading ? (
         <ul className="space-y-2 pr-1" style={{ height: LIST_HEIGHT }}>

--- a/frontend/components/TwitchVideos.tsx
+++ b/frontend/components/TwitchVideos.tsx
@@ -52,7 +52,7 @@ export default function TwitchVideos() {
   const LIST_HEIGHT = 2400;
   if (loading) {
     return (
-      <Card className="space-y-2 relative">
+      <Card variant="shadow" className="space-y-2 relative">
         <h2 className="text-lg font-semibold">Stream VODs</h2>
         <ul className="space-y-2 pr-1" style={{ height: LIST_HEIGHT }}>
           {Array.from({ length: 4 }).map((_, i) => (
@@ -68,7 +68,7 @@ export default function TwitchVideos() {
 
   if (videos.length === 0 || error) {
     return (
-      <Card className="space-y-2 relative">
+      <Card variant="shadow" className="space-y-2 relative">
         <h2 className="text-lg font-semibold">Stream VODs</h2>
         <div className="flex items-center justify-center" style={{ height: LIST_HEIGHT }}>
           <div className="space-y-2 text-center">

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -1,14 +1,18 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+export interface CardProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: "plain" | "shadow";
+}
 
 const Card = React.forwardRef<HTMLDivElement, CardProps>(
-  ({ className, ...props }, ref) => (
+  ({ className, variant = "shadow", ...props }, ref) => (
     <div
       ref={ref}
       className={cn(
-        "rounded-lg bg-muted p-4 border",
+        "rounded-lg bg-muted p-4 border shadow-sm",
+        variant === "plain" && "border-none shadow-none",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- add `plain` and `shadow` variants to Card component
- update EventLog, TwitchVideos and TwitchClips to use shadow Card variant

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689dac06f0348320a4a141194413ae5b