### PR TITLE
Drop obs_media text field and update handlers

### DIFF
--- a/backend/__tests__/obs_media.test.js
+++ b/backend/__tests__/obs_media.test.js
@@ -94,7 +94,7 @@ describe('OBS media endpoints', () => {
     isModerator = true;
     userColumns = ['intim_no_tag_0', 'poceluy_no_tag_0'];
     obsMediaData = [
-      { id: 1, type: 'intim_no_tag_0', gif_url: 'g', sound_url: 's', text: 't' },
+      { id: 1, type: 'intim_no_tag_0', gif_url: 'g', sound_url: 's' },
     ];
     insertedObsMedia = null;
     eventLogsEq = null;
@@ -110,7 +110,7 @@ describe('OBS media endpoints', () => {
   });
 
   it('POST /api/obs-media inserts media', async () => {
-    const newItem = { type: 'poceluy_no_tag_0', gif_url: 'g2', sound_url: 's2', text: 'hello' };
+    const newItem = { type: 'poceluy_no_tag_0', gif_url: 'g2', sound_url: 's2' };
     const res = await request(app)
       .post('/api/obs-media')
       .set('Authorization', 'Bearer token')
@@ -124,7 +124,7 @@ describe('OBS media endpoints', () => {
     const res = await request(app)
       .post('/api/obs-media')
       .set('Authorization', 'Bearer token')
-      .send({ type: 'invalid', gif_url: 'g', sound_url: 's', text: 't' });
+      .send({ type: 'invalid', gif_url: 'g', sound_url: 's' });
     expect(res.status).toBe(400);
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -2296,7 +2296,7 @@ app.get('/api/playlists', async (_req, res) => {
 
 app.get('/api/obs-media', requireModerator, async (req, res) => {
   const { type } = req.query;
-  let query = supabase.from('obs_media').select('*');
+  let query = supabase.from('obs_media').select('id, type, gif_url, sound_url');
   if (type) {
     if (!(await isValidUserColumn(type))) {
       return res.status(400).json({ error: 'Invalid type' });
@@ -2309,13 +2309,13 @@ app.get('/api/obs-media', requireModerator, async (req, res) => {
 });
 
 app.post('/api/obs-media', requireModerator, async (req, res) => {
-  const { type, gif_url, sound_url, text } = req.body;
+  const { type, gif_url, sound_url } = req.body;
   if (!(await isValidUserColumn(type))) {
     return res.status(400).json({ error: 'Invalid type' });
   }
   const { data, error } = await supabase
     .from('obs_media')
-    .insert({ type, gif_url, sound_url, text })
+    .insert({ type, gif_url, sound_url })
     .select()
     .single();
   if (error) return res.status(500).json({ error: error.message });

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -21,7 +21,7 @@ export default function SettingsPage() {
   const [checkedMod, setCheckedMod] = useState(false);
   const [rewards, setRewards] = useState<Reward[]>([]);
   const [selected, setSelected] = useState<string[]>([]);
-  const [obsMedia, setObsMedia] = useState<Record<string, { gif: string; sound: string; text: string }>>({});
+  const [obsMedia, setObsMedia] = useState<Record<string, { gif: string; sound: string }>>({});
   const [loading, setLoading] = useState(true);
   const [tokenError, setTokenError] = useState(false);
 
@@ -70,12 +70,11 @@ export default function SettingsPage() {
       const mediaResp = await fetch(`${backendUrl}/api/obs-media`);
       if (mediaResp.ok) {
         const { media } = await mediaResp.json();
-        const mapped: Record<string, { gif: string; sound: string; text: string }> = {};
+        const mapped: Record<string, { gif: string; sound: string }> = {};
         for (const m of media || []) {
           mapped[m.type] = {
             gif: m.gif_url || "",
             sound: m.sound_url || "",
-            text: m.text || "",
           };
         }
         setObsMedia(mapped);
@@ -132,22 +131,21 @@ export default function SettingsPage() {
       body: JSON.stringify({ ids: selected }),
     });
     await Promise.all(
-      Object.entries(obsMedia).map(([type, vals]) =>
-        fetch(`${backendUrl}/api/obs-media`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...(token ? { Authorization: `Bearer ${token}` } : {}),
-          },
-          body: JSON.stringify({
-            type,
-            gif_url: vals.gif,
-            sound_url: vals.sound,
-            text: vals.text,
-          }),
-        })
-      )
-    );
+        Object.entries(obsMedia).map(([type, vals]) =>
+          fetch(`${backendUrl}/api/obs-media`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            },
+            body: JSON.stringify({
+              type,
+              gif_url: vals.gif,
+              sound_url: vals.sound,
+            }),
+          })
+        )
+      );
   };
   if (!backendUrl) return <div className="p-4">{t("backendUrlNotConfigured")}</div>;
   if (loading) return <div className="p-4">{t("loading")}</div>;

--- a/frontend/components/ObsMediaFields.tsx
+++ b/frontend/components/ObsMediaFields.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next";
 interface MediaValues {
   gif: string;
   sound: string;
-  text: string;
 }
 
 interface Props {
@@ -34,14 +33,6 @@ export default function ObsMediaFields({ prefix, values, onChange }: Props) {
           className="border p-1 w-full text-foreground"
           value={values.sound}
           onChange={(e) => onChange({ ...values, sound: e.target.value })}
-        />
-      </div>
-      <div>
-        <label className="block">{t(`${prefix}Text`)}</label>
-        <input
-          className="border p-1 w-full text-foreground"
-          value={values.text}
-          onChange={(e) => onChange({ ...values, text: e.target.value })}
         />
       </div>
     </div>

--- a/frontend/components/__tests__/ObsEventOverlay.test.tsx
+++ b/frontend/components/__tests__/ObsEventOverlay.test.tsx
@@ -1,17 +1,17 @@
 import { render, screen, act } from '@testing-library/react';
 import ObsEventOverlay, { ObsEvent } from '../ObsEventOverlay';
 
-// Mock data representing rows from the obs_media table
+// Mock data representing OBS events
 const obsMediaMock = [
   {
     type: 'intim',
-    text: 'Интим',
+    message: 'Интим',
     gif_url: '/obs/intim.gif',
     sound_url: '/obs/intim.mp3',
   },
   {
     type: 'poceluy',
-    text: 'Поцелуй',
+    message: 'Поцелуй',
     gif_url: '/obs/poceluy.gif',
     sound_url: '/obs/poceluy.mp3',
   },
@@ -37,7 +37,7 @@ test.each(obsMediaMock)('renders %s event and hides after timeout', (media) => {
 
   const event: ObsEvent = {
     type: media.type,
-    message: media.text,
+    message: media.message,
     gifUrl: media.gif_url,
     soundUrl: media.sound_url,
     timestamp: Date.now(),
@@ -48,7 +48,7 @@ test.each(obsMediaMock)('renders %s event and hides after timeout', (media) => {
     <ObsEventOverlay event={event} onComplete={onComplete} />
   );
 
-  expect(screen.getByText(media.text)).toBeInTheDocument();
+  expect(screen.getByText(media.message)).toBeInTheDocument();
   expect(audioMock).toHaveBeenCalledWith(media.sound_url);
   expect(play).toHaveBeenCalled();
 
@@ -60,6 +60,6 @@ test.each(obsMediaMock)('renders %s event and hides after timeout', (media) => {
   rerender(<ObsEventOverlay event={null} onComplete={onComplete} />);
 
   expect(onComplete).toHaveBeenCalled();
-  expect(queryByText(media.text)).toBeNull();
+  expect(queryByText(media.message)).toBeNull();
 });
 

--- a/supabase/migrations/20250808180452_drop_text_from_obs_media.sql
+++ b/supabase/migrations/20250808180452_drop_text_from_obs_media.sql
@@ -1,0 +1,1 @@
+alter table obs_media drop column if exists text;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -234,8 +234,7 @@ create table if not exists obs_media (
   id serial primary key,
   type varchar not null,
   gif_url text,
-  sound_url text,
-  text text
+  sound_url text
 );
 
 create index if not exists obs_media_type_idx on obs_media(type);


### PR DESCRIPTION
## Summary
- remove text column from obs_media table and schema
- stop accepting/returning text in backend and frontend
- adjust tests and UI to reflect obs media without text

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5afa4564483208e0d16702ec6299e