### PR TITLE
feat(bot): add instructions for game voting command

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -666,6 +666,22 @@ describe('addVote', () => {
   });
 });
 
+describe('message handler no args', () => {
+  test('shows instructions when no game specified', async () => {
+    const on = jest.fn();
+    const say = jest.fn();
+    const supabase = createSupabaseMessage([]);
+    loadBotWithOn(supabase, on, say);
+    await new Promise(setImmediate);
+    const messageHandler = on.mock.calls.find((c) => c[0] === 'message')[1];
+    await messageHandler('channel', { username: 'user' }, '!game', false);
+    expect(say).toHaveBeenCalledWith(
+      'channel',
+      'Вы можете проголосовать за игру из списка командой !игра [Название игры]. Получить список игр - !игра список'
+    );
+  });
+});
+
 describe('message handler vote results', () => {
   test('notifies when vote limit reached', async () => {
     const on = jest.fn();

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -1250,7 +1250,10 @@ client.on('message', async (channel, tags, message, self) => {
   const { args } = parsed;
   const [firstArg, ...restArgs] = args;
   if (!firstArg) {
-    client.say(channel, `@${tags.username}, укажите название игры.`);
+    client.say(
+      channel,
+      'Вы можете проголосовать за игру из списка командой !игра [Название игры]. Получить список игр - !игра список'
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary
- show usage instructions when `!игра` command lacks arguments
- cover empty-argument `!game` path with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b43d1f25748320b40c523c1d1f8f14