### PR TITLE
Add Together.ai env config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ roulette via chat commands:
    TWITCH_CLIENT_ID=your-client-id
    TWITCH_SECRET=your-client-secret
    TWITCH_CHANNEL_ID=your-channel-id
+   # Together.ai chat settings (optional; defaults are shown)
+   TOGETHER_CHAT_URL=https://api.together.xyz/v1/chat/completions
+   TOGETHER_MODEL=meta-llama/Llama-3.3-70B-Instruct-Turbo
+   TOGETHER_TIMEOUT_MS=10000
    # Optional comma separated list of reward IDs to log
    # These will be merged with IDs stored in the `log_rewards` table
    LOG_REWARD_IDS=id1,id2

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -7,6 +7,9 @@ TWITCH_SECRET=
 TWITCH_CHANNEL_ID=
 # Together.ai API key for location suggestions
 TOGETHER_API_KEY=
+TOGETHER_CHAT_URL=https://api.together.xyz/v1/chat/completions
+TOGETHER_MODEL=meta-llama/Llama-3.3-70B-Instruct-Turbo
+TOGETHER_TIMEOUT_MS=10000
 # Base URL of the backend, e.g. https://your-service.onrender.com
 BACKEND_URL=
 # Comma separated reward IDs to log, leave empty to log all

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -38,6 +38,9 @@ const {
   STREAMERBOT_INTIM_ACTION,
   STREAMERBOT_POCELUY_ACTION,
   TOGETHER_API_KEY,
+  TOGETHER_CHAT_URL,
+  TOGETHER_MODEL,
+  TOGETHER_TIMEOUT_MS,
   HORNY_PAPS_BLOCKED_USERS,
 } = process.env;
 
@@ -71,6 +74,21 @@ if (!togetherApiKey) {
   console.error('Missing Together.ai configuration (TOGETHER_API_KEY)');
   process.exit(1);
 }
+
+const togetherTimeoutMs = Number.parseInt(TOGETHER_TIMEOUT_MS, 10);
+const togetherConfig = {
+  chatUrl:
+    (TOGETHER_CHAT_URL && TOGETHER_CHAT_URL.trim()) ||
+    'https://api.together.xyz/v1/chat/completions',
+  model:
+    (TOGETHER_MODEL && TOGETHER_MODEL.trim()) ||
+    'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+  timeoutMs:
+    Number.isFinite(togetherTimeoutMs) && togetherTimeoutMs > 0
+      ? togetherTimeoutMs
+      : 10_000,
+  apiKey: togetherApiKey,
+};
 
 const twitchConfig = {
   clientId: TWITCH_CLIENT_ID,
@@ -112,12 +130,7 @@ const streamState = {
 
 const aiService = createAiService({
   supabase,
-  togetherConfig: {
-    chatUrl: 'https://api.together.xyz/v1/chat/completions',
-    model: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
-    timeoutMs: 10_000,
-    apiKey: togetherApiKey,
-  },
+  togetherConfig,
   getStreamMetadata: () => ({
     game: streamState.currentStreamGame,
     startedAt: streamState.streamStartedAt,


### PR DESCRIPTION
### Motivation
- Centralize Together.ai chat configuration so the bot uses a single source of truth with environment overrides and sensible defaults.
- Make Together.ai connection parameters configurable (URL, model, timeout) so deployments can target different endpoints or models without code changes.

### Description
- Read `TOGETHER_CHAT_URL`, `TOGETHER_MODEL`, and `TOGETHER_TIMEOUT_MS` from `process.env` and build a single `togetherConfig` object in `bot/bot.js` that includes the API key and defaults.
- Replace the inline Together.ai config passed to `createAiService` with the new shared `togetherConfig` object.
- Document the new env vars in `README.md` and add defaults to `bot/.env.example`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a28e656d883289b44fac839f806c2)