### PR TITLE
Simplify locale handling

### DIFF
--- a/frontend/__tests__/middleware.redirect.test.ts
+++ b/frontend/__tests__/middleware.redirect.test.ts
@@ -1,5 +1,3 @@
-const cookiesMap = new Map<string, { value: string }>();
-
 jest.mock('next/server', () => ({
   NextResponse: {
     redirect: (url: URL) => ({
@@ -7,67 +5,22 @@ jest.mock('next/server', () => ({
         get: (name: string) =>
           name.toLowerCase() === 'location' ? url.toString() : undefined,
       },
-      cookies: {
-        set: (name: string, value: string) => {
-          cookiesMap.set(name, { value });
-        },
-        get: (name: string) => cookiesMap.get(name),
-      },
     }),
   },
 }));
 
 const { middleware } = require('@/middleware');
 
-function createRequest({
-  cookie,
-  acceptLanguage,
-}: {
-  cookie?: string;
-  acceptLanguage?: string;
-}) {
-  const headers = new Map<string, string>();
-  if (acceptLanguage) headers.set('accept-language', acceptLanguage);
+function createRequest() {
   return {
-    cookies: {
-      get: (name: string) => {
-        if (!cookie) return undefined;
-        const found = cookie
-          .split(';')
-          .map((c) => c.trim())
-          .find((c) => c.startsWith(`${name}=`));
-        if (!found) return undefined;
-        return { value: found.split('=')[1] } as const;
-      },
-    },
-    headers: {
-      get: (name: string) => headers.get(name),
-    },
     url: 'https://example.com',
   } as any;
 }
 
 describe('middleware locale redirect', () => {
-  beforeEach(() => cookiesMap.clear());
-
-  it('uses locale from cookie', () => {
-    const request = createRequest({ cookie: 'i18nextLng=ru' });
+  it('always redirects to /ru', () => {
+    const request = createRequest();
     const response = middleware(request);
     expect(response.headers.get('location')).toBe('https://example.com/ru');
-    expect(response.cookies.get('i18nextLng')).toBeUndefined();
-  });
-
-  it('falls back to Accept-Language and sets cookie', () => {
-    const request = createRequest({ acceptLanguage: 'ru-RU,ru;q=0.9' });
-    const response = middleware(request);
-    expect(response.headers.get('location')).toBe('https://example.com/ru');
-    expect(response.cookies.get('i18nextLng')?.value).toBe('ru');
-  });
-
-  it('defaults to en when nothing matches', () => {
-    const request = createRequest({ acceptLanguage: 'fr-FR,fr;q=0.9' });
-    const response = middleware(request);
-    expect(response.headers.get('location')).toBe('https://example.com/en');
-    expect(response.cookies.get('i18nextLng')?.value).toBe('en');
   });
 });

--- a/frontend/app/__tests__/RootPage.redirect.test.tsx
+++ b/frontend/app/__tests__/RootPage.redirect.test.tsx
@@ -2,21 +2,6 @@ import { redirect } from 'next/navigation';
 
 jest.mock('next/navigation', () => ({ redirect: jest.fn() }));
 
-const cookieGet = jest.fn();
-const cookieSet = jest.fn();
-const headersGet = jest.fn();
-
-jest.mock('next/headers', () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: cookieGet,
-      set: cookieSet,
-    }),
-  headers: () => ({
-    get: headersGet,
-  }),
-}));
-
 const Page = require('@/app/page').default;
 
 describe('RootPage redirect', () => {
@@ -24,18 +9,8 @@ describe('RootPage redirect', () => {
     jest.clearAllMocks();
   });
 
-  it('redirects to locale from cookie', async () => {
-    cookieGet.mockReturnValue({ value: 'ru' });
-    await Page();
+  it('always redirects to /ru', () => {
+    Page();
     expect(redirect).toHaveBeenCalledWith('/ru');
-    expect(cookieSet).not.toHaveBeenCalled();
-  });
-
-  it('detects locale from headers and sets cookie', async () => {
-    cookieGet.mockReturnValue(undefined);
-    headersGet.mockReturnValue('ru-RU,ru;q=0.9');
-    await Page();
-    expect(redirect).toHaveBeenCalledWith('/ru');
-    expect(cookieSet).toHaveBeenCalledWith('i18nextLng', 'ru');
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,34 +1,7 @@
-import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
-
-const SUPPORTED_LOCALES = ['en', 'ru'] as const;
-const DEFAULT_LOCALE = 'en';
-const LANGUAGE_COOKIE = 'i18nextLng';
 
 export const dynamic = 'force-dynamic';
 
-export default async function RootPage() {
-  const cookieStore = await cookies();
-  let locale = cookieStore.get(LANGUAGE_COOKIE)?.value as
-    | (typeof SUPPORTED_LOCALES)[number]
-    | undefined;
-
-  if (!locale || !SUPPORTED_LOCALES.includes(locale)) {
-    const headersList = await headers();
-    const accept = headersList.get('accept-language') || '';
-    const headerLocale = accept.split(',')[0]?.split('-')[0];
-    if (
-      headerLocale &&
-      SUPPORTED_LOCALES.includes(
-        headerLocale as (typeof SUPPORTED_LOCALES)[number]
-      )
-    ) {
-      locale = headerLocale as (typeof SUPPORTED_LOCALES)[number];
-    } else {
-      locale = DEFAULT_LOCALE;
-    }
-    cookieStore.set(LANGUAGE_COOKIE, locale);
-  }
-
-  redirect(`/${locale}`);
+export default function RootPage() {
+  redirect('/ru');
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,37 +1,8 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-const SUPPORTED_LOCALES = ['en', 'ru'] as const;
-const DEFAULT_LOCALE = 'en';
-const LANGUAGE_COOKIE = 'i18nextLng';
-
 export function middleware(request: NextRequest) {
-  let locale = request.cookies.get(LANGUAGE_COOKIE)?.value as
-    | (typeof SUPPORTED_LOCALES)[number]
-    | undefined;
-  let shouldSetCookie = false;
-
-  if (!locale || !SUPPORTED_LOCALES.includes(locale)) {
-    const accept = request.headers.get('accept-language') || '';
-    const headerLocale = accept.split(',')[0]?.split('-')[0];
-    if (
-      headerLocale &&
-      SUPPORTED_LOCALES.includes(
-        headerLocale as (typeof SUPPORTED_LOCALES)[number]
-      )
-    ) {
-      locale = headerLocale as (typeof SUPPORTED_LOCALES)[number];
-    } else {
-      locale = DEFAULT_LOCALE;
-    }
-    shouldSetCookie = true;
-  }
-
-  const response = NextResponse.redirect(new URL(`/${locale}`, request.url));
-  if (shouldSetCookie) {
-    response.cookies.set(LANGUAGE_COOKIE, locale);
-  }
-  return response;
+  return NextResponse.redirect(new URL('/ru', request.url));
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- redirect root page directly to `/ru`
- hardcode middleware redirect to `/ru`
- update tests for new locale behavior

## Testing
- `npm test`
- `npm run lint` *(fails: interactive config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689e10a6db108320b02d7d88b8d4992a