### PR TITLE
Remove Twitch OAuth env references from bot tests

### DIFF
--- a/bot/__tests__/achievements.test.js
+++ b/bot/__tests__/achievements.test.js
@@ -136,7 +136,6 @@ test('awards multiple achievements for a single counter', async () => {
   process.env.TWITCH_SECRET = 'secret';
   process.env.TWITCH_CHANNEL_ID = '123';
   process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
-  delete process.env.TWITCH_OAUTH_TOKEN;
 
   const { incrementUserStat } = require('../bot');
   jest.useRealTimers();

--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -56,7 +56,6 @@ const loadBot = (mockSupabase) => {
   process.env.TWITCH_CLIENT_ID = 'cid';
   process.env.TWITCH_CHANNEL_ID = '123';
   process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
-  delete process.env.TWITCH_OAUTH_TOKEN;
   const bot = require('../bot');
   jest.useRealTimers();
   return bot;
@@ -122,7 +121,6 @@ const loadBotWithOn = (mockSupabase, onMock, sayMock = jest.fn()) => {
   process.env.TWITCH_CHANNEL_ID = '123';
   process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
   delete process.env.LOG_REWARD_IDS;
-  delete process.env.TWITCH_OAUTH_TOKEN;
   const bot = require('../bot');
   jest.useRealTimers();
   return bot;
@@ -167,7 +165,6 @@ const loadBotNoToken = (connectMock = jest.fn()) => {
   process.env.TWITCH_CHANNEL_ID = '123';
   process.env.MUSIC_REWARD_ID = '545cc880-f6c1-4302-8731-29075a8a1f17';
   delete process.env.LOG_REWARD_IDS;
-  delete process.env.TWITCH_OAUTH_TOKEN;
   const bot = require('../bot');
   jest.useRealTimers();
   return { bot, connectMock };

--- a/bot/__tests__/subsync.test.js
+++ b/bot/__tests__/subsync.test.js
@@ -20,7 +20,6 @@ const loadBot = (supabase, fetchImpl) => {
   process.env.TWITCH_CHANNEL_ID = 'chan1';
   process.env.TWITCH_SECRET = 'secret';
   process.env.MUSIC_REWARD_ID = 'id';
-  delete process.env.TWITCH_OAUTH_TOKEN;
   const bot = require('../bot');
   jest.useRealTimers();
   return bot;


### PR DESCRIPTION
## Summary
- Drop `process.env.TWITCH_OAUTH_TOKEN` cleanup in bot-related tests
- Tests now rely on Supabase `bot_tokens` mocks for OAuth tokens

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b52e5626f0832081ed5373a7d34e85