### PR TITLE
feat(frontend): add OBS events overlay

### DIFF
--- a/frontend/app/obs/page.tsx
+++ b/frontend/app/obs/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ObsEventOverlay, { ObsEvent } from '@/components/ObsEventOverlay';
+
+const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+export default function ObsPage() {
+  const [event, setEvent] = useState<ObsEvent | null>(null);
+
+  useEffect(() => {
+    if (!backendUrl) return;
+    const es = new EventSource(`${backendUrl}/api/obs-events`);
+    es.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data) as ObsEvent;
+        setEvent(data);
+      } catch (err) {
+        console.error('Failed to parse event', err);
+      }
+    };
+    return () => es.close();
+  }, []);
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-transparent pointer-events-none">
+      <ObsEventOverlay event={event} onComplete={() => setEvent(null)} />
+    </div>
+  );
+}

--- a/frontend/components/ObsEventOverlay.tsx
+++ b/frontend/components/ObsEventOverlay.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type ObsEvent = {
+  type: 'intim' | 'poceluy';
+  timestamp: number;
+};
+
+const MEDIA: Record<ObsEvent['type'], { gif: string; sound: string; text: string; duration: number }> = {
+  intim: {
+    gif: '/obs/intim.gif',
+    sound: '/obs/intim.mp3',
+    text: 'Интим',
+    duration: 5000,
+  },
+  poceluy: {
+    gif: '/obs/poceluy.gif',
+    sound: '/obs/poceluy.mp3',
+    text: 'Поцелуй',
+    duration: 5000,
+  },
+};
+
+interface Props {
+  event: ObsEvent | null;
+  onComplete?: () => void;
+}
+
+export default function ObsEventOverlay({ event, onComplete }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!event) return;
+    const settings = MEDIA[event.type];
+    if (!settings) return;
+    setVisible(true);
+    const audio = new Audio(settings.sound);
+    audio.play().catch(() => {});
+    const timer = setTimeout(() => {
+      setVisible(false);
+      onComplete?.();
+    }, settings.duration);
+    return () => {
+      clearTimeout(timer);
+      try {
+        audio.pause();
+        audio.currentTime = 0;
+      } catch {
+        // jsdom may not implement pause
+      }
+    };
+  }, [event, onComplete]);
+
+  if (!event) return null;
+  const settings = MEDIA[event.type];
+  if (!settings || !visible) return null;
+  return (
+    <div className="flex flex-col items-center text-center">
+      <img src={settings.gif} alt={settings.text} className="max-w-full max-h-screen" />
+      <p className="mt-2 text-white text-2xl drop-shadow">{settings.text}</p>
+    </div>
+  );
+}
+
+export { MEDIA as OBS_MEDIA_SETTINGS };

--- a/frontend/components/__tests__/ObsEventOverlay.test.tsx
+++ b/frontend/components/__tests__/ObsEventOverlay.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, act } from '@testing-library/react';
+import ObsEventOverlay, { ObsEvent } from '../ObsEventOverlay';
+
+beforeAll(() => {
+  Object.defineProperty(window.HTMLMediaElement.prototype, 'play', {
+    configurable: true,
+    value: jest.fn().mockResolvedValue(undefined),
+  });
+  Object.defineProperty(window.HTMLMediaElement.prototype, 'pause', {
+    configurable: true,
+    value: jest.fn(),
+  });
+});
+
+test('shows and hides media for event', () => {
+  jest.useFakeTimers();
+  const event: ObsEvent = { type: 'intim', timestamp: Date.now() };
+  const onComplete = jest.fn();
+  const { queryByText } = render(
+    <ObsEventOverlay event={event} onComplete={onComplete} />
+  );
+  expect(screen.getByText('Интим')).toBeInTheDocument();
+  act(() => {
+    jest.advanceTimersByTime(5000);
+  });
+  expect(onComplete).toHaveBeenCalled();
+  expect(queryByText('Интим')).toBeNull();
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- add `/obs` page that listens to backend OBS events and shows overlay
- create `ObsEventOverlay` component to display GIF/text and play sounds
- test overlay component behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e21fe5908320ae122fba874922fd