### PR TITLE
feat: build locale-aware nav links

### DIFF
--- a/frontend/components/MainNav.tsx
+++ b/frontend/components/MainNav.tsx
@@ -17,18 +17,22 @@ const activeClass = "text-primary font-bold";
 
 export default function MainNav() {
   const pathname = usePathname();
+  const segments = pathname.split("/").filter(Boolean);
+  const lang = segments[0] ?? "en";
+  const buildHref = (path: string) => `/${lang}${path === "/" ? "" : path}`;
+
   return (
     <>
       {links.map((l) => (
         <Link
           key={l.href}
-          href={l.href}
-          className={pathname === l.href ? activeClass : undefined}
+          href={buildHref(l.href)}
+          className={pathname === buildHref(l.href) ? activeClass : undefined}
         >
           {l.label}
         </Link>
       ))}
-      <div className={pathname === "/settings" ? activeClass : undefined}>
+      <div className={pathname === buildHref("/settings") ? activeClass : undefined}>
         <SettingsLink />
       </div>
     </>

--- a/frontend/components/MobileMenu.tsx
+++ b/frontend/components/MobileMenu.tsx
@@ -20,6 +20,9 @@ export default function MobileMenu() {
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
+  const segments = pathname.split("/").filter(Boolean);
+  const lang = segments[0] ?? "en";
+  const buildHref = (path: string) => `/${lang}${path === "/" ? "" : path}`;
 
   const toggle = () => setOpen((prev) => !prev);
   const close = () => setOpen(false);
@@ -85,16 +88,16 @@ export default function MobileMenu() {
         {links.map((l) => (
           <Link
             key={l.href}
-            href={l.href}
+            href={buildHref(l.href)}
             onClick={close}
-            className={pathname === l.href ? activeClass : undefined}
+            className={pathname === buildHref(l.href) ? activeClass : undefined}
           >
             {l.label}
           </Link>
         ))}
         <div
           onClick={close}
-          className={pathname === "/settings" ? activeClass : undefined}
+          className={pathname === buildHref("/settings") ? activeClass : undefined}
         >
           <SettingsLink />
         </div>

--- a/frontend/components/SettingsLink.tsx
+++ b/frontend/components/SettingsLink.tsx
@@ -2,12 +2,17 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import type { Session } from "@supabase/supabase-js";
 
 export default function SettingsLink() {
   const [session, setSession] = useState<Session | null>(null);
   const [isModerator, setIsModerator] = useState(false);
+  const pathname = usePathname();
+  const segments = pathname.split("/").filter(Boolean);
+  const lang = segments[0] ?? "en";
+  const buildHref = (path: string) => `/${lang}${path === "/" ? "" : path}`;
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -35,5 +40,5 @@ export default function SettingsLink() {
 
   if (!isModerator) return null;
 
-  return <Link href="/settings">Settings</Link>;
+  return <Link href={buildHref("/settings")}>Settings</Link>;
 }


### PR DESCRIPTION
## Summary
- build locale-aware helper to prefix navigation links with current language
- update nav components to use locale-aware links

## Testing
- `npm test` (frontend)
- `npm test` (backend)
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689df9fc64c483209d6132a25cdf899d