### PR TITLE
Fix self partner naming in intimacy and kiss commands

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -1153,7 +1153,7 @@ describe('!интим', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что у @author в кустах будет интим с самим собой'
+      '50% шанс того, что у @author в кустах будет интим с @author'
     );
     Math.random.mockRestore();
   });
@@ -1176,7 +1176,7 @@ describe('!интим', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что @author тайно @target интимиться с самим собой в кустах'
+      '50% шанс того, что @author тайно @target интимиться с @author в кустах'
     );
     Math.random.mockRestore();
   });
@@ -1369,7 +1369,7 @@ describe('!поцелуй', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что у @author страстно поцелует с самим собой'
+      '50% шанс того, что у @author страстно поцелует с @author'
     );
     Math.random.mockRestore();
   });
@@ -1392,7 +1392,7 @@ describe('!поцелуй', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что @author осмелится @target поцеловать самим собой страстно'
+      '50% шанс того, что @author осмелится @target поцеловать @author страстно'
     );
     Math.random.mockRestore();
   });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -978,7 +978,7 @@ client.on('message', async (channel, tags, message, self) => {
       }
       const percentSpecial = [0, 69, 100].includes(percent);
       const authorName = `@${tags.username}`;
-      const partnerName = isSelf ? 'самим собой' : `@${partnerUser.username}`;
+      const partnerName = `@${partnerUser.username}`;
       if (percentSpecial) {
         const columns = [];
         const suffix = String(percent);
@@ -1111,7 +1111,7 @@ client.on('message', async (channel, tags, message, self) => {
       }
       const percentSpecial = [0, 69, 100].includes(percent);
       const authorName = `@${tags.username}`;
-      const partnerName = isSelf ? 'самим собой' : `@${partnerUser.username}`;
+      const partnerName = `@${partnerUser.username}`;
       if (percentSpecial) {
         const columns = [];
         const suffix = String(percent);


### PR DESCRIPTION
## Summary
- Always reference partner username for `!интим` and `!поцелуй` commands
- Update tests to expect `@author` when author is selected as partner

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac8e8cd438832089611d2b1bcf95e3