### PR TITLE
chore: simplify frontend test script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --maxWorkers=2"
+    "test": "NODE_OPTIONS=--max-old-space-size=8192 jest --maxWorkers=2"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.15",


### PR DESCRIPTION
## Summary
- remove `--runInBand` option from frontend `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfedb5407883208d2180601d8858b1