### PR TITLE
fix(frontend): await cookies in layout

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -40,12 +40,12 @@ const geistMono = Geist_Mono({
   preload: false,
 });
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const resolvedLocale = cookieStore.get("i18nextLng")?.value ?? "ru";
 
   return (


### PR DESCRIPTION
## Summary
- make `RootLayout` async and await cookies for locale detection

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bff562dfac83208052ee54d6317953