### PR TITLE
Guard chatter stats when offline

### DIFF
--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -1752,6 +1752,30 @@ describe('first message achievement', () => {
   });
 });
 
+describe('stream chatters updates', () => {
+  test('skips chatter tracking when stream is offline', async () => {
+    const on = jest.fn();
+    const say = jest.fn();
+    const supabase = createSupabaseFirstMessage();
+    const originalFrom = supabase.from;
+    loadBotWithOn(supabase, on, say);
+    await new Promise(setImmediate);
+    const handler = on.mock.calls.find((c) => c[0] === 'message')[1];
+
+    await handler(
+      'channel',
+      { username: 'viewer', 'display-name': 'Viewer' },
+      'hello there',
+      false
+    );
+
+    const chatterCalls = originalFrom.mock.calls.filter(
+      ([table]) => table === 'stream_chatters'
+    );
+    expect(chatterCalls).toHaveLength(0);
+  });
+});
+
 describe('applyRandomPlaceholders', () => {
   test('replaces [от 3 до 10] and [random_chatter] placeholders', async () => {
     const supabase = {

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -823,7 +823,7 @@ client.on('message', async (channel, tags, message, self) => {
       firstMessageAchieved = true;
       firstMessageUserId = user.id;
     }
-    if (tags.username.toLowerCase() !== 'hornypaps') {
+    if (streamOnline && tags.username.toLowerCase() !== 'hornypaps') {
       let messageCount = 0;
       try {
         const { data: chatter } = await supabase


### PR DESCRIPTION
## Summary
- gate the stream chatter upsert and message_count achievement behind the live stream flag
- add a regression test confirming offline messages skip chatter tracking

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc681b644483209dada9483095bb3d