### PR TITLE
chore: configure jest with next/jest

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,11 +1,11 @@
-module.exports = {
-  preset: 'ts-jest',
+const nextJest = require('next/jest');
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
   testEnvironment: 'jsdom',
-  transform: {
-    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }],
-  },
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/$1',
-  },
+  moduleNameMapper: { '^@/(.*)$': '<rootDir>/$1' },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };
+
+module.exports = createJestConfig(customJestConfig);
+


### PR DESCRIPTION
## Summary
- replace ts-jest preset with Next.js-specific next/jest configuration for frontend tests

## Testing
- `npx jest --runInBand --ci` *(fails to exit, but tests pass before termination)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe586b9e08320be9d541630fe88b7