### PR TITLE
Allow dynamic OBS media types

### DIFF
--- a/frontend/components/ObsEventOverlay.tsx
+++ b/frontend/components/ObsEventOverlay.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 
 export type ObsEvent = {
-  type: 'intim' | 'poceluy';
+  type: string;
   timestamp: number;
   text: string;
   gifUrl: string;

--- a/frontend/components/ObsMediaFields.tsx
+++ b/frontend/components/ObsMediaFields.tsx
@@ -9,7 +9,7 @@ interface MediaValues {
 }
 
 interface Props {
-  prefix: "intim" | "kiss";
+  prefix: string;
   values: MediaValues;
   onChange: (vals: MediaValues) => void;
 }

--- a/supabase/migrations/20250808180451_create_obs_media_and_add_type_to_event_logs.sql
+++ b/supabase/migrations/20250808180451_create_obs_media_and_add_type_to_event_logs.sql
@@ -1,9 +1,11 @@
 create table if not exists obs_media (
   id serial primary key,
-  type varchar not null check (type in ('intim','poceluy')),
+  type varchar not null,
   gif_url text,
   sound_url text,
   text text
 );
+
+create index if not exists obs_media_type_idx on obs_media(type);
 
 alter table event_logs add column if not exists type varchar;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -232,11 +232,13 @@ create table if not exists event_logs (
 
 create table if not exists obs_media (
   id serial primary key,
-  type varchar not null check (type in ('intim','poceluy')),
+  type varchar not null,
   gif_url text,
   sound_url text,
   text text
 );
+
+create index if not exists obs_media_type_idx on obs_media(type);
 
 create table if not exists twitch_tokens (
   id serial primary key,


### PR DESCRIPTION
## Summary
- Remove hard-coded obs_media type restriction and index type column
- Validate obs-media endpoints against users columns and support arbitrary types
- Allow settings UI and overlay components to handle dynamic media types

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(interrupted after running suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a5824c54748320adcc904f01f54d99