### PR TITLE
fix: improve border visibility in dark mode

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -63,7 +63,7 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 240 3.7% 15.9%;
+    --border: 240 5% 30%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
   }


### PR DESCRIPTION
## Summary
- lighten `--border` variable in dark theme for better contrast

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a1961db9dc8320b7f6bc34e44f6280