### PR TITLE
feat: track watch time and achievements

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -97,6 +97,7 @@ const ACHIEVEMENT_THRESHOLDS = {
   total_times_tagged: [10],
   total_commands_run: [20],
   total_months_subbed: [3],
+  total_watch_time: [60, 120, 240, 600, 1800, 3000],
 };
 
 for (const col of [...INTIM_COLUMNS, ...POCELUY_COLUMNS]) {
@@ -403,6 +404,23 @@ async function checkStreamStatus() {
 
 checkStreamStatus();
 setInterval(checkStreamStatus, 60000);
+
+async function incrementWatchTime() {
+  try {
+    const { data, error } = await supabase
+      .from('stream_chatters')
+      .select('user_id');
+    if (error) throw error;
+    const chatters = data || [];
+    await Promise.all(
+      chatters.map((c) => incrementUserStat(c.user_id, 'total_watch_time'))
+    );
+  } catch (err) {
+    console.error('watch time update failed', err);
+  }
+}
+
+setInterval(incrementWatchTime, 60 * 1000);
 
 let warnedNoBotToken = false;
 async function connectClient() {

--- a/supabase/migrations/20250808180448_add_total_watch_time.sql
+++ b/supabase/migrations/20250808180448_add_total_watch_time.sql
@@ -1,0 +1,11 @@
+alter table users
+  add column if not exists total_watch_time integer default 0;
+
+insert into achievements (stat_key, title, description, threshold) values
+  ('total_watch_time', 'Добросовестный зритель I', 'Просмотр 1 часа трансляций', 60),
+  ('total_watch_time', 'Добросовестный зритель II', 'Просмотр 2 часов трансляций', 120),
+  ('total_watch_time', 'Добросовестный зритель III', 'Просмотр 4 часов трансляций', 240),
+  ('total_watch_time', 'Марафонец I', 'Просмотр 10 часов трансляций', 600),
+  ('total_watch_time', 'Марафонец II', 'Просмотр 30 часов трансляций', 1800),
+  ('total_watch_time', 'Марафонец III', 'Просмотр 50 часов трансляций', 3000)
+on conflict do nothing;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -17,6 +17,7 @@ create table if not exists users (
   total_times_tagged integer default 0,
   total_commands_run integer default 0,
   total_months_subbed integer default 0,
+  total_watch_time integer default 0,
   intim_no_tag_0 integer default 0,
   intim_no_tag_69 integer default 0,
   intim_no_tag_100 integer default 0,
@@ -72,6 +73,7 @@ alter table users
   add column if not exists total_times_tagged integer default 0,
   add column if not exists total_commands_run integer default 0,
   add column if not exists total_months_subbed integer default 0,
+  add column if not exists total_watch_time integer default 0,
   add column if not exists intim_no_tag_0 integer default 0,
   add column if not exists intim_no_tag_69 integer default 0,
   add column if not exists intim_no_tag_100 integer default 0,
@@ -326,6 +328,16 @@ create table if not exists user_medals (
   awarded_at timestamp,
   primary key (user_id, stat_key, medal_type)
 );
+
+
+insert into achievements (stat_key, title, description, threshold) values
+  ('total_watch_time', 'Добросовестный зритель I', 'Просмотр 1 часа трансляций', 60),
+  ('total_watch_time', 'Добросовестный зритель II', 'Просмотр 2 часов трансляций', 120),
+  ('total_watch_time', 'Добросовестный зритель III', 'Просмотр 4 часов трансляций', 240),
+  ('total_watch_time', 'Марафонец I', 'Просмотр 10 часов трансляций', 600),
+  ('total_watch_time', 'Марафонец II', 'Просмотр 30 часов трансляций', 1800),
+  ('total_watch_time', 'Марафонец III', 'Просмотр 50 часов трансляций', 3000)
+on conflict do nothing;
 
 
 alter table users


### PR DESCRIPTION
## Summary
- track user watch time and increment stats periodically
- define watch time achievement thresholds
- migrate schema and seed watch time achievements

## Testing
- `npm test` (bot)
- `npm test` (backend)
- `npm test` (frontend) *(failed: process did not exit, partial output)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b75447c83209ca7f506e7ff9649