### PR TITLE
Fix Mix It Up command endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ roulette via chat commands:
 
    To forward intimacy and kiss results to [Mix It Up](https://mixitupapp.com)
    via its Developer API, add the optional variables below. When configured,
-   the bot calls `POST /commands/{id}` on the Mix It Up instance and passes the
+   the bot calls `POST /commands/{id}/trigger` on the Mix It Up instance and passes the
    intimacy type, initiator login and selected target as a pipe-separated
    argument string (`type|initiator|target`). Use the provided values inside Mix
    It Up to trigger custom overlays or other actions.

--- a/bot/__tests__/bot.test.js
+++ b/bot/__tests__/bot.test.js
@@ -1283,7 +1283,7 @@ describe('!интим', () => {
       Math.random.mockRestore();
 
       const commandCall = fetchMock.mock.calls.find(([url]) =>
-        String(url).includes('/commands/intim-command-id')
+        String(url).includes('/commands/intim-command-id/trigger')
       );
       expect(commandCall).toBeDefined();
       const [, options] = commandCall;
@@ -1328,7 +1328,7 @@ describe('!интим', () => {
       Math.random.mockRestore();
 
       const commandCall = fetchMock.mock.calls.find(([url]) =>
-        String(url).includes('/commands/intim-command-id')
+        String(url).includes('/commands/intim-command-id/trigger')
       );
       expect(commandCall).toBeDefined();
       const [, options] = commandCall;

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -158,11 +158,14 @@ async function sendMixItUpCommand(commandId, payload) {
     if (mixItUpApiKey) {
       headers['X-API-Key'] = mixItUpApiKey;
     }
-    const resp = await fetch(`${mixItUpApiBase}/commands/${commandId}`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body),
-    });
+    const resp = await fetch(
+      `${mixItUpApiBase}/commands/${commandId}/trigger`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      }
+    );
     if (!resp.ok) {
       const text = await resp.text().catch(() => '');
       console.error(


### PR DESCRIPTION
## Summary
- update the Mix It Up integration to call the trigger endpoint when firing commands
- align the Mix It Up tests with the corrected endpoint path
- document the correct Mix It Up endpoint in the README

## Testing
- npm test -- --runTestsByPath __tests__/bot.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e43428bef4832088731ebbf24d5992