### PR TITLE
Center OBS overlay with transparent layout

### DIFF
--- a/frontend/app/obs/layout.tsx
+++ b/frontend/app/obs/layout.tsx
@@ -1,0 +1,12 @@
+import '../globals.css';
+import type { ReactNode } from 'react';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body className="flex items-center justify-center min-h-screen bg-transparent pointer-events-none">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/obs/page.tsx
+++ b/frontend/app/obs/page.tsx
@@ -31,8 +31,6 @@ export default function ObsPage() {
   }, []);
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-transparent pointer-events-none">
-      <ObsEventOverlay event={event} onComplete={() => setEvent(null)} />
-    </div>
+    <ObsEventOverlay event={event} onComplete={() => setEvent(null)} />
   );
 }


### PR DESCRIPTION
## Summary
- add OBS route layout that centers children and uses a transparent background
- simplify OBS page to render overlay directly without an extra wrapper

## Testing
- `CI=true npm test`
- `npm run lint` *(fails: configuration prompt from `next lint`)*

------
https://chatgpt.com/codex/tasks/task_e_68c1af97c3648320bdfa656c83b94f00