### PR TITLE
Localize 'No game' playlist label

### DIFF
--- a/frontend/components/PlaylistRow.tsx
+++ b/frontend/components/PlaylistRow.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { useTranslation } from "react-i18next";
 import { Card } from "@/components/ui/card";
 import { proxiedImage, cn } from "@/lib/utils";
 
@@ -39,6 +40,7 @@ export default function PlaylistRow({
   const [itemWidth, setItemWidth] = useState(0);
   const [canLeft, setCanLeft] = useState(false);
   const [canRight, setCanRight] = useState(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (headerRef.current) {
@@ -125,7 +127,7 @@ export default function PlaylistRow({
             )}
           </h2>
           <div className="flex items-center space-x-2 text-sm">
-            {!game && <span className="text-gray-500">No game</span>}
+            {!game && <span className="text-gray-500">{t('noGame')}</span>}
             {isModerator && (
               <button
                 className={cn(

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -24,6 +24,7 @@
   "droppedGame": "Dropped game: {{name}}",
   "winningGame": "Winning game: {{name}}",
   "close": "Close",
+  "noGame": "No game",
   "loading": "Loading...",
   "settings": {
     "title": "Settings",

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -24,6 +24,7 @@
   "droppedGame": "Вылетевшая игра: {{name}}",
   "winningGame": "Победившая игра: {{name}}",
   "close": "Закрыть",
+  "noGame": "Нет игры",
   "loading": "Загрузка...",
   "settings": {
     "title": "Настройки",


### PR DESCRIPTION
## Summary
- use translation hook in PlaylistRow instead of hardcoded 'No game' text
- add English and Russian translation entries for missing game label

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc9e8ec848320bb3f838b7d6573e8