### PR TITLE
feat: localize spin result modal

### DIFF
--- a/frontend/components/SpinResultModal.tsx
+++ b/frontend/components/SpinResultModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { WheelGame } from "./RouletteWheel";
+import { useTranslation } from "react-i18next";
 
 interface SpinResultModalProps {
   eliminated: WheelGame;
@@ -8,16 +9,20 @@ interface SpinResultModalProps {
 }
 
 export default function SpinResultModal({ eliminated, winner, onClose }: SpinResultModalProps) {
+  const { t } = useTranslation();
+
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-background text-foreground p-4 rounded space-y-4 shadow-lg">
-        <h2 className="text-xl font-semibold">Dropped game: {eliminated.name}</h2>
+        <h2 className="text-xl font-semibold">
+          {t("droppedGame", { name: eliminated.name })}
+        </h2>
         {winner && (
-          <p className="text-lg">Winning game: {winner.name}</p>
+          <p className="text-lg">{t("winningGame", { name: winner.name })}</p>
         )}
         <div className="flex justify-end">
           <button className="px-4 py-2 bg-purple-600 text-white rounded" onClick={onClose}>
-            Close
+            {t("close")}
           </button>
         </div>
       </div>

--- a/frontend/components/__tests__/SpinResultModal.test.tsx
+++ b/frontend/components/__tests__/SpinResultModal.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import SpinResultModal from '../SpinResultModal';
+import '../../i18n';
 
 const game = { id: 1, name: 'Test', count: 1 } as any;
 

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -21,7 +21,9 @@
   "usedVotes": "You have used {{used}} of {{limit}} votes.",
   "spin": "Spin",
   "reset": "Reset",
+  "droppedGame": "Dropped game: {{name}}",
   "winningGame": "Winning game: {{name}}",
+  "close": "Close",
   "settings": {
     "title": "Settings",
     "voiceCoefficient": "Voice coefficient:",

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -21,7 +21,9 @@
   "usedVotes": "Вы использовали {{used}} из {{limit}} голосов.",
   "spin": "Крутить",
   "reset": "Сброс",
+  "droppedGame": "Вылетевшая игра: {{name}}",
   "winningGame": "Победившая игра: {{name}}",
+  "close": "Закрыть",
   "settings": {
     "title": "Настройки",
     "voiceCoefficient": "Коэффициент голоса:",


### PR DESCRIPTION
## Summary
- localize spin result modal strings
- add translations for dropped and winning games

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc131575c83209b38bbd86901bc71