### PR TITLE
refactor: use next/image for images

### DIFF
--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { use, useEffect, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { ROLE_ICONS, getSubBadge } from "@/lib/roleIcons";
 import { useTwitchUserInfo } from "@/lib/useTwitchUserInfo";
 import { proxiedImage, cn } from "@/lib/utils";
@@ -168,25 +169,39 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
             r === "Sub"
               ? subBadge
                 ? (
-                    <img
+                    <Image
                       key={r}
                       src={subBadge}
                       alt={r}
+                      width={24}
+                      height={24}
                       className="w-6 h-6"
+                      loading="lazy"
                     />
                   )
                 : null
               : ROLE_ICONS[r]
               ? (
-                  <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-6 h-6" />
+                  <Image
+                    key={r}
+                    src={ROLE_ICONS[r]}
+                    alt={r}
+                    width={24}
+                    height={24}
+                    className="w-6 h-6"
+                    loading="lazy"
+                  />
                 )
               : null
           )}
         {enableTwitchRoles && profileUrl && (
-          <img
+          <Image
             src={profileUrl}
             alt="profile"
+            width={40}
+            height={40}
             className="w-10 h-10 rounded-full"
+            priority
           />
         )}
         <a
@@ -194,10 +209,13 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
           target="_blank"
           rel="noopener noreferrer"
         >
-          <img
+          <Image
             src="/icons/socials/twitch.svg"
             alt="Twitch"
+            width={16}
+            height={16}
             className="inline-block h-[1em] w-[1em]"
