### PR TITLE
Add OBS localization strings

### DIFF
--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -108,6 +108,8 @@
   "kissGif": "Гифка поцелуя",
   "kissSound": "Звук поцелуя",
   "kissText": "Текст поцелуя",
+  "obsIntim": "Интим",
+  "obsKiss": "Поцелуй",
   "commaSeparated": "через запятую",
   "statusActive": "Активная",
   "statusCompleted": "Завершено",


### PR DESCRIPTION
## Summary
- add obs overlay messages to Russian locale

## Testing
- `CI=true npx jest components/__tests__/ObsEventOverlay.test.tsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68a5683e3f80832095ea901def5c60d5