### PR TITLE
fix: handle async cookies

### DIFF
--- a/frontend/app/__tests__/RootPage.redirect.test.tsx
+++ b/frontend/app/__tests__/RootPage.redirect.test.tsx
@@ -11,37 +11,37 @@ describe('RootPage locale redirect', () => {
     jest.clearAllMocks();
   });
 
-  it('uses locale from cookie', () => {
+  it('uses locale from cookie', async () => {
     const get = jest.fn().mockReturnValue({ value: 'ru' });
     const set = jest.fn();
-    (mockCookies as unknown as jest.Mock).mockReturnValue({ get, set });
-    (mockHeaders as unknown as jest.Mock).mockReturnValue({ get: () => 'en-US' });
+    (mockCookies as unknown as jest.Mock).mockResolvedValue({ get, set });
+    (mockHeaders as unknown as jest.Mock).mockResolvedValue({ get: () => 'en-US' });
 
-    Page();
+    await Page();
 
     expect(redirect).toHaveBeenCalledWith('/ru');
     expect(set).not.toHaveBeenCalled();
   });
 
-  it('falls back to Accept-Language and sets cookie', () => {
+  it('falls back to Accept-Language and sets cookie', async () => {
     const get = jest.fn().mockReturnValue(undefined);
     const set = jest.fn();
-    (mockCookies as unknown as jest.Mock).mockReturnValue({ get, set });
-    (mockHeaders as unknown as jest.Mock).mockReturnValue({ get: () => 'ru-RU,ru;q=0.9' });
+    (mockCookies as unknown as jest.Mock).mockResolvedValue({ get, set });
+    (mockHeaders as unknown as jest.Mock).mockResolvedValue({ get: () => 'ru-RU,ru;q=0.9' });
 
-    Page();
+    await Page();
 
     expect(set).toHaveBeenCalledWith('i18nextLng', 'ru');
     expect(redirect).toHaveBeenCalledWith('/ru');
   });
 
-  it('defaults to en when nothing matches', () => {
+  it('defaults to en when nothing matches', async () => {
     const get = jest.fn().mockReturnValue(undefined);
     const set = jest.fn();
-    (mockCookies as unknown as jest.Mock).mockReturnValue({ get, set });
-    (mockHeaders as unknown as jest.Mock).mockReturnValue({ get: () => 'fr-FR,fr;q=0.9' });
+    (mockCookies as unknown as jest.Mock).mockResolvedValue({ get, set });
+    (mockHeaders as unknown as jest.Mock).mockResolvedValue({ get: () => 'fr-FR,fr;q=0.9' });
 
-    Page();
+    await Page();
 
     expect(set).toHaveBeenCalledWith('i18nextLng', 'en');
     expect(redirect).toHaveBeenCalledWith('/en');

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,12 +7,15 @@ const LANGUAGE_COOKIE = 'i18nextLng';
 
 export const dynamic = 'force-dynamic';
 
-export default function RootPage() {
-  const cookieStore = cookies();
-  let locale = cookieStore.get(LANGUAGE_COOKIE)?.value as typeof SUPPORTED_LOCALES[number] | undefined;
+export default async function RootPage() {
+  const cookieStore = await cookies();
+  let locale =
+    cookieStore.get(LANGUAGE_COOKIE)?.value as
+      | typeof SUPPORTED_LOCALES[number]
+      | undefined;
 
   if (!locale || !SUPPORTED_LOCALES.includes(locale)) {
-    const accept = headers().get('accept-language') || '';
+    const accept = (await headers()).get('accept-language') || '';
     const headerLocale = accept.split(',')[0]?.split('-')[0];
     if (headerLocale && SUPPORTED_LOCALES.includes(headerLocale as typeof SUPPORTED_LOCALES[number])) {
       locale = headerLocale as typeof SUPPORTED_LOCALES[number];


### PR DESCRIPTION
## Summary
- await `cookies()` and `headers()` in root page for Next.js 15
- update redirect tests for async cookie API

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689def9262b4832099ff317ea57072b7