### PR TITLE
Refresh bot token before reconnect

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -8,6 +8,8 @@ TWITCH_OAUTH_TOKEN=
 TWITCH_CLIENT_ID=
 TWITCH_SECRET=
 TWITCH_CHANNEL_ID=
+# Base URL of the backend, e.g. https://your-service.onrender.com
+BACKEND_URL=
 # Comma separated reward IDs to log, leave empty to log all
 LOG_REWARD_IDS=
 MUSIC_REWARD_ID=545cc880-f6c1-4302-8731-29075a8a1f17


### PR DESCRIPTION
## Summary
- Refresh bot token via backend before reconnecting after auth failures
- Document BACKEND_URL for bot configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4448090548320b81591ef7d2610af