### PR TITLE
test: sync spin duration expectation

### DIFF
--- a/frontend/components/__tests__/RouletteWheel.test.tsx
+++ b/frontend/components/__tests__/RouletteWheel.test.tsx
@@ -8,6 +8,8 @@ const games = [
   { id: 2, name: 'G2', count: 0, background_image: null },
 ];
 
+const spinDuration = 4;
+
 test('calls onDone after spin', () => {
   const onDone = jest.fn();
   const ref = { current: null as RouletteWheelHandle | null };
@@ -17,7 +19,7 @@ test('calls onDone after spin', () => {
       games={games}
       onDone={onDone}
       spinSeed="seed"
-      spinDuration={4}
+      spinDuration={spinDuration}
     />
   );
   act(() => {
@@ -36,7 +38,7 @@ test('spins twice to expected angles', () => {
       games={games}
       onDone={onDone}
       spinSeed="seed"
-      spinDuration={4}
+      spinDuration={spinDuration}
     />
   );
 
@@ -94,7 +96,7 @@ test('spins twice to expected angles', () => {
 
     rand(); // duration random
 
-    const spins = 4;
+    const spins = spinDuration;
     const normalized = rotation % (2 * Math.PI);
     const target =
       rotation + spins * 2 * Math.PI + (Math.PI * 3) / 2 - angle - normalized;


### PR DESCRIPTION
## Summary
- Pass fixed spinDuration prop when rendering RouletteWheel in tests
- Reuse same base duration to compute expected rotation and consume one random call for duration

## Testing
- `npx jest components/__tests__/RouletteWheel.test.tsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bedf39a4088320bd2cead49a068091