### PR TITLE
exclude specific users from medals

### DIFF
--- a/backend/__tests__/achievements_medals.test.js
+++ b/backend/__tests__/achievements_medals.test.js
@@ -37,6 +37,9 @@ const votes = [
   { game_id: 1, user_id: 1, poll_id: 1 },
   { game_id: 1, user_id: 2, poll_id: 1 },
   { game_id: 2, user_id: 1, poll_id: 2 },
+  { game_id: 3, user_id: 4, poll_id: 3 },
+  { game_id: 4, user_id: 4, poll_id: 4 },
+  { game_id: 5, user_id: 4, poll_id: 5 },
 ];
 
 const users = [
@@ -64,6 +67,15 @@ const users = [
     total_streams_watched: 30,
     total_subs_gifted: 3,
     intim_no_tag_0: 10,
+    clips_created: 0,
+    combo_commands: 0,
+  },
+  {
+    id: 4,
+    username: 'terrenkur',
+    total_streams_watched: 100,
+    total_subs_gifted: 10,
+    intim_no_tag_0: 0,
     clips_created: 0,
     combo_commands: 0,
   },
@@ -175,6 +187,15 @@ describe('medals endpoint', () => {
     expect(res.body.medals.intim_no_tag_0).toBe('bronze');
     expect(res.body.medals.top_voters).toBe('gold');
     expect(res.body.medals.top_roulette_users).toBe('gold');
+  });
+
+  it('does not return medals for excluded users', async () => {
+    const res = await request(app).get('/api/medals/4');
+    expect(res.status).toBe(200);
+    expect(res.body.medals.total_streams_watched).toBeNull();
+    expect(res.body.medals.total_subs_gifted).toBeNull();
+    expect(res.body.medals.top_voters).toBeNull();
+    expect(res.body.medals.top_roulette_users).toBeNull();
   });
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -93,6 +93,11 @@ const TOTAL_COLUMNS = [
   'combo_commands',
 ];
 const MEDAL_TYPES = ['gold', 'silver', 'bronze'];
+const EXCLUDED_MEDAL_USERNAMES = new Set([
+  'terrenkur',
+  'hornypaps',
+  'streamelements',
+]);
 
 async function getTopByColumns(columns, limit = 5) {
   const { data, error } = await supabase
@@ -104,7 +109,11 @@ async function getTopByColumns(columns, limit = 5) {
   for (const col of columns) {
     stats[col] = rows
       .map((u) => ({ id: u.id, username: u.username, value: u[col] || 0 }))
-      .filter((u) => u.value > 0)
+      .filter(
+        (u) =>
+          u.value > 0 &&
+          !EXCLUDED_MEDAL_USERNAMES.has((u.username || '').toLowerCase())
+      )
       .sort((a, b) => b.value - a.value)
       .slice(0, limit);
   }
@@ -128,6 +137,9 @@ async function getTopVoters(limit = 5) {
   if (usersErr) throw usersErr;
   return users
     .map((u) => ({ id: u.id, username: u.username, votes: counts[u.id] || 0 }))
+    .filter(
+      (u) => !EXCLUDED_MEDAL_USERNAMES.has((u.username || '').toLowerCase())
+    )
     .sort((a, b) => b.votes - a.votes)
     .slice(0, limit);
 }
@@ -154,6 +166,9 @@ async function getTopRouletteUsers(limit = 5) {
       username: u.username,
       roulettes: userPolls[u.id]?.size || 0,
     }))
+    .filter(
+      (u) => !EXCLUDED_MEDAL_USERNAMES.has((u.username || '').toLowerCase())
+    )
     .sort((a, b) => b.roulettes - a.roulettes)
     .slice(0, limit);
 }


### PR DESCRIPTION
## Summary
- skip medal awards for specific usernames
- cover exclusions with backend tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47736c57483208bae716a47e6ce67