### PR TITLE
feat: localize navigation menus

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -469,7 +469,7 @@ export default function Home() {
               className="px-2 py-1 bg-purple-600 text-white rounded"
               onClick={() => setShowSettings(true)}
           >
-            {t('settings.title')}
+            {t('settingsModal.title')}
           </button>
           {!officialMode ? (
             <button

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -135,7 +135,7 @@ export default function SettingsPage() {
 
   return (
     <main className="col-span-12 md:col-span-9 p-4 space-y-4">
-      <h1 className="text-2xl font-semibold">{t("settingsTitle")}</h1>
+      <h1 className="text-2xl font-semibold">{t("settings")}</h1>
       {rewards.length === 0 ? (
         <p>{t("noRewards")}</p>
       ) : (

--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -124,25 +124,25 @@ export default function StatsPage() {
     return <div className="p-4">{t('backendUrlNotConfigured')}</div>;
   }
 
-  if (loading) return <div className="p-4">{t('stats.loading')}</div>;
+  if (loading) return <div className="p-4">{t('statsPage.loading')}</div>;
   const intimCategories = categorizeBy(intim, getIntimCategory);
   const poceluyCategories = categorizeBy(poceluy, getPoceluyCategory);
 
   return (
     <main className="col-span-12 md:col-span-9 p-4 space-y-6">
-      <h1 className="text-2xl font-semibold">{t('stats.title')}</h1>
+      <h1 className="text-2xl font-semibold">{t('statsPage.title')}</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <section className="space-y-2">
-          <h2 className="text-xl font-semibold mb-2">{t('stats.mostPopularGames')}</h2>
+          <h2 className="text-xl font-semibold mb-2">{t('statsPage.mostPopularGames')}</h2>
           {games.length === 0 ? (
-            <p>{t('stats.noData')}</p>
+            <p>{t('statsPage.noData')}</p>
           ) : (
             <div className="max-h-60 overflow-y-auto">
               <table className="min-w-full border">
                 <thead>
                   <tr className="bg-muted">
-                    <th className="p-2 text-left">{t('stats.game')}</th>
-                    <th className="p-2 text-right">{t('stats.votes')}</th>
+                    <th className="p-2 text-left">{t('statsPage.game')}</th>
+                    <th className="p-2 text-right">{t('statsPage.votes')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -162,16 +162,16 @@ export default function StatsPage() {
           )}
         </section>
         <section className="space-y-2">
-          <h2 className="text-xl font-semibold mb-2">{t('stats.gamesByRoulette')}</h2>
+          <h2 className="text-xl font-semibold mb-2">{t('statsPage.gamesByRoulette')}</h2>
           {roulettes.length === 0 ? (
-            <p>{t('stats.noData')}</p>
+            <p>{t('statsPage.noData')}</p>
           ) : (
             <div className="max-h-60 overflow-y-auto">
               <table className="min-w-full border">
                 <thead>
                   <tr className="bg-muted">
-                    <th className="p-2 text-left">{t('stats.game')}</th>
-                    <th className="p-2 text-right">{t('stats.roulettes')}</th>
+                    <th className="p-2 text-left">{t('statsPage.game')}</th>
+                    <th className="p-2 text-right">{t('statsPage.roulettes')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -191,16 +191,16 @@ export default function StatsPage() {
           )}
         </section>
         <section className="space-y-2">
-          <h2 className="text-xl font-semibold mb-2">{t('stats.topVoters')}</h2>
+          <h2 className="text-xl font-semibold mb-2">{t('statsPage.topVoters')}</h2>
           {voters.length === 0 ? (
-            <p>{t('stats.noData')}</p>
+            <p>{t('statsPage.noData')}</p>
           ) : (
             <div className="max-h-60 overflow-y-auto">
               <table className="min-w-full border">
                 <thead>
                   <tr className="bg-muted">
-                    <th className="p-2 text-left">{t('stats.user')}</th>
-                    <th className="p-2 text-right">{t('stats.votes')}</th>
+                    <th className="p-2 text-left">{t('statsPage.user')}</th>
+                    <th className="p-2 text-right">{t('statsPage.votes')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -237,16 +237,16 @@ export default function StatsPage() {
           )}
         </section>
         <section className="space-y-2">
-          <h2 className="text-xl font-semibold mb-2">{t('stats.topRouletteParticipants')}</h2>
+          <h2 className="text-xl font-semibold mb-2">{t('statsPage.topRouletteParticipants')}</h2>
           {participants.length === 0 ? (
-            <p>{t('stats.noData')}</p>
+            <p>{t('statsPage.noData')}</p>
           ) : (
             <div className="max-h-60 overflow-y-auto">
               <table className="min-w-full border">
                 <thead>
                   <tr className="bg-muted">
-                    <th className="p-2 text-left">{t('stats.user')}</th>
-                    <th className="p-2 text-right">{t('stats.roulettes')}</th>
+                    <th className="p-2 text-left">{t('statsPage.user')}</th>
+                    <th className="p-2 text-right">{t('statsPage.roulettes')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -285,7 +285,7 @@ export default function StatsPage() {
       </div>
       <div className="space-y-6">
         <details>
-          <summary className="cursor-pointer text-xl font-semibold">{t('stats.title')}</summary>
+          <summary className="cursor-pointer text-xl font-semibold">{t('statsPage.title')}</summary>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
             {Object.entries(totals).map(([key, users]) => (
               <StatsTable
@@ -297,12 +297,12 @@ export default function StatsPage() {
           </div>
         </details>
         <details>
-          <summary className="cursor-pointer text-xl font-semibold">{t('stats.intims')}</summary>
+          <summary className="cursor-pointer text-xl font-semibold">{t('statsPage.intims')}</summary>
           <div className="space-y-2 mt-2">
             {Object.entries(intimCategories).map(([category, stats]) => (
               <details key={`intim-${category}`}>
                 <summary className="cursor-pointer font-semibold">
-                  {t('stats.intim')}: {CATEGORY_LABELS[category as Category]}
+                  {t('statsPage.intim')}: {CATEGORY_LABELS[category as Category]}
                 </summary>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
                   {Object.entries(stats).map(([key, users]) => {
@@ -321,12 +321,12 @@ export default function StatsPage() {
           </div>
         </details>
         <details>
-          <summary className="cursor-pointer text-xl font-semibold">{t('stats.kisses')}</summary>
+          <summary className="cursor-pointer text-xl font-semibold">{t('statsPage.kisses')}</summary>
           <div className="space-y-2 mt-2">
             {Object.entries(poceluyCategories).map(([category, stats]) => (
               <details key={`poceluy-${category}`}>
                 <summary className="cursor-pointer font-semibold">
-                  {t('stats.kiss')}: {CATEGORY_LABELS[category as Category]}
+                  {t('statsPage.kiss')}: {CATEGORY_LABELS[category as Category]}
                 </summary>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
                   {Object.entries(stats).map(([key, users]) => {

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -66,8 +66,8 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
     ...TOTAL_LABELS,
     ...INTIM_LABELS,
     ...POCELUY_LABELS,
-    top_voters: t("stats.topVoters"),
-    top_roulette_users: t("stats.topRouletteParticipants"),
+    top_voters: t("statsPage.topVoters"),
+    top_roulette_users: t("statsPage.topRouletteParticipants"),
   };
 
   useEffect(() => {
@@ -233,10 +233,10 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       </h1>
       <div className="border rounded-lg relative overflow-hidden p-4 space-y-1 bg-muted">
         <p>
-          {t("stats.votes")}: {user.votes}
+          {t("statsPage.votes")}: {user.votes}
         </p>
         <p>
-          {t("stats.roulettes")}: {user.roulettes}
+          {t("statsPage.roulettes")}: {user.roulettes}
         </p>
       </div>
       {achievements.length > 0 && (
@@ -264,7 +264,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       )}
       {intimStats.length > 0 && (
         <details>
-          <summary>{t("stats.intims")}</summary>
+          <summary>{t("statsPage.intims")}</summary>
           <ul className="pl-4 list-disc">
             {intimStats.map(([key, value]) => (
               <li key={key}>
@@ -276,7 +276,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       )}
       {poceluyStats.length > 0 && (
         <details>
-          <summary>{t("stats.kisses")}</summary>
+          <summary>{t("statsPage.kisses")}</summary>
           <ul className="pl-4 list-disc">
             {poceluyStats.map(([key, value]) => (
               <li key={key}>
@@ -288,7 +288,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       )}
       {totalStats.length > 0 && (
         <details>
-          <summary>{t("stats.title")}</summary>
+          <summary>{t("statsPage.title")}</summary>
           <ul className="pl-4 list-disc">
             {totalStats.map(([key, value]) => (
               <li key={key}>

--- a/frontend/components/MainNav.tsx
+++ b/frontend/components/MainNav.tsx
@@ -11,12 +11,12 @@ export default function MainNav() {
   const pathname = usePathname();
   const { t } = useTranslation();
   const links = [
-    { href: "/", label: "Home" },
-    { href: "/archive", label: "Archive" },
-    { href: "/games", label: "Games" },
+    { href: "/", label: t("home") },
+    { href: "/archive", label: t("archive") },
+    { href: "/games", label: t("games") },
     { href: "/users", label: t("users") },
-    { href: "/stats", label: "Stats" },
-    { href: "/playlists", label: "Playlists" },
+    { href: "/stats", label: t("stats") },
+    { href: "/playlists", label: t("playlists") },
   ];
 
   return (

--- a/frontend/components/MobileMenu.tsx
+++ b/frontend/components/MobileMenu.tsx
@@ -14,12 +14,12 @@ export default function MobileMenu() {
   const pathname = usePathname();
   const { t } = useTranslation();
   const links = [
-    { href: "/", label: "Home" },
-    { href: "/archive", label: "Archive" },
-    { href: "/games", label: "Games" },
+    { href: "/", label: t("home") },
+    { href: "/archive", label: t("archive") },
+    { href: "/games", label: t("games") },
     { href: "/users", label: t("users") },
-    { href: "/stats", label: "Stats" },
-    { href: "/playlists", label: "Playlists" },
+    { href: "/stats", label: t("stats") },
+    { href: "/playlists", label: t("playlists") },
   ];
 
   const toggle = () => setOpen((prev) => !prev);

--- a/frontend/components/SettingsLink.tsx
+++ b/frontend/components/SettingsLink.tsx
@@ -2,12 +2,14 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { supabase } from "@/lib/supabase";
 import type { Session } from "@supabase/supabase-js";
 
 export default function SettingsLink() {
   const [session, setSession] = useState<Session | null>(null);
   const [isModerator, setIsModerator] = useState(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -35,5 +37,5 @@ export default function SettingsLink() {
 
   if (!isModerator) return null;
 
-  return <Link href="/settings">Settings</Link>;
+  return <Link href="/settings">{t("settings")}</Link>;
 }

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -46,9 +46,9 @@ export default function SettingsModal({
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-background text-foreground p-4 rounded space-y-4 shadow-lg">
-        <h2 className="text-xl font-semibold">{t('settings.title')}</h2>
+        <h2 className="text-xl font-semibold">{t('settingsModal.title')}</h2>
         <div className="flex items-center space-x-2">
-          <label className="text-sm">{t('settings.voiceCoefficient')}</label>
+          <label className="text-sm">{t('settingsModal.voiceCoefficient')}</label>
           <input
             type="number"
             value={value}
@@ -57,7 +57,7 @@ export default function SettingsModal({
           />
         </div>
         <div className="flex items-center space-x-2">
-          <label className="text-sm">{t('settings.zeroVoteWeight')}</label>
+          <label className="text-sm">{t('settingsModal.zeroVoteWeight')}</label>
           <input
             type="number"
             value={zero}
@@ -66,7 +66,7 @@ export default function SettingsModal({
           />
         </div>
         <div className="flex items-center space-x-2">
-          <label className="text-sm">{t('settings.acceptVotes')}</label>
+          <label className="text-sm">{t('settingsModal.acceptVotes')}</label>
           <input
             type="checkbox"
             checked={accept}
@@ -74,7 +74,7 @@ export default function SettingsModal({
           />
         </div>
         <div className="flex items-center space-x-2">
-          <label className="text-sm">{t('settings.allowEdit')}</label>
+          <label className="text-sm">{t('settingsModal.allowEdit')}</label>
           <input
             type="checkbox"
             checked={edit}
@@ -83,10 +83,10 @@ export default function SettingsModal({
         </div>
         <div className="flex justify-end space-x-2">
           <Button variant="secondary" onClick={onClose}>
-            {t('settings.cancel')}
+            {t('settingsModal.cancel')}
           </Button>
           <Button variant="default" onClick={handleSave}>
-            {t('settings.save')}
+            {t('settingsModal.save')}
           </Button>
         </div>
       </div>

--- a/frontend/components/__tests__/UserPage.test.tsx
+++ b/frontend/components/__tests__/UserPage.test.tsx
@@ -74,21 +74,21 @@ describe("UserPage", () => {
       render(<UserPage params={Promise.resolve({ id: "1" })} />);
     });
 
-    expect(await screen.findByText(`${i18n.t('stats.votes')}: 3`)).toBeInTheDocument();
+    expect(await screen.findByText(`${i18n.t('statsPage.votes')}: 3`)).toBeInTheDocument();
     expect(screen.queryByText(i18n.t('userPage.achievements'))).not.toBeInTheDocument();
     expect(screen.queryByText(i18n.t('userPage.medals'))).not.toBeInTheDocument();
 
-    const intimSummary = screen.getByText(i18n.t('stats.intims'));
+    const intimSummary = screen.getByText(i18n.t('statsPage.intims'));
     fireEvent.click(intimSummary);
     expect(intimSummary.closest("details")).toHaveAttribute("open");
     expect(screen.getByText("Интим с 0%: 1")).toBeInTheDocument();
 
-    const poceluySummary = screen.getByText(i18n.t('stats.kisses'));
+    const poceluySummary = screen.getByText(i18n.t('statsPage.kisses'));
     fireEvent.click(poceluySummary);
     expect(poceluySummary.closest("details")).toHaveAttribute("open");
     expect(screen.getByText("Заставил кого-то поцеловаться с 69%: 2")).toBeInTheDocument();
 
-    const totalSummary = screen.getByText(i18n.t('stats.title'));
+    const totalSummary = screen.getByText(i18n.t('statsPage.title'));
     fireEvent.click(totalSummary);
     expect(totalSummary.closest("details")).toHaveAttribute("open");
     expect(screen.getByText("Просмотрено стримов: 1")).toBeInTheDocument();

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -73,7 +73,13 @@
   "twitchInfoFetchFailed": "Не удалось получить информацию из Twitch.",
   "sessionExpired": "Сессия истекла. Обновите страницу, чтобы авторизоваться снова.",
   "refresh": "Обновить",
-  "settingsTitle": "Настройки",
+  "home": "Главная",
+  "archive": "Архив",
+  "games": "Игры",
+  "users": "Пользователи",
+  "stats": "Статистика",
+  "playlists": "Плейлисты",
+  "settings": "Настройки",
   "noRewards": "Награды не найдены.",
   "failedLoadGames": "Не удалось загрузить игры.",
   "searching": "Поиск...",
@@ -94,7 +100,7 @@
   "methodDonation": "Донат",
   "methodRoulette": "Рулетка",
   "methodPoints": "Баллы",
-  "settings": {
+  "settingsModal": {
     "title": "Настройки",
     "voiceCoefficient": "Коэффициент голоса:",
     "zeroVoteWeight": "Вес нулевого голоса:",
@@ -103,7 +109,7 @@
     "cancel": "Отмена",
     "save": "Сохранить"
   },
-  "stats": {
+  "statsPage": {
     "loading": "Загрузка...",
     "title": "Статистика",
     "mostPopularGames": "Самые популярные игры",
@@ -120,7 +126,6 @@
     "kisses": "Поцелуи",
     "kiss": "Поцелуй"
   },
-  "users": "Пользователи",
   "filterRoles": "Фильтр ролей",
   "loggedIn": "входил через сайт",
   "neverLoggedIn": "никогда не входил через сайт",


### PR DESCRIPTION
## Summary
- localize main and mobile navigation menus
- add Russian translations for navigation and refactor stats/settings keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5026a008832088b6cd9b5126acba