### PR TITLE
docs: clarify bot token setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,11 @@ roulette via chat commands:
    ```bash
    cp bot/.env.example bot/.env
    ```
-   The bot can also log channel point rewards, new followers and subs.
-   To enable these features set the following variables in `bot/.env`:
+   Generate a Twitch Chat OAuth token for your bot account at
+   [twitchapps.com/tmi](https://twitchapps.com/tmi/) (it starts with `oauth:`) and
+   set it as `TWITCH_OAUTH_TOKEN` in `bot/.env`. The bot can also log channel
+   point rewards, new followers and subs. To enable these features set the
+   following variables in `bot/.env`:
 
    ```
    TWITCH_CLIENT_ID=your-client-id
@@ -230,12 +233,13 @@ roulette via chat commands:
    MUSIC_REWARD_ID=545cc880-f6c1-4302-8731-29075a8a1f17
    ```
 
-   The bot stores its current access token in the `bot_tokens` table. The backend
-   exposes `/refresh-token/bot` which refreshes this token using
+   By default the bot reads its chat token from the `bot_tokens` table. The
+   backend exposes `/refresh-token/bot` which refreshes this stored token using
    `BOT_REFRESH_TOKEN`, `TWITCH_CLIENT_ID` and `TWITCH_SECRET`. If you prefer not
-   to manage the token in the database, provide it via the `BOT_TOKEN`
-   environment variable or Fly secret. Schedule a cron job to call it
-   periodically, for example:
+   to manage the token in the database, provide a token via the
+   `TWITCH_OAUTH_TOKEN` environment variable or Fly secret instead. In either
+   case, schedule a cron job to call the refresh endpoint periodically, for
+   example:
 
    ```bash
    curl https://<your-backend>/refresh-token/bot
@@ -260,9 +264,9 @@ The repository includes a `Dockerfile` and `fly.toml` for deploying the bot on
    fly launch --no-deploy
    ```
 2. Configure the required secrets for your environment. Either ensure the bot
-   token exists in the `bot_tokens` table or supply one via `BOT_TOKEN`:
+   token exists in the `bot_tokens` table or supply one via `TWITCH_OAUTH_TOKEN`:
    ```bash
-   fly secrets set SUPABASE_URL=... SUPABASE_KEY=... BOT_USERNAME=... TWITCH_CHANNEL=... BOT_TOKEN=...
+   fly secrets set SUPABASE_URL=... SUPABASE_KEY=... BOT_USERNAME=... TWITCH_CHANNEL=... TWITCH_OAUTH_TOKEN=...
    ```
 3. Deploy the bot:
    ```bash


### PR DESCRIPTION
## Summary
- document using TWITCH_OAUTH_TOKEN for the Twitch chat bot
- explain database vs env token handling and update Fly.io secrets example

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test` *(fails: JS heap out of memory)*
- `cd ../bot && TWITCH_OAUTH_TOKEN=token npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea951f5883209279b85fea4673be