### PR TITLE
Rename OBS event text field to message

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -52,7 +52,7 @@ async function broadcastObsEvent(payload) {
       .maybeSingle();
     const event = {
       type,
-      text: row.message || '',
+      message: '',
       gifUrl: media?.gif_url || '',
       soundUrl: media?.sound_url || '',
       timestamp: Date.now(),

--- a/frontend/app/obs/page.tsx
+++ b/frontend/app/obs/page.tsx
@@ -16,7 +16,7 @@ export default function ObsPage() {
         const raw = JSON.parse(e.data);
         const data: ObsEvent = {
           type: raw.type,
-          text: raw.text ?? raw.message ?? '',
+          message: raw.message ?? '',
           gifUrl: raw.gifUrl ?? raw.gif_url ?? '',
           soundUrl: raw.soundUrl ?? raw.sound_url ?? '',
           timestamp: raw.timestamp ?? Date.now(),

--- a/frontend/components/ObsEventOverlay.tsx
+++ b/frontend/components/ObsEventOverlay.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 export type ObsEvent = {
   type: string;
   timestamp: number;
-  text: string;
+  message: string;
   gifUrl: string;
   soundUrl: string;
   variant?: string;
@@ -44,8 +44,8 @@ export default function ObsEventOverlay({ event, onComplete }: Props) {
   if (!event || !visible) return null;
   return (
     <div className="flex flex-col items-center text-center">
-      <img src={event.gifUrl} alt={event.text} className="max-w-full max-h-screen" />
-      <p className="mt-2 text-white text-2xl drop-shadow">{event.text}</p>
+      <img src={event.gifUrl} alt={event.message} className="max-w-full max-h-screen" />
+      <p className="mt-2 text-white text-2xl drop-shadow">{event.message}</p>
     </div>
   );
 }

--- a/frontend/components/__tests__/ObsEventOverlay.test.tsx
+++ b/frontend/components/__tests__/ObsEventOverlay.test.tsx
@@ -37,7 +37,7 @@ test.each(obsMediaMock)('renders %s event and hides after timeout', (media) => {
 
   const event: ObsEvent = {
     type: media.type,
-    text: media.text,
+    message: media.text,
     gifUrl: media.gif_url,
     soundUrl: media.sound_url,
     timestamp: Date.now(),


### PR DESCRIPTION
## Summary
- rename server-side OBS event payload field from `text` to `message`
- handle SSE events in the client using `message` and update overlay
- adjust ObsEvent types and tests for renamed field

## Testing
- `npm test` (backend)
- `npm test` (frontend)
- `npx jest components/__tests__/ObsEventOverlay.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a5935dad088320bc9918d528922515