### PR TITLE
Move Hornypaps and user-cache settings to message handler config

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -5,6 +5,7 @@ const { createStreamerBotIntegration } = require('./streamerBotClient');
 const streamerBotHandlers = require('./streamerBotHandlers');
 const streamerBotChatActions = require('../shared/streamerBotChatActions');
 const { aiConfig } = require('./config/ai');
+const { loadMessageHandlerConfig } = require('./config/message');
 const { createAiService } = require('./services/ai');
 const {
   createUserService,
@@ -91,6 +92,7 @@ const userService = createUserService({
 
 const pollService = createPollService({ supabase });
 const chatterService = createChatterService({ supabase });
+const messageHandlerConfig = loadMessageHandlerConfig({ env: process.env });
 
 const loggingService = createLoggingService({
   supabase,
@@ -251,6 +253,7 @@ client.on(
     streamState,
     getRewardIds,
     config: {
+      ...messageHandlerConfig,
       twitchChannelId: TWITCH_CHANNEL_ID,
       twitchClientId: TWITCH_CLIENT_ID,
       twitchBotUsername: TWITCH_BOT_USERNAME,

--- a/bot/config/message.js
+++ b/bot/config/message.js
@@ -1,0 +1,84 @@
+const DEFAULT_MESSAGE_HANDLER_CONFIG = {
+  hornypapsThrottleMs: 12 * 1000,
+  hornypapsGlobalThrottleMs: 4 * 1000,
+  hornypapsMoodWindowMs: 60 * 1000,
+  hornypapsTagsPerUserCap: 2,
+  hornypapsReplyMaxLength: 460,
+  userDataCacheTtlMs: 2 * 60 * 1000,
+  userDataCacheCleanupIntervalMs: 60 * 1000,
+  userDataCacheMaxEntries: 5000,
+};
+
+function parseNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseJsonConfig(rawJson) {
+  if (!rawJson) return {};
+  try {
+    const parsed = JSON.parse(rawJson);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed;
+  } catch (err) {
+    console.warn('Failed to parse MESSAGE_HANDLER_CONFIG_JSON', err);
+    return {};
+  }
+}
+
+function loadMessageHandlerConfig({
+  env = process.env,
+  jsonConfig,
+  supabaseConfig = {},
+} = {}) {
+  const jsonOverrides =
+    jsonConfig || parseJsonConfig(env.MESSAGE_HANDLER_CONFIG_JSON);
+
+  const envOverrides = {
+    hornypapsThrottleMs: parseNumber(
+      env.HORNY_PAPS_THROTTLE_MS,
+      undefined
+    ),
+    hornypapsGlobalThrottleMs: parseNumber(
+      env.HORNY_PAPS_GLOBAL_THROTTLE_MS,
+      undefined
+    ),
+    hornypapsMoodWindowMs: parseNumber(
+      env.HORNY_PAPS_MOOD_WINDOW_MS,
+      undefined
+    ),
+    hornypapsTagsPerUserCap: parseNumber(
+      env.HORNY_PAPS_TAGS_PER_USER_CAP,
+      undefined
+    ),
+    hornypapsReplyMaxLength: parseNumber(
+      env.HORNYPAPS_REPLY_MAX_LENGTH,
+      undefined
+    ),
+    userDataCacheTtlMs: parseNumber(env.USER_DATA_CACHE_TTL_MS, undefined),
+    userDataCacheCleanupIntervalMs: parseNumber(
+      env.USER_DATA_CACHE_CLEANUP_INTERVAL_MS,
+      undefined
+    ),
+    userDataCacheMaxEntries: parseNumber(
+      env.USER_DATA_CACHE_MAX_ENTRIES,
+      undefined
+    ),
+  };
+
+  return {
+    ...DEFAULT_MESSAGE_HANDLER_CONFIG,
+    ...supabaseConfig,
+    ...jsonOverrides,
+    ...Object.fromEntries(
+      Object.entries(envOverrides).filter(([, value]) => value !== undefined)
+    ),
+  };
+}
+
+module.exports = {
+  DEFAULT_MESSAGE_HANDLER_CONFIG,
+  loadMessageHandlerConfig,
+};


### PR DESCRIPTION
### Motivation
- Centralize Hornypaps throttles, mood/window, per-user tag cap, reply length and user-data cache settings into a single config so they can be overridden via ENV/JSON/Supabase and to keep defaults out of business logic.

### Description
- Add `bot/config/message.js` which provides `DEFAULT_MESSAGE_HANDLER_CONFIG` and `loadMessageHandlerConfig` with ENV and `MESSAGE_HANDLER_CONFIG_JSON` support and safe numeric parsing.
- Wire `loadMessageHandlerConfig` in `bot/bot.js` and merge the loaded config into the `config` passed to `createMessageHandler`.
- Replace local Hornypaps and cache constants in `bot/handlers/message.js` with `config.*` usages for throttles, mood window, tags cap, reply max length, and cache TTL/cleanup/maxEntries.
- Update cache helpers to accept TTL (`readCachedValue(cache, key, ttlMs)` and `cleanupCache(cache, { maxEntries, ttlMs })`) so defaults live only in the config layer.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a27c163508328abf0e03f28dc17a9)