### PR TITLE
Reduce height of sidebar media/event panels

### DIFF
--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -76,7 +76,7 @@ export default function EventLog() {
 
   if (!backendUrl) return null;
 
-  const LIST_HEIGHT = 960;
+  const LIST_HEIGHT = 500;
   if (loading) {
     return (
       <Card variant="shadow" className="space-y-2 relative">

--- a/frontend/components/TwitchClips.tsx
+++ b/frontend/components/TwitchClips.tsx
@@ -96,7 +96,7 @@ export default function TwitchClips() {
     listRef.current.scrollBy({ top: itemHeight, behavior: "smooth" });
   };
 
-  const LIST_HEIGHT = 2400;
+  const LIST_HEIGHT = 500;
 
   return (
     <Card variant="shadow" className="space-y-2 relative">

--- a/frontend/components/TwitchVideos.tsx
+++ b/frontend/components/TwitchVideos.tsx
@@ -50,7 +50,7 @@ export default function TwitchVideos() {
 
   if (!backendUrl) return null;
 
-  const LIST_HEIGHT = 2400;
+  const LIST_HEIGHT = 500;
   if (loading) {
     return (
       <Card variant="shadow" className="space-y-2 relative">


### PR DESCRIPTION
## Summary
- limit EventLog panel height to match roulette wheel
- limit Twitch VODs and Clips panels to same shorter height

## Testing
- `CI=1 npx jest --runInBand --passWithNoTests` *(hangs; no output)*
- `npm run lint` *(interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a191fab9c8832090ea99a382e6587c