### PR TITLE
feat: route root requests through locale middleware

### DIFF
--- a/frontend/__tests__/middleware.redirect.test.ts
+++ b/frontend/__tests__/middleware.redirect.test.ts
@@ -1,0 +1,73 @@
+const cookiesMap = new Map<string, { value: string }>();
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    redirect: (url: URL) => ({
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === 'location' ? url.toString() : undefined,
+      },
+      cookies: {
+        set: (name: string, value: string) => {
+          cookiesMap.set(name, { value });
+        },
+        get: (name: string) => cookiesMap.get(name),
+      },
+    }),
+  },
+}));
+
+const { middleware } = require('@/middleware');
+
+function createRequest({
+  cookie,
+  acceptLanguage,
+}: {
+  cookie?: string;
+  acceptLanguage?: string;
+}) {
+  const headers = new Map<string, string>();
+  if (acceptLanguage) headers.set('accept-language', acceptLanguage);
+  return {
+    cookies: {
+      get: (name: string) => {
+        if (!cookie) return undefined;
+        const found = cookie
+          .split(';')
+          .map((c) => c.trim())
+          .find((c) => c.startsWith(`${name}=`));
+        if (!found) return undefined;
+        return { value: found.split('=')[1] } as const;
+      },
+    },
+    headers: {
+      get: (name: string) => headers.get(name),
+    },
+    url: 'https://example.com',
+  } as any;
+}
+
+describe('middleware locale redirect', () => {
+  beforeEach(() => cookiesMap.clear());
+
+  it('uses locale from cookie', () => {
+    const request = createRequest({ cookie: 'i18nextLng=ru' });
+    const response = middleware(request);
+    expect(response.headers.get('location')).toBe('https://example.com/ru');
+    expect(response.cookies.get('i18nextLng')).toBeUndefined();
+  });
+
+  it('falls back to Accept-Language and sets cookie', () => {
+    const request = createRequest({ acceptLanguage: 'ru-RU,ru;q=0.9' });
+    const response = middleware(request);
+    expect(response.headers.get('location')).toBe('https://example.com/ru');
+    expect(response.cookies.get('i18nextLng')?.value).toBe('ru');
+  });
+
+  it('defaults to en when nothing matches', () => {
+    const request = createRequest({ acceptLanguage: 'fr-FR,fr;q=0.9' });
+    const response = middleware(request);
+    expect(response.headers.get('location')).toBe('https://example.com/en');
+    expect(response.cookies.get('i18nextLng')?.value).toBe('en');
+  });
+});

--- a/frontend/app/__tests__/RootPage.redirect.test.tsx
+++ b/frontend/app/__tests__/RootPage.redirect.test.tsx
@@ -1,49 +1,16 @@
 import { redirect } from 'next/navigation';
-import { cookies as mockCookies, headers as mockHeaders } from 'next/headers';
 
 jest.mock('next/navigation', () => ({ redirect: jest.fn() }));
-jest.mock('next/headers', () => ({ cookies: jest.fn(), headers: jest.fn() }));
 
 const Page = require('@/app/page').default;
 
