### PR TITLE
feat: localize home page messages

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -11,6 +11,7 @@ import type { Session } from "@supabase/supabase-js";
 import type { Game, Poll, Voter } from "@/types";
 import { proxiedImage, cn } from "@/lib/utils";
 import { Spinner } from "@/components/ui/spinner";
+import { useTranslation } from "react-i18next";
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 if (!backendUrl) {
@@ -21,6 +22,7 @@ if (!backendUrl) {
 
 
 export default function Home() {
+  const { t } = useTranslation();
   const [poll, setPoll] = useState<Poll | null>(null);
   const [loading, setLoading] = useState(true);
   const [session, setSession] = useState<Session | null>(null);
@@ -76,7 +78,7 @@ export default function Home() {
 
   const resetWheel = async () => {
     if (!poll) return;
-    const confirmReset = window.confirm('Reset the wheel?');
+    const confirmReset = window.confirm(t('resetWheelConfirm'));
     if (!confirmReset) return;
 
     if (officialMode && isModerator && backendUrl) {
@@ -116,7 +118,7 @@ export default function Home() {
   };
 
   if (!backendUrl) {
-    return <div className="p-4">Backend URL not configured.</div>;
+    return <div className="p-4">{t('backendUrlNotConfigured')}</div>;
   }
 
   const fetchPoll = async () => {
@@ -233,15 +235,15 @@ export default function Home() {
       (currentSelected.length !== originalSelected.length ||
         currentSelected.some((v, i) => v !== originalSelected[i]));
     if (added) {
-      setActionHint("Adding vote");
+      setActionHint(t('addingVote'));
     } else if (removed) {
-      setActionHint("Removing vote");
+      setActionHint(t('removingVote'));
     } else if (changed) {
-      setActionHint("Revoting");
+      setActionHint(t('revoting'));
     } else {
-      setActionHint("");
+      setActionHint('');
     }
-  }, [slots, initialSlots]);
+  }, [slots, initialSlots, t]);
 
   useEffect(() => {
     if (poll) {
@@ -257,7 +259,7 @@ export default function Home() {
   const adjustVote = (gameId: number, delta: number) => {
     if (!acceptVotes) return;
     if (!allowEdit) {
-      setActionHint("Editing disabled");
+      setActionHint(t('editingDisabled'));
       return;
     }
     setActionHint("");
@@ -268,7 +270,7 @@ export default function Home() {
         if (free !== -1) {
           arr[free] = gameId;
         } else {
-          setActionHint("Vote limit reached");
+          setActionHint(t('voteLimitReached'));
           return arr;
         }
       } else if (delta < 0) {
@@ -350,7 +352,7 @@ export default function Home() {
     const selected = slots.filter((id) => id !== null) as number[];
     if (selected.length === 0) return;
     if (!backendUrl) {
-      alert("Backend URL not configured");
+      alert(t('backendUrlNotConfigured'));
       return;
     }
     setSubmitting(true);
@@ -438,7 +440,7 @@ export default function Home() {
   };
 
   const startOfficialSpin = async () => {
-    const confirmStart = window.confirm("Start official spin?");
+    const confirmStart = window.confirm(t('startOfficialSpinConfirm'));
     if (!confirmStart) return;
     await saveAccept(false);
     await saveAllowEdit(false);
@@ -454,38 +456,38 @@ export default function Home() {
       </div>
     );
   }
-  if (!poll) return <div className="p-4">No poll available.</div>;
+  if (!poll) return <div className="p-4">{t('noPollAvailable')}</div>;
 
   return (
     <>
       <main className="col-span-12 md:col-span-9 grid grid-cols-1 md:grid-cols-9 gap-x-2 gap-y-4 max-w-5xl">
         <div className="col-span-12 md:col-span-3 px-2 py-4 space-y-4 overflow-y-auto">
-        <h1 className="text-2xl font-semibold">Current Poll</h1>
+        <h1 className="text-2xl font-semibold">{t('currentPoll')}</h1>
         {isModerator && (
           <div className="space-x-2">
             <button
               className="px-2 py-1 bg-purple-600 text-white rounded"
               onClick={() => setShowSettings(true)}
           >
-            Settings
+            {t('settings')}
           </button>
           {!officialMode ? (
             <button
               className="px-2 py-1 bg-red-600 text-white rounded"
               onClick={startOfficialSpin}
             >
-              Start official spin
+              {t('startOfficialSpin')}
             </button>
           ) : (
           <span className="px-2 py-1 bg-green-600 text-white rounded">
-            Official spin
+            {t('officialSpin')}
           </span>
         )}
       </div>
       )}
-      <p>You can cast up to {voteLimit} votes.</p>
+      <p>{t('castUpToVotes', { count: voteLimit })}</p>
       {!acceptVotes && (
-        <p className="text-red-500">Voting is currently closed.</p>
+        <p className="text-red-500">{t('votingClosed')}</p>
       )}
       <ul className="space-y-2">
         {poll.games.map((game) => {
@@ -564,13 +566,13 @@ export default function Home() {
         disabled={!slots.some((s) => s !== null) || submitting || !session || !acceptVotes || !allowEdit}
         onClick={handleVote}
       >
-        {submitting ? "Voting..." : "Vote"}
+        {submitting ? t('voting') : t('vote')}
       </button>
       {actionHint && (
         <p className="text-sm text-gray-500">{actionHint}</p>
       )}
       <p className="text-sm text-gray-500">
-        You have used {usedVotes} of {voteLimit} votes.
+        {t('usedVotes', { used: usedVotes, limit: voteLimit })}
       </p>
         </div>
         <div className="col-span-12 md:col-span-6 px-2 py-4 flex flex-col items-center justify-start">
@@ -589,21 +591,21 @@ export default function Home() {
                 className="px-4 py-2 bg-purple-600 text-white rounded"
                 onClick={handleSpin}
               >
-                Spin
+                {t('spin')}
               </button>
               {showReset && (
                 <button
                   className="px-4 py-2 bg-gray-300 rounded"
                   onClick={resetWheel}
                 >
-                  Reset
+                  {t('reset')}
                 </button>
               )}
             </div>
           </>
         )}
         {winner && (
-          <h2 className="text-2xl font-bold">Winning game: {winner.name}</h2>
+          <h2 className="text-2xl font-bold">{t('winningGame', { name: winner.name })}</h2>
         )}
         </div>
       </main>

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -1,5 +1,26 @@
 {
   "language": "Language",
   "english": "English",
-  "russian": "Russian"
+  "russian": "Russian",
+  "resetWheelConfirm": "Reset the wheel?",
+  "backendUrlNotConfigured": "Backend URL not configured.",
+  "addingVote": "Adding vote",
+  "removingVote": "Removing vote",
+  "revoting": "Revoting",
+  "editingDisabled": "Editing disabled",
+  "voteLimitReached": "Vote limit reached",
+  "startOfficialSpinConfirm": "Start official spin?",
+  "noPollAvailable": "No poll available.",
+  "currentPoll": "Current Poll",
+  "settings": "Settings",
+  "startOfficialSpin": "Start official spin",
+  "officialSpin": "Official spin",
+  "castUpToVotes": "You can cast up to {{count}} votes.",
+  "votingClosed": "Voting is currently closed.",
+  "voting": "Voting...",
+  "vote": "Vote",
+  "usedVotes": "You have used {{used}} of {{limit}} votes.",
+  "spin": "Spin",
+  "reset": "Reset",
+  "winningGame": "Winning game: {{name}}"
 }

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -1,5 +1,26 @@
 {
   "language": "Язык",
   "english": "Английский",
-  "russian": "Русский"
+  "russian": "Русский",
+  "resetWheelConfirm": "Сбросить рулетку?",
+  "backendUrlNotConfigured": "URL бэкенда не настроен.",
+  "addingVote": "Добавление голоса",
+  "removingVote": "Удаление голоса",
+  "revoting": "Переголосование",
+  "editingDisabled": "Редактирование отключено",
+  "voteLimitReached": "Достигнут лимит голосов",
+  "startOfficialSpinConfirm": "Начать официальный спин?",
+  "noPollAvailable": "Нет доступного опроса.",
+  "currentPoll": "Текущий опрос",
+  "settings": "Настройки",
+  "startOfficialSpin": "Начать официальный спин",
+  "officialSpin": "Официальный спин",
+  "castUpToVotes": "Вы можете отдать до {{count}} голосов.",
+  "votingClosed": "Голосование закрыто.",
+  "voting": "Голосование...",
+  "vote": "Голосовать",
+  "usedVotes": "Вы использовали {{used}} из {{limit}} голосов.",
+  "spin": "Крутить",
+  "reset": "Сброс",
+  "winningGame": "Победившая игра: {{name}}"
 }


### PR DESCRIPTION
## Summary
- localize roulette page messages and prompts
- add Russian and English translations for roulette page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689db8c2405c8320ae16d794a565658e