### PR TITLE
Localize auth callback messages

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -2,10 +2,12 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { supabase } from "@/lib/supabase";
 
 export default function AuthCallback() {
   const router = useRouter();
+  const { t } = useTranslation();
   const exchanged = useRef(false);
   const loggedError = useRef<string | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
@@ -31,7 +33,7 @@ export default function AuthCallback() {
       }
 
       if (!code) {
-        setAuthError("Missing code parameter");
+        setAuthError(t("missingCode"));
         return;
       }
 
@@ -59,8 +61,8 @@ export default function AuthCallback() {
   }, [authError]);
 
   if (authError) {
-    return <p className="p-4">Login failed: {authError}</p>;
+    return <p className="p-4">{t("loginFailed", { error: authError })}</p>;
   }
 
-  return <p className="p-4">Logging in...</p>;
+  return <p className="p-4">{t("loggingIn")}</p>;
 }

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -23,6 +23,9 @@
   "close": "Закрыть",
   "noGame": "Нет игры",
   "loading": "Загрузка...",
+  "missingCode": "Отсутствует параметр кода",
+  "loginFailed": "Ошибка входа: {{error}}",
+  "loggingIn": "Выполняется вход...",
   "settings": {
     "title": "Настройки",
     "voiceCoefficient": "Коэффициент голоса:",


### PR DESCRIPTION
## Summary
- use i18next on auth callback page
- add Russian translations for auth callback errors and loading state

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e1cb1db588320b3e87bfd4004803d