### PR TITLE
feat: support multiple OBS media entries

### DIFF
--- a/backend/__tests__/obs_media.test.js
+++ b/backend/__tests__/obs_media.test.js
@@ -6,6 +6,8 @@ process.env.SUPABASE_KEY = 'test';
 let isModerator = true;
 let obsMediaData;
 let insertedObsMedia;
+let updatedObsMedia;
+let deletedId;
 let eventLogsEq;
 let userColumns;
 
@@ -61,6 +63,24 @@ const mockSupabase = {
             })),
           };
         }),
+        update: jest.fn((row) => {
+          updatedObsMedia = row;
+          return {
+            eq: jest.fn((col, val) => ({
+              select: jest.fn(() => ({
+                single: jest.fn(() =>
+                  Promise.resolve({ data: { id: Number(val), ...row }, error: null })
+                ),
+              })),
+            })),
+          };
+        }),
+        delete: jest.fn(() => ({
+          eq: jest.fn((col, val) => {
+            deletedId = Number(val);
+            return Promise.resolve({ data: null, error: null });
+          }),
+        })),
       };
     }
     if (table === 'event_logs') {
@@ -95,8 +115,11 @@ describe('OBS media endpoints', () => {
     userColumns = ['intim_no_tag_0', 'poceluy_no_tag_0'];
     obsMediaData = [
       { id: 1, type: 'intim_no_tag_0', gif_url: 'g', sound_url: 's' },
+      { id: 2, type: 'poceluy_no_tag_0', gif_url: 'g2', sound_url: 's2' },
     ];
     insertedObsMedia = null;
+    updatedObsMedia = null;
+    deletedId = null;
     eventLogsEq = null;
     mockSupabase.from.mockClear();
   });
@@ -107,6 +130,20 @@ describe('OBS media endpoints', () => {
       .set('Authorization', 'Bearer token');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ media: obsMediaData });
+  });
+
+  it('GET /api/obs-media?grouped=true returns grouped media', async () => {
+    const res = await request(app)
+      .get('/api/obs-media')
+      .query({ grouped: 'true' })
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      media: {
+        intim: [obsMediaData[0]],
+        kiss: [obsMediaData[1]],
+      },
+    });
   });
 
   it('POST /api/obs-media inserts media', async () => {
@@ -126,6 +163,25 @@ describe('OBS media endpoints', () => {
       .set('Authorization', 'Bearer token')
       .send({ type: 'invalid', gif_url: 'g', sound_url: 's' });
     expect(res.status).toBe(400);
+  });
+
+  it('PUT /api/obs-media/:id updates media', async () => {
+    const res = await request(app)
+      .put('/api/obs-media/1')
+      .set('Authorization', 'Bearer token')
+      .send({ gif_url: 'new', sound_url: 'snd' });
+    expect(res.status).toBe(200);
+    expect(updatedObsMedia).toEqual({ gif_url: 'new', sound_url: 'snd' });
+    expect(res.body).toEqual({ media: { id: 1, gif_url: 'new', sound_url: 'snd' } });
+  });
+
+  it('DELETE /api/obs-media/:id removes media', async () => {
+    const res = await request(app)
+      .delete('/api/obs-media/1')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(deletedId).toBe(1);
   });
 });
 

--- a/frontend/components/ObsMediaFields.tsx
+++ b/frontend/components/ObsMediaFields.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from "react-i18next";
 
 interface MediaValues {
+  id?: number;
   gif: string;
   sound: string;
 }
@@ -11,30 +12,44 @@ interface Props {
   prefix: string;
   values: MediaValues;
   onChange: (vals: MediaValues) => void;
+  onRemove?: () => void;
 }
 
-export default function ObsMediaFields({ prefix, values, onChange }: Props) {
+export default function ObsMediaFields({ prefix, values, onChange, onRemove }: Props) {
   const { t } = useTranslation();
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 border p-2 rounded">
       <div>
-        <label className="block">{t(`${prefix}Gif`)}</label>
-        <input
-          type="url"
-          className="border p-1 w-full text-foreground"
-          value={values.gif}
-          onChange={(e) => onChange({ ...values, gif: e.target.value })}
-        />
+        <label className="block">
+          {t(`${prefix}Gif`)}
+          <input
+            type="url"
+            className="border p-1 w-full text-foreground"
+            value={values.gif}
+            onChange={(e) => onChange({ ...values, gif: e.target.value })}
+          />
+        </label>
       </div>
       <div>
-        <label className="block">{t(`${prefix}Sound`)}</label>
-        <input
-          type="url"
-          className="border p-1 w-full text-foreground"
-          value={values.sound}
-          onChange={(e) => onChange({ ...values, sound: e.target.value })}
-        />
+        <label className="block">
+          {t(`${prefix}Sound`)}
+          <input
+            type="url"
+            className="border p-1 w-full text-foreground"
+            value={values.sound}
+            onChange={(e) => onChange({ ...values, sound: e.target.value })}
+          />
+        </label>
       </div>
+      {onRemove && (
+        <button
+          type="button"
+          className="px-2 py-1 bg-red-600 text-white rounded"
+          onClick={onRemove}
+        >
+          {t("remove")}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/components/ObsMediaList.tsx
+++ b/frontend/components/ObsMediaList.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import ObsMediaFields from "./ObsMediaFields";
+
+export interface MediaItem {
+  id?: number;
+  gif: string;
+  sound: string;
+}
+
+interface Props {
+  type: string;
+  items: MediaItem[];
+  onChange: (items: MediaItem[]) => void;
+  onRemove?: (id: number) => void;
+}
+
+export default function ObsMediaList({ type, items, onChange, onRemove }: Props) {
+  const { t } = useTranslation();
+
+  const handleUpdate = (idx: number, vals: MediaItem) => {
+    const next = [...items];
+    next[idx] = vals;
+    onChange(next);
+  };
+
+  const handleAdd = () => {
+    onChange([...items, { gif: "", sound: "" }]);
+  };
+
+  const handleRemove = (idx: number) => {
+    const next = [...items];
+    const [removed] = next.splice(idx, 1);
+    onChange(next);
+    if (removed?.id && onRemove) onRemove(removed.id);
+  };
+
+  return (
+    <details className="space-y-2" open>
+      <summary className="cursor-pointer text-lg font-semibold">
+        {t(`obs${type.charAt(0).toUpperCase()}${type.slice(1)}`)}
+      </summary>
+      {items.map((vals, idx) => (
+        <ObsMediaFields
+          key={vals.id ?? idx}
+          prefix={type}
+          values={vals}
+          onChange={(v) => handleUpdate(idx, v)}
+          onRemove={() => handleRemove(idx)}
+        />
+      ))}
+      <button
+        type="button"
+        className="px-2 py-1 bg-purple-600 text-white rounded"
+        onClick={handleAdd}
+      >
+        {t("addMedia")}
+      </button>
+    </details>
+  );
+}

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -110,6 +110,7 @@
   "kissText": "Текст поцелуя",
   "obsIntim": "Интим",
   "obsKiss": "Поцелуй",
+  "addMedia": "Добавить медиа",
   "commaSeparated": "через запятую",
   "statusActive": "Активная",
   "statusCompleted": "Завершено",


### PR DESCRIPTION
## Summary
- allow multiple OBS media items grouped by type
- add update/delete endpoints and grouping support on backend
- expand settings page to manage multiple media entries

## Testing
- `npm test --prefix backend`
- `node --max-old-space-size=4096 ./node_modules/.bin/jest app/__tests__/SettingsPage.moderator.test.tsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b456a9afdc8320a7e99f614c9b4bad