### PR TITLE
Fix layout params type for Next.js 15 deployment

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -18,12 +18,16 @@ const geistMono = Geist_Mono({
 export default async function RootLayout({
   children,
   params,
-}: Readonly<{ children: ReactNode; params: { locale?: string } }>) {
+}: {
+  children: ReactNode;
+  params: Promise<{ locale?: string }>;
+}) {
   const cookieStore = await cookies();
-  const locale = params.locale ?? cookieStore.get("i18nextLng")?.value ?? "en";
+  const { locale } = await params;
+  const resolvedLocale = locale ?? cookieStore.get("i18nextLng")?.value ?? "en";
 
   return (
-    <html lang={locale}>
+    <html lang={resolvedLocale}>
       <head>
         <link rel="icon" href="/favicon.ico" />
       </head>


### PR DESCRIPTION
## Summary
- adjust RootLayout to accept asynchronous `params` and resolve locale

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de6021fdc8320b5994ed3b1d9f7ef