### PR TITLE
Ensure event logging only when stats updated

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -1163,6 +1163,23 @@ describe('!интим', () => {
     expect(created).toBeLessThan(Date.now() + 5000);
     expect(created).toBeGreaterThan(Date.now() - 5000);
   });
+  test('does not log event without main column', async () => {
+    const on = jest.fn();
+    const say = jest.fn();
+    const supabase = createSupabaseIntim();
+    loadBotWithOn(supabase, on, say);
+    await new Promise(setImmediate);
+    const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    await handler(
+      'channel',
+      { username: 'author', 'display-name': 'Author' },
+      '!интим',
+      false
+    );
+    Math.random.mockRestore();
+    expect(supabase.eventLogsInsert).not.toHaveBeenCalled();
+  });
   test('без тега выводит шанс для автора', async () => {
     const on = jest.fn();
     const say = jest.fn();
@@ -1378,6 +1395,23 @@ describe('!поцелуй', () => {
     const created = new Date(logged.created_at).getTime();
     expect(created).toBeLessThan(Date.now() + 5000);
     expect(created).toBeGreaterThan(Date.now() - 5000);
+  });
+  test('does not log event without main column', async () => {
+    const on = jest.fn();
+    const say = jest.fn();
+    const supabase = createSupabasePoceluy();
+    loadBotWithOn(supabase, on, say);
+    await new Promise(setImmediate);
+    const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    await handler(
+      'channel',
+      { username: 'author', 'display-name': 'Author' },
+      '!поцелуй',
+      false
+    );
+    Math.random.mockRestore();
+    expect(supabase.eventLogsInsert).not.toHaveBeenCalled();
   });
   test('без тега выводит шанс для автора', async () => {
     const on = jest.fn();

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -1037,7 +1037,9 @@ client.on('message', async (channel, tags, message, self) => {
         ? `${percent}% шанс того, что ${authorName} ${variantTwo} ${tagArg} интимиться с ${partnerName} ${variantOne}`
         : `${percent}% шанс того, что у ${authorName} ${variantOne} будет интим с ${partnerName}`;
       client.say(channel, text);
-      await logEvent(text, null, null, null, mainColumn);
+      if (mainColumn) {
+        await logEvent(text, null, null, null, mainColumn);
+      }
     } catch (err) {
       console.error('intim command failed', err);
     }
@@ -1177,7 +1179,9 @@ client.on('message', async (channel, tags, message, self) => {
         : `${percent}% шанс того, что у ${authorName} ${variantThree} поцелует ${variantFour} ${partnerName}`;
       const cleanText = text.replace(/\s+/g, ' ').trim();
       client.say(channel, cleanText);
-      await logEvent(cleanText, null, null, null, mainColumn);
+      if (mainColumn) {
+        await logEvent(cleanText, null, null, null, mainColumn);
+      }
     } catch (err) {
       console.error('poceluy command failed', err);
     }


### PR DESCRIPTION
## Summary
- log `!интим` and `!поцелуй` events only when statistics column is updated
- test that no event log is inserted when no main column exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d6c835748320aa13964a59be8a25