### PR TITLE
fix: await async headers in RootPage

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -14,7 +14,8 @@ export default async function RootPage() {
     | undefined;
 
   if (!locale || !SUPPORTED_LOCALES.includes(locale)) {
-    const accept = headers().get('accept-language') || '';
+    const headersList = await headers();
+    const accept = headersList.get('accept-language') || '';
     const headerLocale = accept.split(',')[0]?.split('-')[0];
     if (
       headerLocale &&


### PR DESCRIPTION
## Summary
- await `headers()` before retrieving `accept-language`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint configuration file missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e0101ddb88320b77e63899aad0948