### PR TITLE
feat: stream OBS events via SSE

### DIFF
--- a/frontend/app/obs/page.tsx
+++ b/frontend/app/obs/page.tsx
@@ -13,7 +13,15 @@ export default function ObsPage() {
     const es = new EventSource(`${backendUrl}/api/obs-events`);
     es.onmessage = (e) => {
       try {
-        const data = JSON.parse(e.data) as ObsEvent;
+        const raw = JSON.parse(e.data);
+        const data: ObsEvent = {
+          type: raw.type,
+          text: raw.text ?? raw.message ?? '',
+          gifUrl: raw.gifUrl ?? raw.gif_url ?? '',
+          soundUrl: raw.soundUrl ?? raw.sound_url ?? '',
+          timestamp: raw.timestamp ?? Date.now(),
+          variant: raw.variant,
+        };
         setEvent(data);
       } catch (err) {
         console.error('Failed to parse event', err);


### PR DESCRIPTION
## Summary
- add server-sent events endpoint for OBS events and broadcast media
- wire client page to new event structure

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a585a959d483208da7645b0056a1e2