### PR TITLE
feat: centralize session expiry handling

### DIFF
--- a/frontend/components/AuthStatus.tsx
+++ b/frontend/components/AuthStatus.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import Image from "next/image";
 import { useTranslation } from "react-i18next";
+import { notifySessionExpired } from "@/lib/sessionExpired";
 
 import type { Session } from "@supabase/supabase-js";
 
@@ -124,9 +125,8 @@ export default function AuthStatus() {
       if (resp.status === 401) {
         const { token: newToken, error } = await refreshProviderToken();
         if (error || !newToken) {
-          await supabase.auth.signOut();
           storeProviderToken(undefined);
-          alert(t('sessionExpired'));
+          await notifySessionExpired(t);
           return null;
         }
         headers.Authorization = `Bearer ${newToken}`;

--- a/frontend/lib/sessionExpired.ts
+++ b/frontend/lib/sessionExpired.ts
@@ -1,0 +1,13 @@
+import { supabase } from './supabase';
+import type { TFunction } from 'i18next';
+
+let alerted = false;
+
+export async function notifySessionExpired(t: TFunction) {
+  if (alerted) return;
+  alerted = true;
+  await supabase.auth.signOut();
+  if (typeof window !== 'undefined') {
+    alert(t('sessionExpired'));
+  }
+}

--- a/frontend/lib/useTwitchUserInfo.ts
+++ b/frontend/lib/useTwitchUserInfo.ts
@@ -8,6 +8,7 @@ import {
   refreshProviderToken,
   storeProviderToken,
 } from "./twitch";
+import { notifySessionExpired } from "./sessionExpired";
 
 export function useTwitchUserInfo(twitchLogin: string | null) {
   const [session, setSession] = useState<Session | null>(null);
@@ -179,11 +180,8 @@ export function useTwitchUserInfo(twitchLogin: string | null) {
             await fetchStreamerInfo();
             return null;
           }
-          await supabase.auth.signOut();
           storeProviderToken(undefined);
-          if (typeof window !== 'undefined') {
-            alert(t('sessionExpired'));
-          }
+          await notifySessionExpired(t);
           return null;
         }
         headers.Authorization = `Bearer ${newToken}`;


### PR DESCRIPTION
## Summary
- add `notifySessionExpired` helper to sign out and alert only once
- use helper in `AuthStatus` and `useTwitchUserInfo` instead of inline logic

## Testing
- `npm test lib/__tests__/useTwitchUserInfo.test.tsx`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a6da68d7dc8320b08890bb7c9a5514