### PR TITLE
Remove English locale cases and enforce RU redirect

### DIFF
--- a/frontend/__tests__/middleware.redirect.test.ts
+++ b/frontend/__tests__/middleware.redirect.test.ts
@@ -1,11 +1,20 @@
 jest.mock('next/server', () => ({
   NextResponse: {
-    redirect: (url: URL) => ({
-      headers: {
-        get: (name: string) =>
-          name.toLowerCase() === 'location' ? url.toString() : undefined,
-      },
-    }),
+    redirect: (url: URL) => {
+      const cookies = new Map<string, { value: string }>();
+      return {
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === 'location' ? url.toString() : undefined,
+        },
+        cookies: {
+          get: (name: string) => cookies.get(name),
+          set: (name: string, value: string) => {
+            cookies.set(name, { value });
+          },
+        },
+      };
+    },
   },
 }));
 
@@ -14,13 +23,15 @@ const { middleware } = require('@/middleware');
 function createRequest() {
   return {
     url: 'https://example.com',
+    cookies: { get: () => undefined },
   } as any;
 }
 
 describe('middleware locale redirect', () => {
-  it('always redirects to /ru', () => {
+  it('always redirects to /ru and sets cookie', () => {
     const request = createRequest();
     const response = middleware(request);
     expect(response.headers.get('location')).toBe('https://example.com/ru');
+    expect(response.cookies.get('i18nextLng')?.value).toBe('ru');
   });
 });

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -24,7 +24,7 @@ export default async function RootLayout({
 }) {
   const cookieStore = await cookies();
   const { locale } = await params;
-  const resolvedLocale = locale ?? cookieStore.get("i18nextLng")?.value ?? "en";
+  const resolvedLocale = locale ?? cookieStore.get("i18nextLng")?.value ?? "ru";
 
   return (
     <html lang={resolvedLocale}>

--- a/frontend/components/MainNav.tsx
+++ b/frontend/components/MainNav.tsx
@@ -18,7 +18,7 @@ const activeClass = "text-primary font-bold";
 export default function MainNav() {
   const pathname = usePathname();
   const segments = pathname.split("/").filter(Boolean);
-  const lang = segments[0] ?? "en";
+  const lang = segments[0] ?? "ru";
   const buildHref = (path: string) => `/${lang}${path === "/" ? "" : path}`;
 
   return (

--- a/frontend/components/MobileMenu.tsx
+++ b/frontend/components/MobileMenu.tsx
@@ -21,7 +21,7 @@ export default function MobileMenu() {
   const menuRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
   const segments = pathname.split("/").filter(Boolean);
-  const lang = segments[0] ?? "en";
+  const lang = segments[0] ?? "ru";
   const buildHref = (path: string) => `/${lang}${path === "/" ? "" : path}`;
 
   const toggle = () => setOpen((prev) => !prev);

--- a/frontend/components/SettingsLink.tsx
+++ b/frontend/components/SettingsLink.tsx
@@ -11,7 +11,7 @@ export default function SettingsLink() {
   const [isModerator, setIsModerator] = useState(false);
   const pathname = usePathname();
   const segments = pathname.split("/").filter(Boolean);
-  const lang = segments[0] ?? "en";
+  const lang = segments[0] ?? "ru";
   const buildHref = (path: string) => `/${lang}${path === "/" ? "" : path}`;
 
   useEffect(() => {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -2,7 +2,11 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
-  return NextResponse.redirect(new URL('/ru', request.url));
+  const response = NextResponse.redirect(new URL('/ru', request.url));
+  if (!request.cookies.get('i18nextLng')) {
+    response.cookies.set('i18nextLng', 'ru');
+  }
+  return response;
 }
 
 export const config = {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,8 +2,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   // i18n: {
-  //   locales: ["en", "ru"],
-  //   defaultLocale: "en",
+  //   locales: ["ru"],
+  //   defaultLocale: "ru",
   // },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary
- remove English locale fallbacks from layout and navigation
- redirect middleware sets `i18nextLng=ru` cookie and always redirects to `/ru`
- test redirect cookie behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e13407a408320a57250014d26ba48