### PR TITLE
feat: localize user profile page

### DIFF
--- a/frontend/app/__tests__/UserPage.statsZero.test.tsx
+++ b/frontend/app/__tests__/UserPage.statsZero.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, within, act } from "@testing-library/react";
+import i18n from "@/i18n";
 
 process.env.NEXT_PUBLIC_BACKEND_URL = "http://backend";
 process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES = "false";
@@ -10,8 +11,9 @@ jest.mock("@/lib/useTwitchUserInfo", () => ({
 const UserPage = require("@/app/users/[id]/page").default;
 
 describe("UserPage stats filtering", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
+    await i18n.changeLanguage('ru');
   });
 
   it("hides zero values and empty sections", async () => {

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useTwitchUserInfo } from "@/lib/useTwitchUserInfo";
 import { proxiedImage, cn } from "@/lib/utils";
 import { INTIM_LABELS, POCELUY_LABELS, TOTAL_LABELS } from "@/lib/statLabels";
 import MedalIcon, { MedalType } from "@/components/MedalIcon";
+import { useTranslation } from "react-i18next";
 
 interface PollHistory {
   id: number;
@@ -47,14 +48,6 @@ interface Achievement {
 
 type UserMedals = Record<string, MedalType | null>;
 
-const STAT_LABELS: Record<string, string> = {
-  ...TOTAL_LABELS,
-  ...INTIM_LABELS,
-  ...POCELUY_LABELS,
-  top_voters: "Top Voters",
-  top_roulette_users: "Top Roulette Users",
-};
-
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 const enableTwitchRoles = process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES === "true";
 
@@ -67,6 +60,15 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   const [medals, setMedals] = useState<UserMedals>({});
   const [loading, setLoading] = useState(true);
   const { profileUrl, roles, error } = useTwitchUserInfo(user ? user.twitch_login : null);
+  const { t } = useTranslation();
+
+  const STAT_LABELS: Record<string, string> = {
+    ...TOTAL_LABELS,
+    ...INTIM_LABELS,
+    ...POCELUY_LABELS,
+    top_voters: t("stats.topVoters"),
+    top_roulette_users: t("stats.topRouletteParticipants"),
+  };
 
   useEffect(() => {
     const fetchData = async () => {
@@ -151,15 +153,15 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
     ([, type]) => type !== null
   ) as [string, MedalType][];
 
-  if (!backendUrl) return <div className="p-4">Backend URL not configured.</div>;
-  if (loading) return <div className="p-4">Loading...</div>;
-  if (!user) return <div className="p-4">User not found.</div>;
+  if (!backendUrl) return <div className="p-4">{t("backendUrlNotConfigured")}</div>;
+  if (loading) return <div className="p-4">{t("loading")}</div>;
+  if (!user) return <div className="p-4">{t("userPage.userNotFound")}</div>;
   const subBadge = getSubBadge(user.total_months_subbed);
 
   return (
     <main className="col-span-12 md:col-span-9 p-4 space-y-4">
       <Link href="/users" className="text-purple-600 underline">
-        Back to users
+        {t("userPage.backToUsers")}
       </Link>
       {error && <p className="text-red-600">{error}</p>}
       <h1 className="text-2xl font-semibold flex items-center space-x-2">
@@ -197,7 +199,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         {enableTwitchRoles && profileUrl && (
           <Image
             src={profileUrl}
-            alt="profile"
+            alt={t("userPage.profile")}
             width={40}
             height={40}
             className="w-10 h-10 rounded-full"
@@ -221,21 +223,25 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         <span>{user.username}</span>
         {user.logged_in ? (
           <span className="px-2 py-0.5 text-xs bg-green-600 text-white rounded">
-            Logged in via site
+            {t("userPage.loggedIn")}
           </span>
         ) : (
           <span className="px-2 py-0.5 text-xs bg-gray-500 text-white rounded">
-            Not logged in via site
+            {t("userPage.notLoggedIn")}
           </span>
         )}
       </h1>
       <div className="border rounded-lg relative overflow-hidden p-4 space-y-1 bg-muted">
-        <p>Votes: {user.votes}</p>
-        <p>Roulettes: {user.roulettes}</p>
+        <p>
+          {t("stats.votes")}: {user.votes}
+        </p>
+        <p>
+          {t("stats.roulettes")}: {user.roulettes}
+        </p>
       </div>
       {achievements.length > 0 && (
         <details>
-          <summary>Achievements</summary>
+          <summary>{t("userPage.achievements")}</summary>
           <ul className="pl-4 list-disc">
             {achievements.map((a) => (
               <li key={a.id}>{a.title}</li>
@@ -245,7 +251,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       )}
       {earnedMedals.length > 0 && (
         <details>
-          <summary>Medals</summary>
+          <summary>{t("userPage.medals")}</summary>
           <ul className="pl-4 list-disc">
             {earnedMedals.map(([key, type]) => (
               <li key={key} className="flex items-center">
@@ -258,7 +264,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       )}
       {intimStats.length > 0 && (
         <details>
-          <summary>Интимы</summary>
+          <summary>{t("stats.intims")}</summary>
           <ul className="pl-4 list-disc">
             {intimStats.map(([key, value]) => (
               <li key={key}>
@@ -270,7 +276,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       )}
       {poceluyStats.length > 0 && (
         <details>
-          <summary>Поцелуи</summary>
+          <summary>{t("stats.kisses")}</summary>
           <ul className="pl-4 list-disc">
             {poceluyStats.map(([key, value]) => (
               <li key={key}>
@@ -282,7 +288,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       )}
       {totalStats.length > 0 && (
         <details>
-          <summary>Статистика</summary>
+          <summary>{t("stats.title")}</summary>
           <ul className="pl-4 list-disc">
             {totalStats.map(([key, value]) => (
               <li key={key}>
@@ -293,7 +299,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         </details>
       )}
       {history.length === 0 ? (
-        <p>No votes yet.</p>
+        <p>{t("userPage.noVotesYet")}</p>
       ) : (
         <ul className="space-y-2">
           {history.map((poll) => (
@@ -327,7 +333,9 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
                         : "text-purple-600"
                     )}
                   >
-                    Roulette from {new Date(poll.created_at).toLocaleString()}
+                    {t("userPage.rouletteFrom", {
+                      date: new Date(poll.created_at).toLocaleString(),
+                    })}
                   </Link>
                 </h2>
                 {poll.winnerName && poll.winnerId && (
@@ -340,7 +348,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
                         : "text-purple-600"
                     )}
                   >
-                    Winner is {poll.winnerName}
+                    {t("userPage.winnerIs", { name: poll.winnerName })}
                   </Link>
                 )}
                 <ul className="pl-4 list-disc">
@@ -363,7 +371,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
               </div>
               {!poll.archived && (
                 <span className="absolute top-1 right-1 px-2 py-0.5 text-xs bg-purple-600 text-white rounded">
-                  Active
+                  {t("userPage.active")}
                 </span>
               )}
             </li>

--- a/frontend/components/__tests__/UserPage.test.tsx
+++ b/frontend/components/__tests__/UserPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, act, fireEvent, waitFor, within } from "@testing-library/react";
+import i18n from "@/i18n";
 
 process.env.NEXT_PUBLIC_BACKEND_URL = "http://backend";
 process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES = "true";
@@ -14,12 +15,13 @@ const { useTwitchUserInfo } = require("@/lib/useTwitchUserInfo");
 const originalFetch = (global as any).fetch;
 
 describe("UserPage", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     (useTwitchUserInfo as jest.Mock).mockReturnValue({
       profileUrl: null,
       roles: [],
       error: null,
     });
+    await i18n.changeLanguage('en');
   });
 
   afterEach(() => {
@@ -76,17 +78,17 @@ describe("UserPage", () => {
     expect(screen.queryByText("Achievements")).not.toBeInTheDocument();
     expect(screen.queryByText("Medals")).not.toBeInTheDocument();
 
-    const intimSummary = screen.getByText("Интимы");
+    const intimSummary = screen.getByText(i18n.t('stats.intims'));
     fireEvent.click(intimSummary);
     expect(intimSummary.closest("details")).toHaveAttribute("open");
     expect(screen.getByText("Интим с 0%: 1")).toBeInTheDocument();
 
-    const poceluySummary = screen.getByText("Поцелуи");
+    const poceluySummary = screen.getByText(i18n.t('stats.kisses'));
     fireEvent.click(poceluySummary);
     expect(poceluySummary.closest("details")).toHaveAttribute("open");
     expect(screen.getByText("Заставил кого-то поцеловаться с 69%: 2")).toBeInTheDocument();
 
-    const totalSummary = screen.getByText("Статистика");
+    const totalSummary = screen.getByText(i18n.t('stats.title'));
     fireEvent.click(totalSummary);
     expect(totalSummary.closest("details")).toHaveAttribute("open");
     expect(screen.getByText("Просмотрено стримов: 1")).toBeInTheDocument();
@@ -167,13 +169,14 @@ describe("UserPage", () => {
 });
 
 describe("UserPage sub badges", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     process.env.NEXT_PUBLIC_ENABLE_TWITCH_ROLES = "true";
     (useTwitchUserInfo as jest.Mock).mockReturnValue({
       profileUrl: null,
       roles: ["Sub"],
       error: null,
     });
+    await i18n.changeLanguage('en');
   });
 
   afterEach(() => {

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -24,6 +24,7 @@
   "droppedGame": "Dropped game: {{name}}",
   "winningGame": "Winning game: {{name}}",
   "close": "Close",
+  "loading": "Loading...",
   "settings": {
     "title": "Settings",
     "voiceCoefficient": "Voice coefficient:",
@@ -49,5 +50,18 @@
     "intim": "Intim",
     "kisses": "Kisses",
     "kiss": "Kiss"
+  },
+  "userPage": {
+    "backToUsers": "Back to users",
+    "userNotFound": "User not found.",
+    "loggedIn": "Logged in via site",
+    "notLoggedIn": "Not logged in via site",
+    "achievements": "Achievements",
+    "medals": "Medals",
+    "noVotesYet": "No votes yet.",
+    "rouletteFrom": "Roulette from {{date}}",
+    "winnerIs": "Winner is {{name}}",
+    "active": "Active",
+    "profile": "Profile"
   }
 }

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -24,6 +24,7 @@
   "droppedGame": "Вылетевшая игра: {{name}}",
   "winningGame": "Победившая игра: {{name}}",
   "close": "Закрыть",
+  "loading": "Загрузка...",
   "settings": {
     "title": "Настройки",
     "voiceCoefficient": "Коэффициент голоса:",
@@ -49,5 +50,18 @@
     "intim": "Интим",
     "kisses": "Поцелуи",
     "kiss": "Поцелуй"
+  },
+  "userPage": {
+    "backToUsers": "Назад к пользователям",
+    "userNotFound": "Пользователь не найден.",
+    "loggedIn": "Вход через сайт",
+    "notLoggedIn": "Не входил через сайт",
+    "achievements": "Достижения",
+    "medals": "Медали",
+    "noVotesYet": "Пока нет голосов.",
+    "rouletteFrom": "Рулетка от {{date}}",
+    "winnerIs": "Победитель — {{name}}",
+    "active": "Активна",
+    "profile": "Профиль"
   }
 }


### PR DESCRIPTION
## Summary
- replace hardcoded strings on user profile page with i18n dictionary lookups
- add user page keys to Russian and English locale files
- update tests to initialize i18n

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc5bce090832095073e357935083c