### PR TITLE
Fix game list initiator and genre visibility

### DIFF
--- a/frontend/app/games/page.tsx
+++ b/frontend/app/games/page.tsx
@@ -210,12 +210,12 @@ export default function GamesPage() {
         )}
         </div>
         {g.initiators.length > 0 && (
-          <div className="text-sm text-white">
+          <div className="relative z-10 text-sm text-white">
             {t('initiators')} {renderInitiators(g.initiators, true)}
           </div>
         )}
         {g.genres && g.genres.length > 0 && (
-          <div className="text-sm text-white">
+          <div className="relative z-10 text-sm text-white">
             {t('genres')}: {g.genres.join(", ")}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Ensure game initiator and genre info is displayed above background overlays with white text for better visibility

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a44a14b9448320a4c7a5df07dd9b51