### PR TITLE
Use PNG favicon instead of ICO

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -67,7 +67,7 @@ export default async function RootLayout({
   return (
     <html lang={resolvedLocale}>
       <head>
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="/1.png" type="image/png" />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background font-sans antialiased flex flex-col`}


### PR DESCRIPTION
## Summary
- reference new PNG favicon in layout
- remove old favicon.ico

## Testing
- `npm test` *(fails: hangs after 21/22 suites, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a606a486f08320a7a854bc78dd5fbe