### PR TITLE
refactor: remove english locale

### DIFF
--- a/frontend/i18n.ts
+++ b/frontend/i18n.ts
@@ -1,33 +1,13 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
-import en from './locales/en.json';
 import ru from './locales/ru.json';
 
-const SUPPORTED_LOCALES = ['en', 'ru'] as const;
+const SUPPORTED_LOCALES = ['ru'] as const;
 const LANGUAGE_COOKIE = 'i18nextLng';
 
-function detectLocale(): string {
-  if (typeof window === 'undefined') return 'en';
-
-  const cookieMatch = document.cookie.match(new RegExp(`${LANGUAGE_COOKIE}=([^;]+)`));
-  if (cookieMatch && SUPPORTED_LOCALES.includes(cookieMatch[1] as (typeof SUPPORTED_LOCALES)[number])) {
-    return cookieMatch[1];
-  }
-
-  const pathLocale = window.location.pathname.split('/')[1];
-  if (SUPPORTED_LOCALES.includes(pathLocale as (typeof SUPPORTED_LOCALES)[number])) {
-    return pathLocale;
-  }
-
-  const navLang =
-    (navigator.languages && navigator.languages[0]) || navigator.language || 'en';
-  const lang = navLang.split('-')[0];
-  if (SUPPORTED_LOCALES.includes(lang as (typeof SUPPORTED_LOCALES)[number])) {
-    return lang;
-  }
-
-  return 'en';
+function detectLocale(): (typeof SUPPORTED_LOCALES)[number] {
+  return SUPPORTED_LOCALES[0];
 }
 
 const locale = detectLocale();
@@ -40,11 +20,10 @@ void i18n
   .use(initReactI18next)
   .init({
     resources: {
-      en: { translation: en },
       ru: { translation: ru },
     },
-    lng: locale,
-    fallbackLng: locale,
+    lng: 'ru',
+    fallbackLng: 'ru',
     interpolation: { escapeValue: false },
   });
 


### PR DESCRIPTION
## Summary
- remove English resources and simplify locale detection to always use Russian

## Testing
- `npm test` *(failed: UserPage.test.tsx, SpinResultModal.test.tsx)*
- `npm run lint` *(failed: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689e0a76797c83209ad6ce9ba88f207f