### PR TITLE
test: cover ObsEventOverlay audio and timing

### DIFF
--- a/frontend/components/__tests__/ObsEventOverlay.test.tsx
+++ b/frontend/components/__tests__/ObsEventOverlay.test.tsx
@@ -1,37 +1,65 @@
 import { render, screen, act } from '@testing-library/react';
 import ObsEventOverlay, { ObsEvent } from '../ObsEventOverlay';
 
-beforeAll(() => {
-  Object.defineProperty(window.HTMLMediaElement.prototype, 'play', {
-    configurable: true,
-    value: jest.fn().mockResolvedValue(undefined),
-  });
-  Object.defineProperty(window.HTMLMediaElement.prototype, 'pause', {
-    configurable: true,
-    value: jest.fn(),
-  });
+// Mock data representing rows from the obs_media table
+const obsMediaMock = [
+  {
+    type: 'intim',
+    text: 'Интим',
+    gif_url: '/obs/intim.gif',
+    sound_url: '/obs/intim.mp3',
+  },
+  {
+    type: 'poceluy',
+    text: 'Поцелуй',
+    gif_url: '/obs/poceluy.gif',
+    sound_url: '/obs/poceluy.mp3',
+  },
+];
+
+const originalAudio = window.Audio;
+
+afterEach(() => {
+  window.Audio = originalAudio;
+  jest.useRealTimers();
 });
 
-test('shows text and hides overlay when playback completes', () => {
+test.each(obsMediaMock)('renders %s event and hides after timeout', (media) => {
   jest.useFakeTimers();
+
+  const play = jest.fn().mockResolvedValue(undefined);
+  const pause = jest.fn();
+  const audioMock = jest.fn(() => ({ play, pause, currentTime: 0 }));
+  // Mock the Audio constructor so we can verify it is called with the soundUrl
+  // and that playback is initiated.
+  // @ts-ignore
+  window.Audio = audioMock;
+
   const event: ObsEvent = {
-    type: 'intim',
+    type: media.type,
+    text: media.text,
+    gifUrl: media.gif_url,
+    soundUrl: media.sound_url,
     timestamp: Date.now(),
-    text: 'Интим',
-    gifUrl: '/obs/intim.gif',
-    soundUrl: '/obs/intim.mp3',
   };
+
   const onComplete = jest.fn();
   const { queryByText, rerender } = render(
     <ObsEventOverlay event={event} onComplete={onComplete} />
   );
-  expect(screen.getByText('Интим')).toBeInTheDocument();
+
+  expect(screen.getByText(media.text)).toBeInTheDocument();
+  expect(audioMock).toHaveBeenCalledWith(media.sound_url);
+  expect(play).toHaveBeenCalled();
+
   act(() => {
     jest.advanceTimersByTime(5000);
   });
+
   // simulate parent clearing the event on completion
   rerender(<ObsEventOverlay event={null} onComplete={onComplete} />);
+
   expect(onComplete).toHaveBeenCalled();
-  expect(queryByText('Интим')).toBeNull();
-  jest.useRealTimers();
+  expect(queryByText(media.text)).toBeNull();
 });
+


### PR DESCRIPTION
## Summary
- add mock obs_media entries and parameterized tests
- verify audio playback and timer-based hiding for each event type

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a588d5c4448320bbaf0831a90c3f06