+            priority
           />
         </a>
         <span>{user.username}</span>

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { ROLE_ICONS, getSubBadge } from "@/lib/roleIcons";
 import { useTwitchUserInfo } from "@/lib/useTwitchUserInfo";
 import {
@@ -44,17 +45,28 @@ function UserRowBase({
           r === "Sub"
             ? badge
               ? (
-                  <img
+                  <Image
                     key={r}
                     src={badge}
                     alt={r}
+                    width={16}
+                    height={16}
                     className="w-4 h-4"
+                    loading="lazy"
                   />
                 )
               : null
             : ROLE_ICONS[r]
             ? (
-                <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
+                <Image
+                  key={r}
+                  src={ROLE_ICONS[r]}
+                  alt={r}
+                  width={16}
+                  height={16}
+                  className="w-4 h-4"
+                  loading="lazy"
+                />
               )
             : null
         )}

--- a/frontend/components/AddCatalogGameModal.tsx
+++ b/frontend/components/AddCatalogGameModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import type { Session } from "@supabase/supabase-js";
 
 interface Result {
@@ -128,10 +129,13 @@ export default function AddCatalogGameModal({ session, onClose, onAdded }: Props
           {results.map((r) => (
             <div key={r.rawg_id} className="flex items-center space-x-2">
               {r.background_image && (
-                <img
+                <Image
                   src={r.background_image}
                   alt={r.name}
+                  width={64}
+                  height={36}
                   className="w-16 h-9 object-cover"
+                  loading="lazy"
                 />
               )}
               <span className="flex-grow">{r.name}</span>

--- a/frontend/components/AddGameModal.tsx
+++ b/frontend/components/AddGameModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import type { Session } from "@supabase/supabase-js";
 
 interface Result {
@@ -80,10 +81,13 @@ export default function AddGameModal({ pollId, session, onClose, onAdded, onSele
           {results.map((r) => (
             <div key={r.rawg_id} className="flex items-center space-x-2">
               {r.background_image && (
-                <img
+                <Image
                   src={r.background_image}
                   alt={r.name}
+                  width={64}
+                  height={36}
                   className="w-16 h-9 object-cover"
+                  loading="lazy"
                 />
               )}
               <span className="flex-grow">{r.name}</span>

--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import Image from "next/image";
 
 import type { Session } from "@supabase/supabase-js";
 
@@ -404,27 +405,41 @@ export default function AuthStatus() {
                   r === "Sub"
                     ? subBadge
                       ? (
-                          <img
+                          <Image
                             key={r}
                             src={subBadge}
                             alt={r}
+                            width={16}
+                            height={16}
                             className="w-4 h-4"
+                            loading="lazy"
                           />
                         )
                       : null
                     : ROLE_ICONS[r]
                     ? (
-                        <img key={r} src={ROLE_ICONS[r]} alt={r} className="w-4 h-4" />
+                        <Image
+                          key={r}
+                          src={ROLE_ICONS[r]}
+                          alt={r}
+                          width={16}
+                          height={16}
+                          className="w-4 h-4"
+                          loading="lazy"
+                        />
                       )
                     : null
                 )}
               {username}
             </span>
             {profileUrl && (
-              <img
+              <Image
                 src={profileUrl}
                 alt="profile"
+                width={24}
+                height={24}
                 className="w-6 h-6 rounded-full"
+                priority
               />
             )}
           </Button>
@@ -458,10 +473,13 @@ export default function AuthStatus() {
         aria-label="Login with Twitch"
         className="sm:w-auto sm:px-4"
       >
-        <img
+        <Image
           src="/icons/socials/twitch.svg"
           alt="Twitch"
+          width={24}
+          height={24}
           className="w-6 h-6 invert"
+          priority
         />
         <span className="hidden sm:inline ml-2">Login with Twitch</span>
       </Button>

--- a/frontend/components/EditCatalogGameModal.tsx
+++ b/frontend/components/EditCatalogGameModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import type { Session } from "@supabase/supabase-js";
 
 interface Result {
@@ -113,7 +114,14 @@ export default function EditCatalogGameModal({
           </button>
         </div>
         {background && (
-          <img src={background} alt={name} className="w-full h-32 object-cover" />
+          <Image
+            src={background}
+            alt={name}
+            width={640}
+            height={360}
+            className="w-full h-32 object-cover"
+            priority
+          />
         )}
         <input
           className="border p-1 w-full text-foreground"
@@ -170,10 +178,13 @@ export default function EditCatalogGameModal({
           {results.map((r) => (
             <div key={r.rawg_id} className="flex items-center space-x-2">
               {r.background_image && (
-                <img
+                <Image
                   src={r.background_image}
                   alt={r.name}
+                  width={64}
+                  height={36}
                   className="w-16 h-9 object-cover"
+                  loading="lazy"
                 />
               )}
               <span className="flex-grow">{r.name}</span>

--- a/frontend/components/EditPlaylistGameModal.tsx
+++ b/frontend/components/EditPlaylistGameModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import type { Session } from "@supabase/supabase-js";
 
 interface Game {
@@ -134,10 +135,13 @@ export default function EditPlaylistGameModal({
           {results.map((r) => (
             <div key={r.rawg_id} className="flex items-center space-x-2">
               {r.background_image && (
-                <img
+                <Image
                   src={r.background_image}
                   alt={r.name}
+                  width={64}
+                  height={36}
                   className="w-16 h-9 object-cover"
+                  loading="lazy"
                 />
               )}
               <span className="flex-grow">{r.name}</span>

--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
+import Image from "next/image";
 import { supabase } from "@/lib/supabase";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -116,10 +117,13 @@ export default function EventLog() {
           {new Date(l.created_at).toLocaleTimeString()} - {l.message}
           {l.preview_url && l.media_url && (
             <a href={l.media_url} target="_blank" rel="noopener noreferrer">
-              <img
+              <Image
                 src={l.preview_url}
                 alt={l.message}
-                className="mt-2 max-w-full"
+                width={320}
+                height={180}
+                className="mt-2 w-full h-auto"
+                loading="lazy"
               />
             </a>
           )}

--- a/frontend/components/PlaylistRow.tsx
+++ b/frontend/components/PlaylistRow.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { Card } from "@/components/ui/card";
 import { proxiedImage, cn } from "@/lib/utils";
 
@@ -154,7 +155,14 @@ export default function PlaylistRow({
                   className="block"
                 >
                   {src ? (
-                    <img src={src} alt={v.title} className="w-full rounded" />
+                    <Image
+                      src={src}
+                      alt={v.title}
+                      width={320}
+                      height={180}
+                      className="w-full rounded"
+                      loading="lazy"
+                    />
                   ) : null}
                   <p
                     className={cn(

--- a/frontend/components/TwitchClips.tsx
+++ b/frontend/components/TwitchClips.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { proxiedImage } from "@/lib/utils";
+import Image from "next/image";
 
 interface Clip {
   id: string;
@@ -136,7 +137,14 @@ export default function TwitchClips() {
                     rel="noopener noreferrer"
                     className="block"
                   >
-                    <img src={src} alt={clip.title} className="w-full rounded" />
+                    <Image
+                      src={src}
+                      alt={clip.title}
+                      width={320}
+                      height={180}
+                      className="w-full rounded"
+                      loading="lazy"
+                    />
                     <p className="text-sm">{clip.title}</p>
                   </a>
                 </li>

--- a/frontend/components/TwitchVideos.tsx
+++ b/frontend/components/TwitchVideos.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import Image from "next/image";
 import ScrollableList from "@/components/ScrollableList";
 
 interface TwitchVideo {
@@ -101,7 +102,14 @@ export default function TwitchVideos() {
               rel="noopener noreferrer"
               className="block"
             >
-              <img src={src} alt={v.title} className="w-full rounded" />
+              <Image
+                src={src}
+                alt={v.title}
+                width={320}
+                height={180}
+                className="w-full rounded"
+                loading="lazy"
+              />
               <p className="text-sm">{v.title}</p>
             </a>
           </li>

--- a/frontend/components/__tests__/AuthStatus.test.tsx
+++ b/frontend/components/__tests__/AuthStatus.test.tsx
@@ -132,7 +132,7 @@ describe('AuthStatus roles', () => {
         return {
           ok: true,
           status: 200,
-          json: async () => ({ data: [{ id: userId, profile_image_url: 'p.png' }] }),
+          json: async () => ({ data: [{ id: userId, profile_image_url: '/p.png' }] }),
         } as Response;
       }
       if (url === `${backendUrl}/api/streamer-token`) {
@@ -164,7 +164,7 @@ describe('AuthStatus roles', () => {
             ok: true,
             status: 200,
             json: async () => ({
-              data: [{ id: userId, profile_image_url: 'p.png' }],
+              data: [{ id: userId, profile_image_url: '/p.png' }],
             }),
           } as Response;
         }
@@ -273,7 +273,7 @@ describe('AuthStatus sub badges', () => {
         return {
           ok: true,
           status: 200,
-          json: async () => ({ data: [{ id: userId, profile_image_url: 'p.png' }] }),
+          json: async () => ({ data: [{ id: userId, profile_image_url: '/p.png' }] }),
         } as Response;
       }
       if (url === `${backendUrl}/api/streamer-token`) {
@@ -333,7 +333,7 @@ describe('AuthStatus sub badges', () => {
     render(<AuthStatus />);
 
     const img = await screen.findByAltText('Sub');
-    expect(img).toHaveAttribute('src', `/icons/subs/${badge}.svg`);
+    expect(img.getAttribute('src')).toContain(`/icons/subs/${badge}.svg`);
   });
 
   it('does not render badge for 0 months', async () => {
@@ -346,7 +346,7 @@ describe('AuthStatus sub badges', () => {
         return {
           ok: true,
           status: 200,
-          json: async () => ({ data: [{ id: userId, profile_image_url: 'p.png' }] }),
+          json: async () => ({ data: [{ id: userId, profile_image_url: '/p.png' }] }),
         } as Response;
       }
       if (url === `${backendUrl}/api/streamer-token`) {

--- a/frontend/components/__tests__/EditPlaylistGameModal.test.tsx
+++ b/frontend/components/__tests__/EditPlaylistGameModal.test.tsx
@@ -63,7 +63,7 @@ test('selects new game', async () => {
     if (url === `${backend}/api/rawg_search?query=Bar`) {
       return Promise.resolve({
         ok: true,
-        json: async () => ({ results: [{ rawg_id: 20, name: 'Bar', background_image: 'img' }] }),
+        json: async () => ({ results: [{ rawg_id: 20, name: 'Bar', background_image: '/img.png' }] }),
       });
     }
     if (url === `${backend}/api/playlist_game`) {
@@ -91,7 +91,7 @@ test('selects new game', async () => {
           tag: 'tag',
           game_name: 'Bar',
           rawg_id: 20,
-          background_image: 'img',
+          background_image: '/img.png',
         }),
       })
     )

--- a/frontend/components/__tests__/EventLog.test.tsx
+++ b/frontend/components/__tests__/EventLog.test.tsx
@@ -44,7 +44,7 @@ describe('EventLog', () => {
     render(<EventLog />);
 
     const img = await screen.findByAltText('test');
-    expect(img).toHaveAttribute('src', 'http://preview');
+    expect(img.getAttribute('src')).toContain('preview');
     expect(img.closest('a')).toHaveAttribute('href', 'http://media');
   });
 });

--- a/frontend/components/__tests__/Playlists.test.tsx
+++ b/frontend/components/__tests__/Playlists.test.tsx
@@ -32,7 +32,7 @@ describe('PlaylistsPage', () => {
         json: async () => ({
           rpg: {
             videos: [],
-            game: { id: 1, name: 'Game1', background_image: 'img' },
+            game: { id: 1, name: 'Game1', background_image: '/img.png' },
           },
         }),
       });

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "**" },
+      { protocol: "http", hostname: "**" },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- refactor image usage to leverage `next/image` with explicit sizes
- allow remote image domains in Next config
- adjust tests for new image handling

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689dad9eceb883208a055c5751a7e77d