### PR TITLE
Limit header logo height to maintain compact header

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -89,7 +89,13 @@ export default async function RootLayout({
                   rel="noopener noreferrer"
                   className="flex-1 flex justify-center"
                 >
-                  <Image src="/logo.png" alt="Terrenkur" className="w-full max-w-[calc(100%-2rem)] h-auto" />
+                  <Image
+                    src="/logo.png"
+                    alt="Terrenkur"
+                    className="max-h-12 w-auto"
+                    height={48}
+                    width={160}
+                  />
                 </a>
                 <div className="flex items-center space-x-2 sm:space-x-4 flex-shrink-0">
                   <SocialLink


### PR DESCRIPTION
## Summary
- limit header logo image to 48px max height and auto width
- add explicit dimensions to Next.js Image component

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c3ff241c8320b0c3854627571070