### PR TITLE
refactor: fetch theme on client

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -40,30 +40,13 @@ const geistMono = Geist_Mono({
   preload: false,
 });
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  let defaultTheme = "system";
-  const cookieStore = await cookies();
-  const token = cookieStore.get("sb-access-token")?.value;
+  const cookieStore = cookies();
   const resolvedLocale = cookieStore.get("i18nextLng")?.value ?? "ru";
-  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
-  if (token && backendUrl) {
-    try {
-      const resp = await fetch(`${backendUrl}/api/user/theme`, {
-        headers: { Authorization: `Bearer ${token}` },
-        cache: "no-store",
-      });
-      if (resp.ok) {
-        const data = await resp.json();
-        if (typeof data.theme === "string") defaultTheme = data.theme;
-      }
-    } catch {
-      // ignore
-    }
-  }
 
   return (
     <html lang={resolvedLocale}>
@@ -73,7 +56,7 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background font-sans antialiased flex flex-col`}
       >
-        <ThemeProvider defaultTheme={defaultTheme}>
+        <ThemeProvider>
           <I18nProvider>
             <SettingsProvider>
               <Eruda />

--- a/frontend/components/ThemeProvider.tsx
+++ b/frontend/components/ThemeProvider.tsx
@@ -1,7 +1,37 @@
 "use client";
 
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import {
+  ThemeProvider as NextThemesProvider,
+  useTheme,
+} from "next-themes";
 import type { ThemeProviderProps } from "next-themes";
+import { useEffect } from "react";
+
+function ThemeLoader() {
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    const token = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("sb-access-token="))
+      ?.split("=")[1];
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+    if (token && backendUrl) {
+      fetch(`${backendUrl}/api/user/theme`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((resp) => (resp.ok ? resp.json() : null))
+        .then((data) => {
+          if (data && typeof data.theme === "string") setTheme(data.theme);
+        })
+        .catch(() => {
+          // ignore
+        });
+    }
+  }, [setTheme]);
+
+  return null;
+}
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return (
@@ -11,6 +41,7 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
       defaultTheme="system"
       {...props}
     >
+      <ThemeLoader />
       {children}
     </NextThemesProvider>
   );


### PR DESCRIPTION
## Summary
- move user theme lookup to client-side ThemeProvider
- simplify RootLayout into a static component

## Testing
- `npm test components/__tests__/UserPage.test.tsx`
- `npm run lint` (interactive prompt)


------
https://chatgpt.com/codex/tasks/task_e_68b56ceb97648320ad1e4e8fefc9fc06