### PR TITLE
Localize archive and game pages

### DIFF
--- a/frontend/app/archive/page.tsx
+++ b/frontend/app/archive/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import { proxiedImage, cn } from "@/lib/utils";
 import type { Session } from "@supabase/supabase-js";
+import { useTranslation } from "react-i18next";
 
 interface PollInfo {
   id: number;
@@ -21,6 +22,7 @@ export default function ArchivePage() {
   const [polls, setPolls] = useState<PollInfo[]>([]);
   const [session, setSession] = useState<Session | null>(null);
   const [isModerator, setIsModerator] = useState(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!backendUrl) return;
@@ -116,16 +118,16 @@ export default function ArchivePage() {
   }, [session]);
 
   if (!backendUrl) {
-    return <div className="p-4">Backend URL not configured.</div>;
+    return <div className="p-4">{t("backendUrlNotConfigured")}</div>;
   }
 
   return (
     <main className="col-span-12 md:col-span-9 p-4 space-y-4">
-      <h1 className="text-2xl font-semibold">Roulette Archive</h1>
+      <h1 className="text-2xl font-semibold">{t("rouletteArchive")}</h1>
       <ul className="space-y-2">
         <li className="border-2 border-purple-600 p-2 rounded-lg bg-purple-50">
           <Link href="/" className="block text-purple-600 underline font-semibold">
-            Go to active roulette
+            {t("goToActiveRoulette")}
           </Link>
         </li>
         {isModerator && (
@@ -134,7 +136,7 @@ export default function ArchivePage() {
               href="/new-poll"
               className="px-2 py-1 bg-purple-600 text-white rounded inline-block"
             >
-              New Roulette
+              {t("newRoulette")}
             </Link>
           </li>
         )}
@@ -167,7 +169,9 @@ export default function ArchivePage() {
                     p.winnerBackground ? "text-white" : "text-purple-600"
                   )}
                 >
-                  Roulette from {new Date(p.created_at).toLocaleDateString()}
+                  {t("rouletteFrom", {
+                    date: new Date(p.created_at).toLocaleDateString(),
+                  })}
                 </Link>
                 {p.winnerName && p.winnerId && (
                   <Link
@@ -177,7 +181,7 @@ export default function ArchivePage() {
                       p.winnerBackground ? "text-white" : "text-purple-600"
                     )}
                   >
-                    Winner is {p.winnerName}
+                    {t("winnerIs", { name: p.winnerName })}
                   </Link>
                 )}
               </div>

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -55,6 +55,17 @@ export default function GamePage({
   const [loading, setLoading] = useState(true);
   const [playlist, setPlaylist] = useState<PlaylistData | null>(null);
 
+  const statusLabels: Record<string, string> = {
+    active: t("statusActive"),
+    completed: t("statusCompleted"),
+    backlog: t("statusBacklog"),
+  };
+  const methodLabels: Record<string, string> = {
+    donation: t("methodDonation"),
+    roulette: t("methodRoulette"),
+    points: t("methodPoints"),
+  };
+
   useEffect(() => {
     const fetchData = async () => {
       if (!backendUrl) return;
@@ -122,8 +133,14 @@ export default function GamePage({
               <span className="font-mono ml-2">{game.rating}/10</span>
             )}
           </h1>
-          <p>{t("status")}: {game.status}</p>
-          {game.selection_method && <p>{t("selection")}: {game.selection_method}</p>}
+          <p>
+            {t("status")}: {statusLabels[game.status] ?? game.status}
+          </p>
+          {game.selection_method && (
+            <p>
+              {t("selection")}: {methodLabels[game.selection_method] ?? game.selection_method}
+            </p>
+          )}
           {game.released_year && <p>{t("released")}: {game.released_year}</p>}
           {game.genres?.length ? <p>{t("genres")}: {game.genres.join(", ")}</p> : null}
           <p>{t("votes")}: {game.votes}</p>

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -55,6 +55,8 @@
   "gameNotFound": "Игра не найдена.",
   "rouletteFrom": "Рулетка от {{date}}",
   "winnerIs": "Победитель — {{name}}",
+  "rouletteArchive": "Архив рулеток",
+  "goToActiveRoulette": "Перейти к активной рулетке",
   "noGames": "Нет игр.",
   "recentEvents": "Последние события",
   "noEventsFound": "Событий не найдено",


### PR DESCRIPTION
## Summary
- localize roulette archive list and game details using `react-i18next`
- translate status and method values on game page
- add Russian strings for archive navigation

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e35576ae883209d2d52ea0d0825e7