### PR TITLE
chore: downgrade archive fetch error log

### DIFF
--- a/frontend/app/archive/page.tsx
+++ b/frontend/app/archive/page.tsx
@@ -55,10 +55,11 @@ export default function ArchivePage() {
           try {
             const r = await fetch(`${backendUrl}/api/poll/${p.id}/result`);
             if (r.status === 404) {
+              // Missing poll_results is normal and doesn't indicate an error
               return { ...p } as PollInfo;
             }
             if (!r.ok) {
-              console.error("Failed to fetch poll result", r.statusText);
+              console.warn("Failed to fetch poll result", r.statusText);
               return { ...p } as PollInfo;
             }
             const text = await r.text();


### PR DESCRIPTION
## Summary
- treat missing poll results as normal by downgrading log to warning

## Testing
- `CI=1 npm test`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68a39f90c324832084423f913163e491