### PR TITLE
test: set TWITCH_OAUTH_TOKEN for bot tests

### DIFF
--- a/bot/__tests__/achievements.test.js
+++ b/bot/__tests__/achievements.test.js
@@ -117,6 +117,7 @@ test('awards multiple achievements for a single counter', async () => {
   process.env.TWITCH_SECRET = 'secret';
   process.env.TWITCH_CHANNEL_ID = '123';
   process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
+  process.env.TWITCH_OAUTH_TOKEN = 'token';
 
   const { incrementUserStat } = require('../bot');
   jest.useRealTimers();

--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -52,7 +52,7 @@ const loadBot = (mockSupabase) => {
   process.env.SUPABASE_URL = 'http://localhost';
   process.env.SUPABASE_KEY = 'key';
   process.env.BOT_USERNAME = 'bot';
-  process.env.BOT_REFRESH_TOKEN = 'refresh';
+  process.env.TWITCH_OAUTH_TOKEN = 'token';
   process.env.TWITCH_CHANNEL = 'channel';
   process.env.TWITCH_CLIENT_ID = 'cid';
   process.env.TWITCH_CHANNEL_ID = '123';
@@ -117,7 +117,7 @@ const loadBotWithOn = (mockSupabase, onMock, sayMock = jest.fn()) => {
   process.env.SUPABASE_URL = 'http://localhost';
   process.env.SUPABASE_KEY = 'key';
   process.env.BOT_USERNAME = 'bot';
-  process.env.BOT_REFRESH_TOKEN = 'refresh';
+  process.env.TWITCH_OAUTH_TOKEN = 'token';
   process.env.TWITCH_CHANNEL = 'channel';
   process.env.TWITCH_CLIENT_ID = 'cid';
   process.env.TWITCH_CHANNEL_ID = '123';

--- a/bot/__tests__/subsync.test.js
+++ b/bot/__tests__/subsync.test.js
@@ -15,7 +15,7 @@ const loadBot = (supabase, fetchImpl) => {
   process.env.SUPABASE_URL = 'http://localhost';
   process.env.SUPABASE_KEY = 'key';
   process.env.BOT_USERNAME = 'bot';
-  process.env.BOT_TOKEN = 'token';
+  process.env.TWITCH_OAUTH_TOKEN = 'token';
   process.env.TWITCH_CHANNEL = 'channel';
   process.env.TWITCH_CLIENT_ID = 'cid';
   process.env.TWITCH_CHANNEL_ID = 'chan1';


### PR DESCRIPTION
## Summary
- add TWITCH_OAUTH_TOKEN to bot test setups
- remove legacy BOT_TOKEN/BOT_REFRESH_TOKEN env vars

## Testing
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_68b237b6eca0832092aa05b4b38d8230