### PR TITLE
refactor(bot): remove local twitch oauth token

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -2,9 +2,8 @@ SUPABASE_URL=<SUPABASE_URL>
 SUPABASE_KEY=<SUPABASE_SERVICE_KEY>
 BOT_USERNAME=your-bot-username
 TWITCH_CHANNEL=terrenkur
-# Twitch Chat OAuth token for the bot account.
-# Get one at https://twitchapps.com/tmi/ (starts with "oauth:")
-TWITCH_OAUTH_TOKEN=
+# OAuth token is stored separately; insert it into the
+# `bot_tokens` table or refresh it via the backend.
 TWITCH_CLIENT_ID=
 TWITCH_SECRET=
 TWITCH_CHANNEL_ID=


### PR DESCRIPTION
## Summary
- remove TWITCH_OAUTH_TOKEN from bot env example
- note that token should be stored in `bot_tokens` table or refreshed via backend

## Testing
- `cd bot && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c52be0988320bddc3627d31c61fc