### PR TITLE
feat: redirect to locale-specific root

### DIFF
--- a/frontend/app/__tests__/RootPage.redirect.test.tsx
+++ b/frontend/app/__tests__/RootPage.redirect.test.tsx
@@ -1,0 +1,49 @@
+import { redirect } from 'next/navigation';
+import { cookies as mockCookies, headers as mockHeaders } from 'next/headers';
+
+jest.mock('next/navigation', () => ({ redirect: jest.fn() }));
+jest.mock('next/headers', () => ({ cookies: jest.fn(), headers: jest.fn() }));
+
+const Page = require('@/app/page').default;
+
+describe('RootPage locale redirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses locale from cookie', () => {
+    const get = jest.fn().mockReturnValue({ value: 'ru' });
+    const set = jest.fn();
+    (mockCookies as unknown as jest.Mock).mockReturnValue({ get, set });
+    (mockHeaders as unknown as jest.Mock).mockReturnValue({ get: () => 'en-US' });
+
+    Page();
+
+    expect(redirect).toHaveBeenCalledWith('/ru');
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Accept-Language and sets cookie', () => {
+    const get = jest.fn().mockReturnValue(undefined);
+    const set = jest.fn();
+    (mockCookies as unknown as jest.Mock).mockReturnValue({ get, set });
+    (mockHeaders as unknown as jest.Mock).mockReturnValue({ get: () => 'ru-RU,ru;q=0.9' });
+
+    Page();
+
+    expect(set).toHaveBeenCalledWith('i18nextLng', 'ru');
+    expect(redirect).toHaveBeenCalledWith('/ru');
+  });
+
+  it('defaults to en when nothing matches', () => {
+    const get = jest.fn().mockReturnValue(undefined);
+    const set = jest.fn();
+    (mockCookies as unknown as jest.Mock).mockReturnValue({ get, set });
+    (mockHeaders as unknown as jest.Mock).mockReturnValue({ get: () => 'fr-FR,fr;q=0.9' });
+
+    Page();
+
+    expect(set).toHaveBeenCalledWith('i18nextLng', 'en');
+    expect(redirect).toHaveBeenCalledWith('/en');
+  });
+});

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,27 @@
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+const SUPPORTED_LOCALES = ['en', 'ru'] as const;
+const DEFAULT_LOCALE = 'en';
+const LANGUAGE_COOKIE = 'i18nextLng';
+
+export const dynamic = 'force-dynamic';
+
+export default function RootPage() {
+  const cookieStore = cookies();
+  let locale = cookieStore.get(LANGUAGE_COOKIE)?.value as typeof SUPPORTED_LOCALES[number] | undefined;
+
+  if (!locale || !SUPPORTED_LOCALES.includes(locale)) {
+    const accept = headers().get('accept-language') || '';
+    const headerLocale = accept.split(',')[0]?.split('-')[0];
+    if (headerLocale && SUPPORTED_LOCALES.includes(headerLocale as typeof SUPPORTED_LOCALES[number])) {
+      locale = headerLocale as typeof SUPPORTED_LOCALES[number];
+    } else {
+      locale = DEFAULT_LOCALE;
+    }
+    cookieStore.set(LANGUAGE_COOKIE, locale);
+  }
+
+  redirect(`/${locale}`);
+}
+


### PR DESCRIPTION
## Summary
- redirect / to locale-specific path using cookie or Accept-Language
- store locale in `i18nextLng` cookie
- test root redirect for cookie, header and default cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dedb284cc83208dd9f55ac1171342