### PR TITLE
feat: add timeout handling for twitch requests

### DIFF
--- a/frontend/lib/__tests__/useTwitchUserInfo.test.tsx
+++ b/frontend/lib/__tests__/useTwitchUserInfo.test.tsx
@@ -108,7 +108,11 @@ describe('useTwitchUserInfo fallback', () => {
     await waitFor(() =>
       expect(screen.getByTestId('profile').textContent).toBe('avatar.jpg')
     );
-    expect((global as any).fetch).toHaveBeenNthCalledWith(3, 'http://backend/refresh-token');
+    expect((global as any).fetch).toHaveBeenNthCalledWith(
+      3,
+      'http://backend/refresh-token',
+      expect.any(Object)
+    );
   });
 
   test('falls back when token user_id does not match channel', async () => {
@@ -159,7 +163,8 @@ describe('useTwitchUserInfo fallback', () => {
       expect(screen.getByTestId('profile').textContent).toBe('avatar.jpg')
     );
     expect((global as any).fetch).toHaveBeenCalledWith(
-      'http://backend/api/streamer-token'
+      'http://backend/api/streamer-token',
+      expect.any(Object)
     );
   });
 });


### PR DESCRIPTION
## Summary
- add abortable fetch helper for Twitch requests
- parallelize streamer token and validation lookups
- handle Twitch role queries with timeouts and parallel calls

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ace86fc5d08320a363e2e657cb418d