### PR TITLE
Strip leading 'hornypaps:' prefix from Hornypaps AI replies

### DIFF
--- a/bot/services/ai/index.js
+++ b/bot/services/ai/index.js
@@ -94,6 +94,7 @@ function normalizeHornypapsReply(value) {
   return value
     .toString()
     .trim()
+    .replace(/^(?:@?hornypaps)\s*:\s*/i, '')
     .replace(/[\s\n\r]+/g, ' ')
     .replace(/\s+([,.!?…])/g, '$1')
     .trim();


### PR DESCRIPTION
### Motivation
- Together.ai can occasionally emit responses prefixed with a speaker label like `hornypaps:` (or `@hornypaps:`), which ends up appearing at the start of chat messages and is undesirable.

### Description
- Added a cleanup step in `normalizeHornypapsReply` inside `bot/services/ai/index.js` to `.replace(/^(?:@?hornypaps)\s*:\s*/i, '')`, removing a leading `hornypaps:` or `@hornypaps:` prefix before other normalization.
- This prevents the accidental speaker label from appearing before the mention that the message handler prepends.

### Testing
- Ran `cd bot && npm test -- --runInBand` and all tests passed (5 test suites, 91 tests passed).
- Bot unit test suite completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b03ae489083288fef0f5c7d73c598)