### PR TITLE
feat(frontend): add configurable spin duration

### DIFF
--- a/frontend/app/archive/[id]/page.tsx
+++ b/frontend/app/archive/[id]/page.tsx
@@ -297,6 +297,7 @@ export default function ArchivedPollPage({ params }: { params: Promise<{ id: str
               games={rouletteGames}
               onDone={handleSpinEnd}
               spinSeed={replaySeed ?? undefined}
+              spinDuration={4}
             />
             <div className="flex gap-2 mt-2">
               {result?.spin_seed && !replayDisabled && (

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -673,6 +673,7 @@ export default function Home() {
               weightCoeff={weightCoeff}
               zeroWeight={zeroWeight}
               spinSeed={spinSeed ?? undefined}
+              spinDuration={4}
             />
             <div className="flex gap-2 mt-2">
               <button

--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -36,6 +36,7 @@ interface RouletteWheelProps {
   weightCoeff?: number;
   zeroWeight?: number;
   spinSeed?: string;
+  spinDuration?: number;
 }
 
 const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
@@ -47,6 +48,7 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
       weightCoeff = 2,
       zeroWeight = 40,
       spinSeed,
+      spinDuration = 4,
     },
     ref
   ) => {
@@ -302,7 +304,7 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
       setTooltip((t) => ({ ...t, visible: false }));
     };
 
-    const durationRef = useRef(4);
+    const durationRef = useRef(spinDuration);
 
     useEffect(() => {
       const canvas = canvasRef.current;
@@ -338,7 +340,7 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
         angle += slice;
       }
       const spins = 4;
-      const duration = 3 + randRef.current() * 2; // 3-5 seconds
+      const duration = spinDuration + (randRef.current() - 0.5) * 2;
       durationRef.current = duration;
       const normalized = rotation % (2 * Math.PI);
       const target =

--- a/frontend/components/__tests__/RouletteWheel.test.tsx
+++ b/frontend/components/__tests__/RouletteWheel.test.tsx
@@ -11,7 +11,15 @@ const games = [
 test('calls onDone after spin', () => {
   const onDone = jest.fn();
   const ref = { current: null as RouletteWheelHandle | null };
-  render(<RouletteWheel ref={ref} games={games} onDone={onDone} spinSeed="seed" />);
+  render(
+    <RouletteWheel
+      ref={ref}
+      games={games}
+      onDone={onDone}
+      spinSeed="seed"
+      spinDuration={4}
+    />
+  );
   act(() => {
     ref.current!.spin();
     jest.runAllTimers();
@@ -28,6 +36,7 @@ test('spins twice to expected angles', () => {
       games={games}
       onDone={onDone}
       spinSeed="seed"
+      spinDuration={4}
     />
   );
 


### PR DESCRIPTION
## Summary
- allow configuring roulette spin duration with random +/- 1s
- propagate new property to all component usages

## Testing
- `npx jest components/__tests__/UserPage.test.tsx --runInBand`
- `npx jest components/__tests__/RouletteWheel.test.tsx --runInBand --detectOpenHandles`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5a9ff25c8320baa1a6875566410d