### PR TITLE
Add streamer token fallback for stream status checks

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -434,9 +434,20 @@ let firstMessageAchieved = false;
 let firstMessageUserId = null;
 
 async function checkStreamStatus() {
-  if (!TWITCH_CHANNEL_ID || !TWITCH_CLIENT_ID || !TWITCH_SECRET) return;
+  if (!TWITCH_CHANNEL_ID || !TWITCH_CLIENT_ID) return;
   try {
-    const token = await getTwitchToken();
+    let token = null;
+    if (TWITCH_SECRET) {
+      try {
+        token = await getTwitchToken();
+      } catch (err) {
+        console.error('App token fetch failed, trying streamer token', err);
+      }
+    }
+    if (!token) {
+      token = await getStreamerToken();
+    }
+    if (!token) return;
     const url = new URL('https://api.twitch.tv/helix/streams');
     url.searchParams.set('user_id', TWITCH_CHANNEL_ID);
     const resp = await fetch(url.toString(), {


### PR DESCRIPTION
## Summary
- allow `checkStreamStatus` to fall back to the streamer token when an app token is unavailable
- stub `fetch` in bot test helpers and convert the clip test to use a spy-based mock
- add a regression test that ensures `stream_chatters` is cleared on an online → offline transition without `TWITCH_SECRET`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc6b8a49c48320a257033d4be99bdc