### PR TITLE
feat: localize settings modal

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -469,7 +469,7 @@ export default function Home() {
               className="px-2 py-1 bg-purple-600 text-white rounded"
               onClick={() => setShowSettings(true)}
           >
-            {t('settings')}
+            {t('settings.title')}
           </button>
           {!officialMode ? (
             <button

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 
 interface SettingsModalProps {
@@ -29,6 +30,7 @@ export default function SettingsModal({
   const [zero, setZero] = useState(zeroWeight);
   const [accept, setAccept] = useState(acceptVotes);
   const [edit, setEdit] = useState(allowEdit);
+  const { t } = useTranslation();
 
   useEffect(() => {
     setValue(coeff);
@@ -44,9 +46,9 @@ export default function SettingsModal({
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-background text-foreground p-4 rounded space-y-4 shadow-lg">
-        <h2 className="text-xl font-semibold">Settings</h2>
+        <h2 className="text-xl font-semibold">{t('settings.title')}</h2>
         <div className="flex items-center space-x-2">
-          <label className="text-sm">Voice coefficient:</label>
+          <label className="text-sm">{t('settings.voiceCoefficient')}</label>
           <input
             type="number"
             value={value}
@@ -55,7 +57,7 @@ export default function SettingsModal({
           />
         </div>
         <div className="flex items-center space-x-2">
-          <label className="text-sm">Zero vote weight:</label>
+          <label className="text-sm">{t('settings.zeroVoteWeight')}</label>
           <input
             type="number"
             value={zero}
@@ -64,7 +66,7 @@ export default function SettingsModal({
           />
         </div>
         <div className="flex items-center space-x-2">
-          <label className="text-sm">Accept votes:</label>
+          <label className="text-sm">{t('settings.acceptVotes')}</label>
           <input
             type="checkbox"
             checked={accept}
@@ -72,7 +74,7 @@ export default function SettingsModal({
           />
         </div>
         <div className="flex items-center space-x-2">
-          <label className="text-sm">Allow edit:</label>
+          <label className="text-sm">{t('settings.allowEdit')}</label>
           <input
             type="checkbox"
             checked={edit}
@@ -81,10 +83,10 @@ export default function SettingsModal({
         </div>
         <div className="flex justify-end space-x-2">
           <Button variant="secondary" onClick={onClose}>
-            Cancel
+            {t('settings.cancel')}
           </Button>
           <Button variant="default" onClick={handleSave}>
-            Save
+            {t('settings.save')}
           </Button>
         </div>
       </div>

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -12,7 +12,6 @@
   "startOfficialSpinConfirm": "Start official spin?",
   "noPollAvailable": "No poll available.",
   "currentPoll": "Current Poll",
-  "settings": "Settings",
   "startOfficialSpin": "Start official spin",
   "officialSpin": "Official spin",
   "castUpToVotes": "You can cast up to {{count}} votes.",
@@ -22,5 +21,14 @@
   "usedVotes": "You have used {{used}} of {{limit}} votes.",
   "spin": "Spin",
   "reset": "Reset",
-  "winningGame": "Winning game: {{name}}"
+  "winningGame": "Winning game: {{name}}",
+  "settings": {
+    "title": "Settings",
+    "voiceCoefficient": "Voice coefficient:",
+    "zeroVoteWeight": "Zero vote weight:",
+    "acceptVotes": "Accept votes:",
+    "allowEdit": "Allow edit:",
+    "cancel": "Cancel",
+    "save": "Save"
+  }
 }

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -12,7 +12,6 @@
   "startOfficialSpinConfirm": "Начать официальный спин?",
   "noPollAvailable": "Нет доступного опроса.",
   "currentPoll": "Текущий опрос",
-  "settings": "Настройки",
   "startOfficialSpin": "Начать официальный спин",
   "officialSpin": "Официальный спин",
   "castUpToVotes": "Вы можете отдать до {{count}} голосов.",
@@ -22,5 +21,14 @@
   "usedVotes": "Вы использовали {{used}} из {{limit}} голосов.",
   "spin": "Крутить",
   "reset": "Сброс",
-  "winningGame": "Победившая игра: {{name}}"
+  "winningGame": "Победившая игра: {{name}}",
+  "settings": {
+    "title": "Настройки",
+    "voiceCoefficient": "Коэффициент голоса:",
+    "zeroVoteWeight": "Вес нулевого голоса:",
+    "acceptVotes": "Принимать голоса:",
+    "allowEdit": "Разрешить редактирование:",
+    "cancel": "Отмена",
+    "save": "Сохранить"
+  }
 }


### PR DESCRIPTION
## Summary
- replace hardcoded text in SettingsModal with i18next translations
- add settings strings to Russian and English locale files
- update settings button to use new localization key

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dbfac254883208090ff90bf78771a