### PR TITLE
Ensure bot token retrieval uses latest entry

### DIFF
--- a/backend/__tests__/twitch.test.js
+++ b/backend/__tests__/twitch.test.js
@@ -7,6 +7,8 @@ const mockBuilder = {
   insert: jest.fn(async () => ({ data: null, error: null })),
   maybeSingle: jest.fn(async () => ({ data: mockTokenRow, error: null })),
   eq: jest.fn(async () => ({ data: null, error: null })),
+  order: jest.fn(() => mockBuilder),
+  limit: jest.fn(() => mockBuilder),
 };
 const mockFrom = jest.fn(() => mockBuilder);
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -479,6 +479,9 @@ app.get('/refresh-token/bot', async (_req, res) => {
   const { data: row, error: selErr } = await supabase
     .from('bot_tokens')
     .select('id, refresh_token')
+    .order('updated_at', { ascending: false })
+    .order('id', { ascending: false })
+    .limit(1)
     .maybeSingle();
   if (selErr) return res.status(500).json({ error: selErr.message });
   if (row && row.refresh_token) refreshToken = row.refresh_token;
@@ -518,6 +521,7 @@ app.get('/refresh-token/bot', async (_req, res) => {
     const update = {
       access_token: data.access_token,
       expires_at: expiresAt,
+      updated_at: new Date().toISOString(),
     };
     if (data.refresh_token) {
       update.refresh_token = data.refresh_token;

--- a/bot/__tests__/achievements.test.js
+++ b/bot/__tests__/achievements.test.js
@@ -101,8 +101,11 @@ test('awards multiple achievements for a single counter', async () => {
       }
       if (table === 'bot_tokens') {
         return {
-          select: jest.fn(() => ({
-            maybeSingle: jest.fn(() =>
+          select: jest.fn(() => {
+            const chain = {};
+            chain.order = jest.fn(() => chain);
+            chain.limit = jest.fn(() => chain);
+            chain.maybeSingle = jest.fn(() =>
               Promise.resolve({
                 data: {
                   id: 1,
@@ -112,8 +115,9 @@ test('awards multiple achievements for a single counter', async () => {
                 },
                 error: null,
               })
-            ),
-          })),
+            );
+            return chain;
+          }),
           update: jest.fn(() => Promise.resolve({ error: null })),
           insert: jest.fn(() => Promise.resolve({ error: null })),
         };

--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -15,8 +15,11 @@ const loadBot = (mockSupabase) => {
   mockSupabase.from = jest.fn((table) => {
     if (table === 'bot_tokens') {
       return {
-        select: jest.fn(() => ({
-          maybeSingle: jest.fn(() =>
+        select: jest.fn(() => {
+          const chain = {};
+          chain.order = jest.fn(() => chain);
+          chain.limit = jest.fn(() => chain);
+          chain.maybeSingle = jest.fn(() =>
             Promise.resolve({
               data: {
                 id: 1,
@@ -26,8 +29,9 @@ const loadBot = (mockSupabase) => {
               },
               error: null,
             })
-          ),
-        })),
+          );
+          return chain;
+        }),
         update: jest.fn(() => Promise.resolve({ error: null })),
         insert: jest.fn(() => Promise.resolve({ error: null })),
       };
@@ -86,8 +90,11 @@ const loadBotWithOn = (mockSupabase, onMock, sayMock = jest.fn()) => {
   mockSupabase.from = jest.fn((table) => {
     if (table === 'bot_tokens') {
       return {
-        select: jest.fn(() => ({
-          maybeSingle: jest.fn(() =>
+        select: jest.fn(() => {
+          const chain = {};
+          chain.order = jest.fn(() => chain);
+          chain.limit = jest.fn(() => chain);
+          chain.maybeSingle = jest.fn(() =>
             Promise.resolve({
               data: {
                 id: 1,
@@ -97,8 +104,9 @@ const loadBotWithOn = (mockSupabase, onMock, sayMock = jest.fn()) => {
               },
               error: null,
             })
-          ),
-        })),
+          );
+          return chain;
+        }),
         update: jest.fn(() => Promise.resolve({ error: null })),
         insert: jest.fn(() => Promise.resolve({ error: null })),
       };
@@ -147,11 +155,15 @@ const loadBotNoToken = (connectMock = jest.fn()) => {
     from: jest.fn((table) => {
       if (table === 'bot_tokens') {
         return {
-          select: jest.fn(() => ({
-            maybeSingle: jest.fn(() =>
+          select: jest.fn(() => {
+            const chain = {};
+            chain.order = jest.fn(() => chain);
+            chain.limit = jest.fn(() => chain);
+            chain.maybeSingle = jest.fn(() =>
               Promise.resolve({ data: null, error: null })
-            ),
-          })),
+            );
+            return chain;
+          }),
         };
       }
       return {
@@ -220,8 +232,11 @@ const createSupabase = (
       }
       if (table === 'bot_tokens') {
         return {
-          select: jest.fn(() => ({
-            maybeSingle: jest.fn(() =>
+          select: jest.fn(() => {
+            const chain = {};
+            chain.order = jest.fn(() => chain);
+            chain.limit = jest.fn(() => chain);
+            chain.maybeSingle = jest.fn(() =>
               Promise.resolve({
                 data: {
                   id: 1,
@@ -231,8 +246,9 @@ const createSupabase = (
                 },
                 error: null,
               })
-            ),
-          })),
+            );
+            return chain;
+          }),
           update: jest.fn(() => Promise.resolve({ error: null })),
           insert: jest.fn(() => Promise.resolve({ error: null })),
         };
@@ -1863,8 +1879,11 @@ describe('stream chatters updates', () => {
         switch (table) {
           case 'bot_tokens':
             return {
-              select: jest.fn(() => ({
-                maybeSingle: jest.fn(() =>
+              select: jest.fn(() => {
+                const chain = {};
+                chain.order = jest.fn(() => chain);
+                chain.limit = jest.fn(() => chain);
+                chain.maybeSingle = jest.fn(() =>
                   Promise.resolve({
                     data: {
                       id: 1,
@@ -1874,8 +1893,9 @@ describe('stream chatters updates', () => {
                     },
                     error: null,
                   })
-                ),
-              })),
+                );
+                return chain;
+              }),
               update: jest.fn(() => Promise.resolve({ error: null })),
               insert: jest.fn(() => Promise.resolve({ error: null })),
             };

--- a/bot/__tests__/subsync.test.js
+++ b/bot/__tests__/subsync.test.js
@@ -68,8 +68,11 @@ function createSupabase(existingUser) {
     }
     if (table === 'bot_tokens') {
       return {
-        select: jest.fn(() => ({
-          maybeSingle: jest.fn(() =>
+        select: jest.fn(() => {
+          const chain = {};
+          chain.order = jest.fn(() => chain);
+          chain.limit = jest.fn(() => chain);
+          chain.maybeSingle = jest.fn(() =>
             Promise.resolve({
               data: {
                 id: 1,
@@ -79,8 +82,9 @@ function createSupabase(existingUser) {
               },
               error: null,
             })
-          ),
-        })),
+          );
+          return chain;
+        }),
         update: jest.fn(() => Promise.resolve({ error: null })),
         insert: jest.fn(() => Promise.resolve({ error: null })),
       };

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -175,6 +175,9 @@ async function getBotToken() {
     const { data, error } = await supabase
       .from('bot_tokens')
       .select('id, access_token, refresh_token, expires_at')
+      .order('updated_at', { ascending: false })
+      .order('id', { ascending: false })
+      .limit(1)
       .maybeSingle();
     if (!error && data && data.access_token) {
       botToken = data.access_token;


### PR DESCRIPTION
## Summary
- fetch the most recently updated bot token when starting the chat client
- refresh the bot token in the backend using the newest record and update its timestamp
- update bot and backend tests to mock the additional ordering and limiting calls

## Testing
- npm test -- --runTestsByPath __tests__/bot.test.js
- npm test -- --runTestsByPath __tests__/subsync.test.js __tests__/achievements.test.js
- npm test -- --runTestsByPath __tests__/twitch.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2c0d4a7f08320a72594d60b518581