### PR TITLE
Add OBS media endpoints and event log type support

### DIFF
--- a/backend/__tests__/obs_media.test.js
+++ b/backend/__tests__/obs_media.test.js
@@ -1,0 +1,113 @@
+const request = require('supertest');
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_KEY = 'test';
+
+let isModerator = true;
+let obsMediaData;
+let insertedObsMedia;
+let eventLogsEq;
+
+const mockSupabase = {
+  auth: {
+    getUser: jest.fn(() => ({ data: { user: { id: '1', email: 'mod@test' } }, error: null })),
+  },
+  from: jest.fn((table) => {
+    if (table === 'users') {
+      return {
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            maybeSingle: jest.fn(() =>
+              Promise.resolve({ data: { is_moderator: isModerator } })
+            ),
+          })),
+        })),
+      };
+    }
+    if (table === 'obs_media') {
+      return {
+        select: jest.fn(() => {
+          const result = Promise.resolve({ data: obsMediaData, error: null });
+          result.eq = jest.fn(() => Promise.resolve({ data: obsMediaData, error: null }));
+          return result;
+        }),
+        insert: jest.fn((row) => {
+          insertedObsMedia = row;
+          return {
+            select: jest.fn(() => ({
+              single: jest.fn(() =>
+                Promise.resolve({ data: { id: 2, ...row }, error: null })
+              ),
+            })),
+          };
+        }),
+      };
+    }
+    if (table === 'event_logs') {
+      return {
+        select: jest.fn(() => ({
+          order: jest.fn(() => ({
+            eq: jest.fn((col, val) => {
+              eventLogsEq = [col, val];
+              return {
+                limit: jest.fn(() =>
+                  Promise.resolve({ data: [{ id: 1, message: 'm', type: val }], error: null })
+                ),
+              };
+            }),
+          })),
+        })),
+      };
+    }
+    return {};
+  }),
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => mockSupabase),
+}));
+
+const app = require('../server');
+
+describe('OBS media endpoints', () => {
+  beforeEach(() => {
+    isModerator = true;
+    obsMediaData = [
+      { id: 1, type: 'intim', gif_url: 'g', sound_url: 's', text: 't' },
+    ];
+    insertedObsMedia = null;
+    eventLogsEq = null;
+    mockSupabase.from.mockClear();
+  });
+
+  it('GET /api/obs-media returns media', async () => {
+    const res = await request(app)
+      .get('/api/obs-media')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ media: obsMediaData });
+  });
+
+  it('POST /api/obs-media inserts media', async () => {
+    const newItem = { type: 'poceluy', gif_url: 'g2', sound_url: 's2', text: 'hello' };
+    const res = await request(app)
+      .post('/api/obs-media')
+      .set('Authorization', 'Bearer token')
+      .send(newItem);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ media: { id: 2, ...newItem } });
+    expect(insertedObsMedia).toEqual(newItem);
+  });
+});
+
+describe('GET /api/logs', () => {
+  it('filters by type', async () => {
+    const res = await request(app)
+      .get('/api/logs')
+      .query({ limit: 5, type: 'intim' });
+    expect(res.status).toBe(200);
+    expect(eventLogsEq).toEqual(['type', 'intim']);
+    expect(res.body).toEqual({ logs: [{ id: 1, message: 'm', type: 'intim' }] });
+  });
+});
+

--- a/supabase/migrations/20250808180451_create_obs_media_and_add_type_to_event_logs.sql
+++ b/supabase/migrations/20250808180451_create_obs_media_and_add_type_to_event_logs.sql
@@ -1,0 +1,9 @@
+create table if not exists obs_media (
+  id serial primary key,
+  type varchar not null check (type in ('intim','poceluy')),
+  gif_url text,
+  sound_url text,
+  text text
+);
+
+alter table event_logs add column if not exists type varchar;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -226,7 +226,16 @@ create table if not exists event_logs (
   media_url text,
   preview_url text,
   title text,
+  type varchar,
   created_at timestamp default now()
+);
+
+create table if not exists obs_media (
+  id serial primary key,
+  type varchar not null check (type in ('intim','poceluy')),
+  gif_url text,
+  sound_url text,
+  text text
 );
 
 create table if not exists twitch_tokens (


### PR DESCRIPTION
## Summary
- add `obs_media` table and `type` column for `event_logs`
- support filtering logs by type and log events with a type
- add moderator-protected `GET/POST /api/obs-media` endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a55e200f2c8320b04db45ea579e455