-describe('RootPage locale redirect', () => {
+describe('RootPage redirect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('uses locale from cookie', async () => {
-    const get = jest.fn().mockReturnValue({ value: 'ru' });
-    const set = jest.fn();
-    (mockCookies as unknown as jest.Mock).mockResolvedValue({ get, set });
-    (mockHeaders as unknown as jest.Mock).mockResolvedValue({ get: () => 'en-US' });
-
-    await Page();
-
-    expect(redirect).toHaveBeenCalledWith('/ru');
-    expect(set).not.toHaveBeenCalled();
-  });
-
-  it('falls back to Accept-Language and sets cookie', async () => {
-    const get = jest.fn().mockReturnValue(undefined);
-    const set = jest.fn();
-    (mockCookies as unknown as jest.Mock).mockResolvedValue({ get, set });
-    (mockHeaders as unknown as jest.Mock).mockResolvedValue({ get: () => 'ru-RU,ru;q=0.9' });
-
-    await Page();
-
-    expect(set).toHaveBeenCalledWith('i18nextLng', 'ru');
-    expect(redirect).toHaveBeenCalledWith('/ru');
-  });
-
-  it('defaults to en when nothing matches', async () => {
-    const get = jest.fn().mockReturnValue(undefined);
-    const set = jest.fn();
-    (mockCookies as unknown as jest.Mock).mockResolvedValue({ get, set });
-    (mockHeaders as unknown as jest.Mock).mockResolvedValue({ get: () => 'fr-FR,fr;q=0.9' });
-
-    await Page();
-
-    expect(set).toHaveBeenCalledWith('i18nextLng', 'en');
-    expect(redirect).toHaveBeenCalledWith('/en');
+  it('redirects to locale placeholder', () => {
+    Page();
+    expect(redirect).toHaveBeenCalledWith('/[locale]');
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,30 +1,7 @@
-import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
-
-const SUPPORTED_LOCALES = ['en', 'ru'] as const;
-const DEFAULT_LOCALE = 'en';
-const LANGUAGE_COOKIE = 'i18nextLng';
 
 export const dynamic = 'force-dynamic';
 
-export default async function RootPage() {
-  const cookieStore = await cookies();
-  let locale =
-    cookieStore.get(LANGUAGE_COOKIE)?.value as
-      | typeof SUPPORTED_LOCALES[number]
-      | undefined;
-
-  if (!locale || !SUPPORTED_LOCALES.includes(locale)) {
-    const accept = (await headers()).get('accept-language') || '';
-    const headerLocale = accept.split(',')[0]?.split('-')[0];
-    if (headerLocale && SUPPORTED_LOCALES.includes(headerLocale as typeof SUPPORTED_LOCALES[number])) {
-      locale = headerLocale as typeof SUPPORTED_LOCALES[number];
-    } else {
-      locale = DEFAULT_LOCALE;
-    }
-    cookieStore.set(LANGUAGE_COOKIE, locale);
-  }
-
-  redirect(`/${locale}`);
+export default function RootPage() {
+  redirect('/[locale]');
 }
-

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const SUPPORTED_LOCALES = ['en', 'ru'] as const;
+const DEFAULT_LOCALE = 'en';
+const LANGUAGE_COOKIE = 'i18nextLng';
+
+export function middleware(request: NextRequest) {
+  let locale = request.cookies.get(LANGUAGE_COOKIE)?.value as
+    | (typeof SUPPORTED_LOCALES)[number]
+    | undefined;
+  let shouldSetCookie = false;
+
+  if (!locale || !SUPPORTED_LOCALES.includes(locale)) {
+    const accept = request.headers.get('accept-language') || '';
+    const headerLocale = accept.split(',')[0]?.split('-')[0];
+    if (
+      headerLocale &&
+      SUPPORTED_LOCALES.includes(
+        headerLocale as (typeof SUPPORTED_LOCALES)[number]
+      )
+    ) {
+      locale = headerLocale as (typeof SUPPORTED_LOCALES)[number];
+    } else {
+      locale = DEFAULT_LOCALE;
+    }
+    shouldSetCookie = true;
+  }
+
+  const response = NextResponse.redirect(new URL(`/${locale}`, request.url));
+  if (shouldSetCookie) {
+    response.cookies.set(LANGUAGE_COOKIE, locale);
+  }
+  return response;
+}
+
+export const config = {
+  matcher: '/',
+};


### PR DESCRIPTION
## Summary
- add middleware to resolve locale via cookie or `Accept-Language` and redirect
- simplify root page to fixed `redirect('/[locale]')`
- cover middleware and root page redirect behaviour with tests

## Testing
- `cd frontend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_689df2479a708320a8e71c12bbaeb716