### PR TITLE
feat: route-based language switching

### DIFF
--- a/frontend/components/LanguageSwitcher.tsx
+++ b/frontend/components/LanguageSwitcher.tsx
@@ -1,14 +1,18 @@
 "use client";
 
 import { useTranslation } from 'react-i18next';
+import { useRouter, usePathname } from 'next/navigation';
 
 export default function LanguageSwitcher() {
+  const router = useRouter();
+  const pathname = usePathname();
   const { i18n, t } = useTranslation();
+
   return (
     <select
       aria-label={t('language')}
       value={i18n.language}
-      onChange={(e) => i18n.changeLanguage(e.target.value)}
+      onChange={(e) => router.replace(`/${e.target.value}${pathname}`)}
       className="border rounded p-1 bg-background text-foreground"
     >
       <option value="en">{t('english')}</option>


### PR DESCRIPTION
## Summary
- use Next.js router and pathname to switch locales
- remove direct i18n.changeLanguage call in LanguageSwitcher

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689ddfe5753083208cd133c4f6af4d82