### PR TITLE
Hide combo and clip totals from stats tables

### DIFF
--- a/frontend/app/__tests__/StatsPage.totals.test.tsx
+++ b/frontend/app/__tests__/StatsPage.totals.test.tsx
@@ -19,6 +19,7 @@ describe("StatsPage totals", () => {
         [{ id: i + 1, username: `User${i + 1}`, value: i + 1 }],
       ])
     );
+    const hiddenTotals = ["combo_commands", "clips_created"];
 
     (global as any).fetch = jest.fn((url: string) =>
       Promise.resolve({
@@ -42,13 +43,21 @@ describe("StatsPage totals", () => {
     const totalsDetails = totalsSummary.closest("details")!;
     expect(totalsDetails).not.toHaveAttribute("open");
 
-    const firstKey = Object.keys(TOTAL_LABELS)[0];
+    const visibleKeys = Object.keys(TOTAL_LABELS).filter(
+      (key) => !hiddenTotals.includes(key)
+    );
+    const firstKey = visibleKeys[0];
     const firstLabel = TOTAL_LABELS[firstKey];
 
     fireEvent.click(totalsSummary);
 
-    Object.values(TOTAL_LABELS).forEach((label) => {
-      expect(screen.getByText(label, { selector: "summary" })).toBeInTheDocument();
+    Object.entries(TOTAL_LABELS).forEach(([key, label]) => {
+      const heading = screen.queryByText(label, { selector: "summary" });
+      if (hiddenTotals.includes(key)) {
+        expect(heading).not.toBeInTheDocument();
+      } else {
+        expect(heading).toBeInTheDocument();
+      }
     });
 
     const tableSummary = screen.getByText(firstLabel, { selector: "summary" });
@@ -56,5 +65,12 @@ describe("StatsPage totals", () => {
     const tableDetails = tableSummary.closest("details")!;
     const firstUser = totals[firstKey][0].username;
     expect(within(tableDetails).getByText(firstUser)).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(TOTAL_LABELS["combo_commands"], { selector: "summary" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(TOTAL_LABELS["clips_created"], { selector: "summary" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -127,6 +127,7 @@ export default function StatsPage() {
   if (loading) return <div className="p-4">{t('statsPage.loading')}</div>;
   const intimCategories = categorizeBy(intim, getIntimCategory);
   const poceluyCategories = categorizeBy(poceluy, getPoceluyCategory);
+  const hiddenTotals = ['combo_commands', 'clips_created'];
 
   return (
     <main className="col-span-12 md:col-span-9 p-4 space-y-6">
@@ -287,13 +288,15 @@ export default function StatsPage() {
         <details>
           <summary className="cursor-pointer text-xl font-semibold">{t('statsPage.title')}</summary>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
-            {Object.entries(totals).map(([key, users]) => (
-              <StatsTable
-                key={`total-${key}`}
-                title={TOTAL_LABELS[key] ?? key}
-                rows={Array.isArray(users) ? users : []}
-              />
-            ))}
+            {Object.entries(totals)
+              .filter(([key]) => !hiddenTotals.includes(key))
+              .map(([key, users]) => (
+                <StatsTable
+                  key={`total-${key}`}
+                  title={TOTAL_LABELS[key] ?? key}
+                  rows={Array.isArray(users) ? users : []}
+                />
+              ))}
           </div>
         </details>
         <details>


### PR DESCRIPTION
## Summary
- filter out `combo_commands` and `clips_created` totals before rendering
- adjust totals page test to ignore hidden totals and ensure they aren't displayed

## Testing
- `npm test app/__tests__/StatsPage.totals.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a47e6457fc8320b7649ac361b49140