### PR TITLE
feat: redirect root page based on locale

### DIFF
--- a/frontend/app/__tests__/RootPage.redirect.test.tsx
+++ b/frontend/app/__tests__/RootPage.redirect.test.tsx
@@ -2,6 +2,21 @@ import { redirect } from 'next/navigation';
 
 jest.mock('next/navigation', () => ({ redirect: jest.fn() }));
 
+const cookieGet = jest.fn();
+const cookieSet = jest.fn();
+const headersGet = jest.fn();
+
+jest.mock('next/headers', () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: cookieGet,
+      set: cookieSet,
+    }),
+  headers: () => ({
+    get: headersGet,
+  }),
+}));
+
 const Page = require('@/app/page').default;
 
 describe('RootPage redirect', () => {
@@ -9,8 +24,18 @@ describe('RootPage redirect', () => {
     jest.clearAllMocks();
   });
 
-  it('redirects to locale placeholder', () => {
-    Page();
-    expect(redirect).toHaveBeenCalledWith('/[locale]');
+  it('redirects to locale from cookie', async () => {
+    cookieGet.mockReturnValue({ value: 'ru' });
+    await Page();
+    expect(redirect).toHaveBeenCalledWith('/ru');
+    expect(cookieSet).not.toHaveBeenCalled();
+  });
+
+  it('detects locale from headers and sets cookie', async () => {
+    cookieGet.mockReturnValue(undefined);
+    headersGet.mockReturnValue('ru-RU,ru;q=0.9');
+    await Page();
+    expect(redirect).toHaveBeenCalledWith('/ru');
+    expect(cookieSet).toHaveBeenCalledWith('i18nextLng', 'ru');
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,33 @@
+import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
+
+const SUPPORTED_LOCALES = ['en', 'ru'] as const;
+const DEFAULT_LOCALE = 'en';
+const LANGUAGE_COOKIE = 'i18nextLng';
 
 export const dynamic = 'force-dynamic';
 
-export default function RootPage() {
-  redirect('/[locale]');
+export default async function RootPage() {
+  const cookieStore = await cookies();
+  let locale = cookieStore.get(LANGUAGE_COOKIE)?.value as
+    | (typeof SUPPORTED_LOCALES)[number]
+    | undefined;
+
+  if (!locale || !SUPPORTED_LOCALES.includes(locale)) {
+    const accept = headers().get('accept-language') || '';
+    const headerLocale = accept.split(',')[0]?.split('-')[0];
+    if (
+      headerLocale &&
+      SUPPORTED_LOCALES.includes(
+        headerLocale as (typeof SUPPORTED_LOCALES)[number]
+      )
+    ) {
+      locale = headerLocale as (typeof SUPPORTED_LOCALES)[number];
+    } else {
+      locale = DEFAULT_LOCALE;
+    }
+    cookieStore.set(LANGUAGE_COOKIE, locale);
+  }
+
+  redirect(`/${locale}`);
 }


### PR DESCRIPTION
## Summary
- detect locale on root page using cookies or `Accept-Language`
- redirect visitors to the resolved locale path
- update root page tests to cover cookie & header detection

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689dfd5b83d4832080d61f4fa18dcaf5