### PR TITLE
Fix language switcher path handling

### DIFF
--- a/frontend/components/LanguageSwitcher.tsx
+++ b/frontend/components/LanguageSwitcher.tsx
@@ -12,7 +12,11 @@ export default function LanguageSwitcher() {
     <select
       aria-label={t('language')}
       value={i18n.language}
-      onChange={(e) => router.replace(`/${e.target.value}${pathname}`)}
+      onChange={(e) => {
+        const segments = pathname.split('/').filter(Boolean);
+        segments[0] = e.target.value;
+        router.replace(`/${segments.join('/')}`);
+      }}
       className="border rounded p-1 bg-background text-foreground"
     >
       <option value="en">{t('english')}</option>


### PR DESCRIPTION
## Summary
- update language switcher to replace first path segment with selected locale, preventing duplicated locales in the URL

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df6f8115883209ef992be7109bde2