### PR TITLE
feat: add variant four to kiss command

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -1300,7 +1300,7 @@ describe('!поцелуй', () => {
     const logged = supabase.eventLogsInsert.mock.calls[0][0];
     expect(logged).toEqual(
       expect.objectContaining({
-        message: '0% шанс того, что у @author страстно поцелует с @target',
+        message: '0% шанс того, что у @author страстно поцелует @target',
         media_url: null,
         preview_url: null,
         title: null,
@@ -1323,7 +1323,7 @@ describe('!поцелуй', () => {
     await handler('channel', { username: 'author', 'display-name': 'Author' }, '!поцелуй', false);
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что у @author страстно поцелует с @target'
+      '50% шанс того, что у @author страстно поцелует @target'
     );
     Math.random.mockRestore();
   });
@@ -1346,7 +1346,7 @@ describe('!поцелуй', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что @author осмелится @target поцеловать @partner страстно'
+      '50% шанс того, что @author осмелится @target поцелует @partner страстно'
     );
     Math.random.mockRestore();
   });
@@ -1369,7 +1369,7 @@ describe('!поцелуй', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что у @author страстно поцелует с @author'
+      '50% шанс того, что у @author страстно поцелует @author'
     );
     Math.random.mockRestore();
   });
@@ -1392,7 +1392,7 @@ describe('!поцелуй', () => {
     );
     expect(say).toHaveBeenCalledTimes(1);
     expect(say.mock.calls[0][1]).toBe(
-      '50% шанс того, что @author осмелится @target поцеловать @author страстно'
+      '50% шанс того, что @author осмелится @target поцелует @author страстно'
     );
     Math.random.mockRestore();
   });

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -1062,12 +1062,13 @@ client.on('message', async (channel, tags, message, self) => {
     try {
       const { data: contexts, error: ctxErr } = await supabase
         .from('poceluy_contexts')
-        .select('variant_two, variant_three');
+        .select('variant_two, variant_three, variant_four');
       if (ctxErr || !contexts || contexts.length === 0) throw ctxErr;
       const context =
         contexts[Math.floor(Math.random() * contexts.length)] || {};
       let variantTwo = context.variant_two || '';
       let variantThree = context.variant_three || '';
+      let variantFour = context.variant_four || '';
       const excludeNames = new Set([
         tags.username.toLowerCase(),
         partnerUser.username.toLowerCase(),
@@ -1079,6 +1080,11 @@ client.on('message', async (channel, tags, message, self) => {
       );
       variantThree = await applyRandomPlaceholders(
         variantThree,
+        supabase,
+        excludeNames
+      );
+      variantFour = await applyRandomPlaceholders(
+        variantFour,
         supabase,
         excludeNames
       );
@@ -1137,10 +1143,11 @@ client.on('message', async (channel, tags, message, self) => {
         mainColumn = baseCol;
       }
       const text = hasTag
-        ? `${percent}% шанс того, что ${authorName} ${variantTwo} ${tagArg} поцеловать ${partnerName} ${variantThree}`
-        : `${percent}% шанс того, что у ${authorName} ${variantThree} поцелует с ${partnerName}`;
-      client.say(channel, text);
-      await logEvent(text, null, null, null, mainColumn);
+        ? `${percent}% шанс того, что ${authorName} ${variantTwo} ${tagArg} поцелует ${variantFour} ${partnerName} ${variantThree}`
+        : `${percent}% шанс того, что у ${authorName} ${variantThree} поцелует ${variantFour} ${partnerName}`;
+      const cleanText = text.replace(/\s+/g, ' ').trim();
+      client.say(channel, cleanText);
+      await logEvent(cleanText, null, null, null, mainColumn);
     } catch (err) {
       console.error('poceluy command failed', err);
     }


### PR DESCRIPTION
## Summary
- allow kiss command contexts to include `variant_four`
- incorporate `variant_four` in randomized output and clean up spacing
- update tests for new phrasing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9658d4408320bcf33690a2258106