### PR TITLE
feat: seed new achievements

### DIFF
--- a/backend/__tests__/achievements_medals.test.js
+++ b/backend/__tests__/achievements_medals.test.js
@@ -4,13 +4,33 @@ process.env.SUPABASE_URL = 'http://localhost';
 process.env.SUPABASE_KEY = 'test';
 
 const achievementsTable = [
-  { id: 1, stat_key: 'total_streams_watched', title: 'Watcher', description: 'Watch 10 streams', threshold: 10 },
-  { id: 2, stat_key: 'total_subs_gifted', title: 'Gifter', description: 'Gift 5 subs', threshold: 5 },
+  {
+    id: 1,
+    stat_key: 'first_message',
+    title: 'First Blood',
+    description: 'Отправлено первое сообщение в чате',
+    threshold: 1,
+  },
+  {
+    id: 2,
+    stat_key: 'clips_created',
+    title: 'Клипмейкер',
+    description: 'Создан первый клип',
+    threshold: 1,
+  },
+  {
+    id: 3,
+    stat_key: 'combo_commands',
+    title: 'Комбо-режим',
+    description: 'Выполнить !интим и !поцелуй в течение 60 секунд',
+    threshold: 1,
+  },
 ];
 
 const userAchievements = [
   { user_id: 1, achievement_id: 1, earned_at: '2024-01-01T00:00:00Z' },
   { user_id: 1, achievement_id: 2, earned_at: '2024-02-01T00:00:00Z' },
+  { user_id: 1, achievement_id: 3, earned_at: '2024-03-01T00:00:00Z' },
 ];
 
 const votes = [
@@ -27,6 +47,7 @@ const users = [
     total_subs_gifted: 5,
     intim_no_tag_0: 2,
     clips_created: 0,
+    combo_commands: 0,
   },
   {
     id: 2,
@@ -35,6 +56,7 @@ const users = [
     total_subs_gifted: 1,
     intim_no_tag_0: 5,
     clips_created: 0,
+    combo_commands: 0,
   },
   {
     id: 3,
@@ -43,6 +65,7 @@ const users = [
     total_subs_gifted: 3,
     intim_no_tag_0: 10,
     clips_created: 0,
+    combo_commands: 0,
   },
 ];
 
@@ -117,19 +140,27 @@ describe('achievements endpoint', () => {
     expect(res.body.achievements).toEqual([
       {
         id: 1,
-        stat_key: 'total_streams_watched',
-        title: 'Watcher',
-        description: 'Watch 10 streams',
-        threshold: 10,
+        stat_key: 'first_message',
+        title: 'First Blood',
+        description: 'Отправлено первое сообщение в чате',
+        threshold: 1,
         earned_at: '2024-01-01T00:00:00Z',
       },
       {
         id: 2,
-        stat_key: 'total_subs_gifted',
-        title: 'Gifter',
-        description: 'Gift 5 subs',
-        threshold: 5,
+        stat_key: 'clips_created',
+        title: 'Клипмейкер',
+        description: 'Создан первый клип',
+        threshold: 1,
         earned_at: '2024-02-01T00:00:00Z',
+      },
+      {
+        id: 3,
+        stat_key: 'combo_commands',
+        title: 'Комбо-режим',
+        description: 'Выполнить !интим и !поцелуй в течение 60 секунд',
+        threshold: 1,
+        earned_at: '2024-03-01T00:00:00Z',
       },
     ]);
   });

--- a/frontend/components/__tests__/UserPage.test.tsx
+++ b/frontend/components/__tests__/UserPage.test.tsx
@@ -134,10 +134,18 @@ describe("UserPage", () => {
             {
               id: 1,
               title: "First Blood",
-              stat_key: "total_streams_watched",
-              description: "desc",
+              stat_key: "first_message",
+              description: "Отправлено первое сообщение в чате",
               threshold: 1,
               earned_at: "2020-01-01",
+            },
+            {
+              id: 2,
+              title: "Клипмейкер",
+              stat_key: "clips_created",
+              description: "Создан первый клип",
+              threshold: 1,
+              earned_at: "2020-01-02",
             },
           ],
         }),
@@ -160,6 +168,9 @@ describe("UserPage", () => {
     const achievementsDetails = achievementsSummary.closest("details")!;
     expect(
       within(achievementsDetails).getByText("First Blood")
+    ).toBeInTheDocument();
+    expect(
+      within(achievementsDetails).getByText("Клипмейкер")
     ).toBeInTheDocument();
 
     const medalsSummary = screen.getByText(i18n.t('userPage.medals'));

--- a/supabase/migrations/20250808180450_add_first_message_clip_and_combo_achievements.sql
+++ b/supabase/migrations/20250808180450_add_first_message_clip_and_combo_achievements.sql
@@ -1,0 +1,5 @@
+insert into achievements (stat_key, title, description, threshold) values
+  ('first_message', 'First Blood', 'Отправлено первое сообщение в чате', 1),
+  ('clips_created', 'Клипмейкер', 'Создан первый клип', 1),
+  ('combo_commands', 'Комбо-режим', 'Выполнить !интим и !поцелуй в течение 60 секунд', 1)
+on conflict do nothing;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -361,6 +361,11 @@ insert into achievements (stat_key, title, description, threshold) values
   ('combo_commands', 'Комбо-режим', 'Выполнить !интим и !поцелуй в течение 60 секунд', 1)
 on conflict do nothing;
 
+insert into achievements (stat_key, title, description, threshold) values
+  ('first_message', 'First Blood', 'Отправлено первое сообщение в чате', 1)
+on conflict do nothing;
+
+
 
 alter table users
   add column if not exists theme text default 'system';


### PR DESCRIPTION
## Summary
- seed first message, clip creation, and combo achievements
- test API returns new achievements and update user page mocks

## Testing
- `npm test` in backend
- `npx jest components/__tests__/UserPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689f34ca950c8320a7c4d5e17c723f0a