### PR TITLE
Log detailed event types for intim and poceluy

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -1040,14 +1040,14 @@ describe('donation logging', () => {
 });
 
 describe('!интим', () => {
-  test('logs event with type intim', async () => {
+  test('logs event with detailed type', async () => {
     const on = jest.fn();
     const say = jest.fn();
     const supabase = createSupabaseIntim();
     loadBotWithOn(supabase, on, say);
     await new Promise(setImmediate);
     const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
-    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    jest.spyOn(Math, 'random').mockReturnValue(0);
     await handler(
       'channel',
       { username: 'author', 'display-name': 'Author' },
@@ -1059,11 +1059,11 @@ describe('!интим', () => {
     const logged = supabase.eventLogsInsert.mock.calls[0][0];
     expect(logged).toEqual(
       expect.objectContaining({
-        message: '50% шанс того, что у @author в кустах будет интим с @target',
+        message: '0% шанс того, что у @author в кустах будет интим с @target',
         media_url: null,
         preview_url: null,
         title: null,
-        type: 'intim',
+        type: 'intim_no_tag_0',
         created_at: expect.any(String),
       })
     );
@@ -1256,14 +1256,14 @@ describe('!интим', () => {
 });
 
 describe('!поцелуй', () => {
-  test('logs event with type poceluy', async () => {
+  test('logs event with detailed type', async () => {
     const on = jest.fn();
     const say = jest.fn();
     const supabase = createSupabasePoceluy();
     loadBotWithOn(supabase, on, say);
     await new Promise(setImmediate);
     const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
-    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    jest.spyOn(Math, 'random').mockReturnValue(0);
     await handler(
       'channel',
       { username: 'author', 'display-name': 'Author' },
@@ -1275,11 +1275,11 @@ describe('!поцелуй', () => {
     const logged = supabase.eventLogsInsert.mock.calls[0][0];
     expect(logged).toEqual(
       expect.objectContaining({
-        message: '50% шанс того, что у @author страстно поцелует с @target',
+        message: '0% шанс того, что у @author страстно поцелует с @target',
         media_url: null,
         preview_url: null,
         title: null,
-        type: 'poceluy',
+        type: 'poceluy_no_tag_0',
         created_at: expect.any(String),
       })
     );

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -909,14 +909,16 @@ client.on('message', async (channel, tags, message, self) => {
         tagArg.replace(/^@/, '').toLowerCase() ===
           partnerUser.username.toLowerCase();
       const columnsBefore = [];
+      let mainColumn = null;
       if (isSelf) {
-        columnsBefore.push(
-          `intim_self_${hasTag ? 'with_tag' : 'no_tag'}`
-        );
+        const col = `intim_self_${hasTag ? 'with_tag' : 'no_tag'}`;
+        columnsBefore.push(col);
+        mainColumn = col;
       }
       if (partnerMatchesTag) {
         columnsBefore.push('intim_tagged_equals_partner');
         columnsBefore.push('intim_tag_match_success');
+        if (!mainColumn) mainColumn = 'intim_tagged_equals_partner';
         if (taggedUser) {
           await incrementUserStat(taggedUser.id, 'intim_tagged_equals_partner');
         }
@@ -933,7 +935,8 @@ client.on('message', async (channel, tags, message, self) => {
         const columns = [];
         const suffix = String(percent);
         const tagType = hasTag ? 'with_tag' : 'no_tag';
-        columns.push(`intim_${tagType}_${suffix}`);
+        const baseCol = `intim_${tagType}_${suffix}`;
+        columns.push(baseCol);
         if (isSelf) {
           columns.push(`intim_self_${tagType}_${suffix}`);
         }
@@ -950,12 +953,13 @@ client.on('message', async (channel, tags, message, self) => {
         await Promise.all(
           columns.map((col) => incrementUserStat(user.id, col))
         );
+        mainColumn = baseCol;
       }
       const text = hasTag
         ? `${percent}% шанс того, что ${authorName} ${variantTwo} ${tagArg} интимиться с ${partnerName} ${variantOne}`
         : `${percent}% шанс того, что у ${authorName} ${variantOne} будет интим с ${partnerName}`;
       client.say(channel, text);
-      await logEvent(text, null, null, null, 'intim');
+      await logEvent(text, null, null, null, mainColumn);
     } catch (err) {
       console.error('intim command failed', err);
     }
@@ -1024,14 +1028,16 @@ client.on('message', async (channel, tags, message, self) => {
         tagArg.replace(/^@/, '').toLowerCase() ===
           partnerUser.username.toLowerCase();
       const columnsBefore = [];
+      let mainColumn = null;
       if (isSelf) {
-        columnsBefore.push(
-          `poceluy_self_${hasTag ? 'with_tag' : 'no_tag'}`
-        );
+        const col = `poceluy_self_${hasTag ? 'with_tag' : 'no_tag'}`;
+        columnsBefore.push(col);
+        mainColumn = col;
       }
       if (partnerMatchesTag) {
         columnsBefore.push('poceluy_tagged_equals_partner');
         columnsBefore.push('poceluy_tag_match_success');
+        if (!mainColumn) mainColumn = 'poceluy_tagged_equals_partner';
         if (taggedUser) {
           await incrementUserStat(taggedUser.id, 'poceluy_tagged_equals_partner');
         }
@@ -1048,7 +1054,8 @@ client.on('message', async (channel, tags, message, self) => {
         const columns = [];
         const suffix = String(percent);
         const tagType = hasTag ? 'with_tag' : 'no_tag';
-        columns.push(`poceluy_${tagType}_${suffix}`);
+        const baseCol = `poceluy_${tagType}_${suffix}`;
+        columns.push(baseCol);
         if (isSelf) {
           columns.push(`poceluy_self_${tagType}_${suffix}`);
         }
@@ -1065,12 +1072,13 @@ client.on('message', async (channel, tags, message, self) => {
         await Promise.all(
           columns.map((col) => incrementUserStat(user.id, col))
         );
+        mainColumn = baseCol;
       }
       const text = hasTag
         ? `${percent}% шанс того, что ${authorName} ${variantTwo} ${tagArg} поцеловать ${partnerName} ${variantThree}`
         : `${percent}% шанс того, что у ${authorName} ${variantThree} поцелует с ${partnerName}`;
       client.say(channel, text);
-      await logEvent(text, null, null, null, 'poceluy');
+      await logEvent(text, null, null, null, mainColumn);
     } catch (err) {
       console.error('poceluy command failed', err);
     }


### PR DESCRIPTION
## Summary
- send specific command variants like `intim_no_tag_0` or `poceluy_no_tag_0` as the event type for logging
- test logging of detailed event types for `!интим` and `!поцелуй`

## Testing
- `cd bot && npm test`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57c12c06883209a25f184a10cad8a