### PR TITLE
feat: add spin duration endpoints

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1377,6 +1377,33 @@ app.post('/api/allow_edit', requireModerator, async (req, res) => {
   res.json({ success: true });
 });
 
+// Get current spin duration
+app.get('/api/spin_duration', async (_req, res) => {
+  const { data, error } = await supabase
+    .from('settings')
+    .select('value')
+    .eq('key', 'spin_duration')
+    .maybeSingle();
+  if (error) return res.status(500).json({ error: error.message });
+  const duration = data ? Number(data.value) : 4;
+  res.json({ duration });
+});
+
+// Update spin duration (moderators only)
+app.post('/api/spin_duration', requireModerator, async (req, res) => {
+  const { duration } = req.body;
+  if (typeof duration !== 'number') {
+    return res.status(400).json({ error: 'duration must be a number' });
+  }
+
+  const { error: upError } = await supabase
+    .from('settings')
+    .upsert({ key: 'spin_duration', value: duration });
+  if (upError) return res.status(500).json({ error: upError.message });
+
+  res.json({ success: true });
+});
+
 // Get reward IDs to log
 app.get('/api/log_reward_ids', async (_req, res) => {
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- add `GET/POST /api/spin_duration` endpoints
- store spin duration in the `settings` table using `spin_duration` key
- restrict spin duration updates to moderators

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be9ac4e1408320ae8da2676269fd10