### PR TITLE
feat(bot): load chat token from Supabase with env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,13 @@ roulette via chat commands:
    ```bash
    cp bot/.env.example bot/.env
    ```
-   Generate a Twitch Chat OAuth token for your bot account at
-   [twitchapps.com/tmi](https://twitchapps.com/tmi/) (it starts with `oauth:`) and
-   set it as `TWITCH_OAUTH_TOKEN` in `bot/.env`. The bot can also log channel
-   point rewards, new followers and subs. To enable these features set the
-   following variables in `bot/.env`:
+   If a chat token already exists in the `bot_tokens` table, the bot will use it
+   and the `TWITCH_OAUTH_TOKEN` variable can be omitted. Otherwise generate a
+   Twitch Chat OAuth token for your bot account at
+   [twitchapps.com/tmi](https://twitchapps.com/tmi/) (it starts with `oauth:`)
+   and set it as `TWITCH_OAUTH_TOKEN` in `bot/.env` to seed the table on the
+   first run. The bot can also log channel point rewards, new followers and
+   subs. To enable these features set the following variables in `bot/.env`:
 
    ```
    TWITCH_CLIENT_ID=your-client-id
@@ -233,13 +235,12 @@ roulette via chat commands:
    MUSIC_REWARD_ID=545cc880-f6c1-4302-8731-29075a8a1f17
    ```
 
-   By default the bot reads its chat token from the `bot_tokens` table. The
-   backend exposes `/refresh-token/bot` which refreshes this stored token using
-   `BOT_REFRESH_TOKEN`, `TWITCH_CLIENT_ID` and `TWITCH_SECRET`. If you prefer not
-   to manage the token in the database, provide a token via the
-   `TWITCH_OAUTH_TOKEN` environment variable or Fly secret instead. In either
-   case, schedule a cron job to call the refresh endpoint periodically, for
-   example:
+   By default the bot reads its chat token from the `bot_tokens` table. If no
+   token is found there it falls back to `TWITCH_OAUTH_TOKEN` (when provided) and
+   stores it in the table. The backend exposes `/refresh-token/bot` which
+   refreshes this stored token using `BOT_REFRESH_TOKEN`, `TWITCH_CLIENT_ID` and
+   `TWITCH_SECRET`. In either case, schedule a cron job to call the refresh
+   endpoint periodically, for example:
 
    ```bash
    curl https://<your-backend>/refresh-token/bot
@@ -264,7 +265,8 @@ The repository includes a `Dockerfile` and `fly.toml` for deploying the bot on
    fly launch --no-deploy
    ```
 2. Configure the required secrets for your environment. Either ensure the bot
-   token exists in the `bot_tokens` table or supply one via `TWITCH_OAUTH_TOKEN`:
+   token exists in the `bot_tokens` table or supply one via `TWITCH_OAUTH_TOKEN`
+   (it will be saved to the table on first run):
    ```bash
    fly secrets set SUPABASE_URL=... SUPABASE_KEY=... BOT_USERNAME=... TWITCH_CHANNEL=... TWITCH_OAUTH_TOKEN=...
    ```

--- a/bot/__tests__/achievements.test.js
+++ b/bot/__tests__/achievements.test.js
@@ -99,6 +99,25 @@ test('awards multiple achievements for a single counter', async () => {
           })),
         };
       }
+      if (table === 'bot_tokens') {
+        return {
+          select: jest.fn(() => ({
+            maybeSingle: jest.fn(() =>
+              Promise.resolve({
+                data: {
+                  id: 1,
+                  access_token: 'token',
+                  refresh_token: 'refresh',
+                  expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+                },
+                error: null,
+              })
+            ),
+          })),
+          update: jest.fn(() => Promise.resolve({ error: null })),
+          insert: jest.fn(() => Promise.resolve({ error: null })),
+        };
+      }
       return {
         select: jest.fn(() => Promise.resolve({ data: null, error: null })),
       };
