### PR TITLE
Track per-stream message counts and chat milestones

### DIFF
--- a/bot/__tests__/achievements.test.js
+++ b/bot/__tests__/achievements.test.js
@@ -4,7 +4,7 @@ test('awards multiple achievements for a single counter', async () => {
 
   const userStats = { total_chat_messages_sent: 0 };
   const userAchievements = new Set();
-  const achievementMap = { 100: 1, 1000: 2 };
+  const achievementMap = { 500: 1, 1000: 2, 2000: 3 };
   const insertMock = jest.fn((obj) => {
     userAchievements.add(obj.achievement_id);
     return Promise.resolve({ error: null });
@@ -121,13 +121,14 @@ test('awards multiple achievements for a single counter', async () => {
   const { incrementUserStat } = require('../bot');
   jest.useRealTimers();
 
-  const first = await incrementUserStat(1, 'total_chat_messages_sent', 100);
-  const second = await incrementUserStat(1, 'total_chat_messages_sent', 900);
+  const first = await incrementUserStat(1, 'total_chat_messages_sent', 500);
+  const second = await incrementUserStat(1, 'total_chat_messages_sent', 1500);
 
   expect(first).toBe(true);
   expect(second).toBe(true);
-  expect(insertMock).toHaveBeenCalledTimes(2);
+  expect(insertMock).toHaveBeenCalledTimes(3);
   expect(insertMock.mock.calls[0][0].achievement_id).toBe(1);
   expect(insertMock.mock.calls[1][0].achievement_id).toBe(2);
+  expect(insertMock.mock.calls[2][0].achievement_id).toBe(3);
 });
 

--- a/supabase/migrations/20250808180449_add_message_count_and_chat_achievements.sql
+++ b/supabase/migrations/20250808180449_add_message_count_and_chat_achievements.sql
@@ -1,0 +1,11 @@
+alter table stream_chatters
+  add column if not exists message_count integer default 0;
+
+insert into achievements (stat_key, title, description, threshold) values
+  ('message_count', 'Болтун I', 'Отправлено 20 сообщений за стрим', 20),
+  ('message_count', 'Болтун II', 'Отправлено 50 сообщений за стрим', 50),
+  ('message_count', 'Болтун III', 'Отправлено 100 сообщений за стрим', 100),
+  ('total_chat_messages_sent', 'Завсегдатая I', 'Отправлено 500 сообщений в чате', 500),
+  ('total_chat_messages_sent', 'Завсегдатая II', 'Отправлено 1000 сообщений в чате', 1000),
+  ('total_chat_messages_sent', 'Завсегдатая III', 'Отправлено 2000 сообщений в чате', 2000)
+on conflict do nothing;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -120,7 +120,8 @@ alter table users
   add column if not exists poceluy_tag_match_success_100 integer default 0;
 
 create table if not exists stream_chatters (
-  user_id integer primary key references users(id)
+  user_id integer primary key references users(id),
+  message_count integer default 0
 );
 
 create table if not exists games (
@@ -337,6 +338,15 @@ insert into achievements (stat_key, title, description, threshold) values
   ('total_watch_time', 'Марафонец I', 'Просмотр 10 часов трансляций', 600),
   ('total_watch_time', 'Марафонец II', 'Просмотр 30 часов трансляций', 1800),
   ('total_watch_time', 'Марафонец III', 'Просмотр 50 часов трансляций', 3000)
+on conflict do nothing;
+
+insert into achievements (stat_key, title, description, threshold) values
+  ('message_count', 'Болтун I', 'Отправлено 20 сообщений за стрим', 20),
+  ('message_count', 'Болтун II', 'Отправлено 50 сообщений за стрим', 50),
+  ('message_count', 'Болтун III', 'Отправлено 100 сообщений за стрим', 100),
+  ('total_chat_messages_sent', 'Завсегдатая I', 'Отправлено 500 сообщений в чате', 500),
+  ('total_chat_messages_sent', 'Завсегдатая II', 'Отправлено 1000 сообщений в чате', 1000),
+  ('total_chat_messages_sent', 'Завсегдатая III', 'Отправлено 2000 сообщений в чате', 2000)
 on conflict do nothing;
 
 


### PR DESCRIPTION
## Summary
- track per-stream chat message counts and award tiered "Болтун" achievements
- add "Завсегдатая" achievements for total chat messages at 500/1000/2000
- expand schema and update tests for new chat-related achievements

## Testing
- `cd bot && npm test`
- `cd backend && npm test`
- `cd frontend && npm test` *(warnings: output truncated but individual suites reported PASS)*

------
https://chatgpt.com/codex/tasks/task_e_689f246e662c8320bed6bb8fc5cd142f