### PR TITLE
feat: pause roulette audio before replaying

### DIFF
--- a/frontend/components/RouletteWheel.tsx
+++ b/frontend/components/RouletteWheel.tsx
@@ -374,6 +374,7 @@ const RouletteWheel = forwardRef<RouletteWheelHandle, RouletteWheelProps>(
           const time = ((crossing - rotation) / omega) * 1000;
           const id = window.setTimeout(() => {
             const audio = clickAudioRef.current;
+            audio.pause();
             audio.currentTime = 0;
             void audio.play();
           }, time);

--- a/frontend/components/__tests__/RouletteWheel.test.tsx
+++ b/frontend/components/__tests__/RouletteWheel.test.tsx
@@ -4,12 +4,15 @@ import RouletteWheel, { RouletteWheelHandle } from '../RouletteWheel';
 jest.useFakeTimers();
 
 const playMock = jest.fn();
+const pauseMock = jest.fn();
 beforeEach(() => {
   playMock.mockClear();
+  pauseMock.mockClear();
   (window as any).Audio = jest.fn().mockImplementation(() => ({
     currentTime: 0,
     preload: '',
     play: playMock,
+    pause: pauseMock,
   }));
 });
 
@@ -221,4 +224,5 @@ test('plays click sound for each boundary crossing', () => {
   });
 
   expect(playMock).toHaveBeenCalledTimes(crossings);
+  expect(pauseMock).toHaveBeenCalledTimes(crossings);
 });


### PR DESCRIPTION
## Summary
- pause roulette wheel click audio before resetting and replaying
- verify pause is invoked for each boundary crossing in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1b581b2ec83209dd061be2c6045dc