@@ -117,7 +136,7 @@ test('awards multiple achievements for a single counter', async () => {
   process.env.TWITCH_SECRET = 'secret';
   process.env.TWITCH_CHANNEL_ID = '123';
   process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
-  process.env.TWITCH_OAUTH_TOKEN = 'token';
+  delete process.env.TWITCH_OAUTH_TOKEN;
 
   const { incrementUserStat } = require('../bot');
   jest.useRealTimers();

--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -52,11 +52,11 @@ const loadBot = (mockSupabase) => {
   process.env.SUPABASE_URL = 'http://localhost';
   process.env.SUPABASE_KEY = 'key';
   process.env.BOT_USERNAME = 'bot';
-  process.env.TWITCH_OAUTH_TOKEN = 'token';
   process.env.TWITCH_CHANNEL = 'channel';
   process.env.TWITCH_CLIENT_ID = 'cid';
   process.env.TWITCH_CHANNEL_ID = '123';
   process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
+  delete process.env.TWITCH_OAUTH_TOKEN;
   const bot = require('../bot');
   jest.useRealTimers();
   return bot;
@@ -117,12 +117,12 @@ const loadBotWithOn = (mockSupabase, onMock, sayMock = jest.fn()) => {
   process.env.SUPABASE_URL = 'http://localhost';
   process.env.SUPABASE_KEY = 'key';
   process.env.BOT_USERNAME = 'bot';
-  process.env.TWITCH_OAUTH_TOKEN = 'token';
   process.env.TWITCH_CHANNEL = 'channel';
   process.env.TWITCH_CLIENT_ID = 'cid';
   process.env.TWITCH_CHANNEL_ID = '123';
   process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
   delete process.env.LOG_REWARD_IDS;
+  delete process.env.TWITCH_OAUTH_TOKEN;
   const bot = require('../bot');
   jest.useRealTimers();
   return bot;

--- a/bot/__tests__/subsync.test.js
+++ b/bot/__tests__/subsync.test.js
@@ -15,12 +15,12 @@ const loadBot = (supabase, fetchImpl) => {
   process.env.SUPABASE_URL = 'http://localhost';
   process.env.SUPABASE_KEY = 'key';
   process.env.BOT_USERNAME = 'bot';
-  process.env.TWITCH_OAUTH_TOKEN = 'token';
   process.env.TWITCH_CHANNEL = 'channel';
   process.env.TWITCH_CLIENT_ID = 'cid';
   process.env.TWITCH_CHANNEL_ID = 'chan1';
   process.env.TWITCH_SECRET = 'secret';
   process.env.MUSIC_REWARD_ID = 'id';
+  delete process.env.TWITCH_OAUTH_TOKEN;
   const bot = require('../bot');
   jest.useRealTimers();
   return bot;
@@ -66,6 +66,25 @@ function createSupabase(existingUser) {
     }
     if (table === 'log_rewards') {
       return { select: jest.fn(() => Promise.resolve({ data: [], error: null })) };
+    }
+    if (table === 'bot_tokens') {
+      return {
+        select: jest.fn(() => ({
+          maybeSingle: jest.fn(() =>
+            Promise.resolve({
+              data: {
+                id: 1,
+                access_token: 'token',
+                refresh_token: 'refresh',
+                expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+              },
+              error: null,
+            })
+          ),
+        })),
+        update: jest.fn(() => Promise.resolve({ error: null })),
+        insert: jest.fn(() => Promise.resolve({ error: null })),
+      };
     }
     return { select: jest.fn(() => Promise.resolve({ data: [], error: null })) };
   });


### PR DESCRIPTION
## Summary
- remove mandatory TWITCH_OAUTH_TOKEN check and bootstrap tmi client without a password
- load bot token from Supabase, falling back to TWITCH_OAUTH_TOKEN if missing and store it
- document optional TWITCH_OAUTH_TOKEN and update tests to mock bot_tokens

## Testing
- `npm test` (bot)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68b42984ec7c8320860e297f6d2d476b