### PR TITLE
feat: sort users by auth_id

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1308,7 +1308,9 @@ app.get('/api/users', async (req, res) => {
   if (search) {
     builder = builder.ilike('username', `%${search}%`);
   }
-  builder = builder.order('username', { ascending: true });
+  builder = builder
+    .order('auth_id', { ascending: false, nullsLast: true })
+    .order('username', { ascending: true });
   const { data, error } = await builder;
   if (error) return res.status(500).json({ error: error.message });
   const users = (data || []).map((u) => {


### PR DESCRIPTION
## Summary
- sort user listing by auth_id then username
- test that users with auth_id appear before others

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a44de0ea7c8320aaf62179dd35fa07