### PR TITLE
Add spin duration setting

### DIFF
--- a/supabase/migrations/20250808180453_add_spin_duration_setting.sql
+++ b/supabase/migrations/20250808180453_add_spin_duration_setting.sql
@@ -1,0 +1,3 @@
+insert into settings(key, value)
+  values ('spin_duration', 4)
+  on conflict (key) do nothing;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -216,6 +216,10 @@ insert into settings(key, value)
   values ('allow_edit', 1)
   on conflict (key) do nothing;
 
+insert into settings(key, value)
+  values ('spin_duration', 4)
+  on conflict (key) do nothing;
+
 create table if not exists log_rewards (
   reward_id text primary key
 );


### PR DESCRIPTION
## Summary
- default `spin_duration` setting
- migration to backfill `spin_duration`

## Testing
- `npm test` (backend)
- `npm test` (bot)
- `npm test` (frontend) *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec8b7c4588320b08150442bf58c69