### PR TITLE
Handle game_id in game creation endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1563,8 +1563,15 @@ app.get('/api/rawg_search', async (req, res) => {
 // Add a game to a poll (moderators only)
 app.post('/api/games', requireModerator, async (req, res) => {
 
-  let { poll_id, rawg_id, name, background_image, released_year, genres } =
-    req.body;
+  let {
+    poll_id,
+    rawg_id,
+    name,
+    background_image,
+    released_year,
+    genres,
+    game_id,
+  } = req.body;
   if (!name && !rawg_id) {
     return res
       .status(400)


### PR DESCRIPTION
## Summary
- include `game_id` when parsing POST `/api/games` requests
- use supplied `game_id` to load existing game before updating or adding it to polls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8659d59648320b7bd875ae1cc51ca